### PR TITLE
Adds a hide-health-checks option

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -36,33 +36,34 @@ The server executable supports the following command line configuration options:
 
 The server can be configured using a configuration file written in YAML, JSON, TOML, HCL or envfile format. It will automatically replace ENV variables written in the format `${NAME}` with their corresponding values. The config file supports the following options:
 
-| Name                       | Datatype | Description                                          | Default                |
-| -------------------------- | -------- | ---------------------------------------------------- | ---------------------- |
-| addr                       | string   | Host address to bind to                              | ":4000"                |
-| auth-mode                  | string   | Auth mode (token, cluster, local)                    | "token"                |
-| gin-mode                   | string   | Gin mode (release, debug)                            | "release"              |
-| kube-config                | string   | Kubectl config file path                             | "${HOME}/.kube/config" |
-| csrf.enabled               | bool     | Enable CSRF protection                               | true                   |
-| csrf.field-name            | string   | CSRF token name in forms                             | "csrf_token"           |
-| csrf.secret                | string   | CSRF hash key                                        | ""                     |
-| csrf.cookie.name           | string   | CSRF cookie name                                     | "csrf"                 |
-| csrf.cookie.path           | string   | CSRF cookie path                                     | "/"                    |
-| csrf.cookie.domain         | string   | CSRF cookie domain                                   | ""                     |
-| csrf.cookie.max-age        | int      | CSRF cookie max age (in seconds)                     | 43200                  |
-| csrf.cookie.secure         | bool     | CSRF cookie secure property                          | false                  |
-| csrf.cookie.http-only      | bool     | CSRF cookie HttpOnly property                        | true                   |
-| csrf.cookie.same-site      | string   | CSRF cookie SameSite property (strict, lax, none)    | "strict"               |
-| logging.enabled            | bool     | Enable logging                                       | true                   |
-| logging.level              | string   | Log level                                            | "info"                 |
-| logging.format             | string   | Log format (json, pretty)                            | "json"                 |
-| logging.access-log-enabled | bool     | Enable access log                                    | true                   |
-| session.secret             | string   | Session hash key                                     | ""                     |
-| session.cookie.path        | string   | Session cookie path                                  | "/"                    |
-| session.cookie.domain      | string   | Session cookie domain                                | ""                     |
-| session.cookie.max-age     | int      | Session cookie max age (in seconds)                  | 43200                  |
-| session.cookie.secure      | bool     | Session cookie secure property                       | false                  |
-| session.cookie.http-only   | bool     | Session cookie HttpOnly property                     | true                   |
-| session.cookie.same-site   | string   | Session cookie SameSite property (strict, lax, none) | "strict"               |
+| Name                                  | Datatype | Description                                          | Default                |
+| ------------------------------------- | -------- | ---------------------------------------------------- | ---------------------- |
+| addr                                  | string   | Host address to bind to                              | ":4000"                |
+| auth-mode                             | string   | Auth mode (token, cluster, local)                    | "token"                |
+| gin-mode                              | string   | Gin mode (release, debug)                            | "release"              |
+| kube-config                           | string   | Kubectl config file path                             | "${HOME}/.kube/config" |
+| csrf.enabled                          | bool     | Enable CSRF protection                               | true                   |
+| csrf.field-name                       | string   | CSRF token name in forms                             | "csrf_token"           |
+| csrf.secret                           | string   | CSRF hash key                                        | ""                     |
+| csrf.cookie.name                      | string   | CSRF cookie name                                     | "csrf"                 |
+| csrf.cookie.path                      | string   | CSRF cookie path                                     | "/"                    |
+| csrf.cookie.domain                    | string   | CSRF cookie domain                                   | ""                     |
+| csrf.cookie.max-age                   | int      | CSRF cookie max age (in seconds)                     | 43200                  |
+| csrf.cookie.secure                    | bool     | CSRF cookie secure property                          | false                  |
+| csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                        | true                   |
+| csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)    | "strict"               |
+| logging.enabled                       | bool     | Enable logging                                       | true                   |
+| logging.level                         | string   | Log level                                            | "info"                 |
+| logging.format                        | string   | Log format (json, pretty)                            | "json"                 |
+| logging.access-log.enabled            | bool     | Enable access log                                    | true                   |
+| logging.access-log.hide-health-checks | bool     | Hide requests to /healthz                            | false                  |
+| session.secret                        | string   | Session hash key                                     | ""                     |
+| session.cookie.path                   | string   | Session cookie path                                  | "/"                    |
+| session.cookie.domain                 | string   | Session cookie domain                                | ""                     |
+| session.cookie.max-age                | int      | Session cookie max age (in seconds)                  | 43200                  |
+| session.cookie.secure                 | bool     | Session cookie secure property                       | false                  |
+| session.cookie.http-only              | bool     | Session cookie HttpOnly property                     | true                   |
+| session.cookie.same-site              | string   | Session cookie SameSite property (strict, lax, none) | "strict"               |
 
 ## GraphQL
 

--- a/backend/cmd/server/config.go
+++ b/backend/cmd/server/config.go
@@ -72,8 +72,14 @@ type Config struct {
 		// log format
 		Format string `validate:"oneof=json pretty"`
 
-		// enable http access request logging
-		AccessLogEnabled bool `mapstructure:"access-log-enabled"`
+		// access-log options
+		AccessLog struct {
+			// enable access-log
+			Enabled bool
+
+			// hide health checks
+			HideHealthChecks bool `mapstructure:"hide-health-checks"`
+		} `mapstructure:"access-log"`
 	}
 }
 
@@ -114,6 +120,7 @@ func DefaultConfig() Config {
 	cfg.Logging.Enabled = true
 	cfg.Logging.Level = "info"
 	cfg.Logging.Format = "json"
-	cfg.Logging.AccessLogEnabled = true
+	cfg.Logging.AccessLog.Enabled = true
+	cfg.Logging.AccessLog.HideHealthChecks = false
 	return cfg
 }

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -166,7 +166,8 @@ func main() {
 			appCfg.AuthMode = ginapp.AuthMode(cfg.AuthMode)
 			appCfg.KubeConfig = cfg.KubeConfig
 			appCfg.Namespace = cfg.Namespace
-			appCfg.AccessLogEnabled = cfg.Logging.AccessLogEnabled
+			appCfg.AccessLog.Enabled = cfg.Logging.AccessLog.Enabled
+			appCfg.AccessLog.HideHealthChecks = cfg.Logging.AccessLog.HideHealthChecks
 			appCfg.Session.Secret = cfg.Session.Secret
 			appCfg.Session.Cookie.Name = cfg.Session.Cookie.Name
 			appCfg.Session.Cookie.Path = cfg.Session.Cookie.Path

--- a/backend/hack/server.yaml
+++ b/backend/hack/server.yaml
@@ -48,4 +48,6 @@ logging:
   enabled: true
   level: info
   format: pretty
-  access-log-enabled: true
+  access-log:
+    enabled: true
+    hide-health-checks: false

--- a/backend/internal/ginapp/config.go
+++ b/backend/internal/ginapp/config.go
@@ -30,8 +30,11 @@ type Config struct {
 	// namespace filter
 	Namespace string
 
-	// enable http access request logging
-	AccessLogEnabled bool
+	// access log options
+	AccessLog struct {
+		Enabled          bool
+		HideHealthChecks bool
+	}
 
 	// session options
 	Session struct {
@@ -72,7 +75,8 @@ func DefaultConfig() Config {
 	cfg := Config{}
 
 	cfg.AuthMode = AuthModeToken
-	cfg.AccessLogEnabled = true
+	cfg.AccessLog.Enabled = true
+	cfg.AccessLog.HideHealthChecks = false
 
 	cfg.Session.Secret = ""
 	cfg.Session.Cookie.Name = "session"

--- a/backend/internal/ginapp/ginapp.go
+++ b/backend/internal/ginapp/ginapp.go
@@ -75,8 +75,8 @@ func NewGinApp(config Config) (*GinApp, error) {
 	app.Use(requestid.New())
 
 	// add logging middleware
-	if config.AccessLogEnabled {
-		app.Use(loggingMiddleware())
+	if config.AccessLog.Enabled {
+		app.Use(loggingMiddleware(config.AccessLog.HideHealthChecks))
 	}
 
 	// gzip middleware

--- a/backend/internal/ginapp/middleware.go
+++ b/backend/internal/ginapp/middleware.go
@@ -82,8 +82,13 @@ func k8sTokenRequiredMiddleware(c *gin.Context) {
 }
 
 // Log HTTP requests
-func loggingMiddleware() gin.HandlerFunc {
+func loggingMiddleware(hideHealthChecks bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if hideHealthChecks && strings.HasSuffix(c.Request.URL.Path, "/healthz") {
+			c.Next()
+			return
+		}
+
 		t0 := time.Now().UTC() // for access log request time
 
 		// create contextual sub-logger

--- a/backend/internal/ginapp/testutils_test.go
+++ b/backend/internal/ginapp/testutils_test.go
@@ -204,7 +204,7 @@ func (c *WebTestClient) NewRequest(method, target string, body io.Reader) *http.
 // Create new base config for testing
 func NewTestConfig() *Config {
 	cfg := Config{}
-	cfg.AccessLogEnabled = false
+	cfg.AccessLog.Enabled = false
 	cfg.Session.Secret = "TESTSESSIONSECRET"
 	cfg.Session.Cookie.Name = "session"
 	cfg.CSRF.Enabled = false


### PR DESCRIPTION
* Groups access-log options together under logging config
* Adds `logging.access-log.hide-health-checks` option that (default: false)
* Updated README
