### PR TITLE
Adds pause/unpause functionality

### DIFF
--- a/frontend/src/lib/console/logfeed.tsx
+++ b/frontend/src/lib/console/logfeed.tsx
@@ -836,12 +836,8 @@ const LogFeedRecordFetcherImpl: React.ForwardRefRenderFunction<LogFeedRecordFetc
       // build args (including resetting `since`)
       const opts = { first: batchSize, since: undefined } as LogFeedHeadOptions;
 
-      if (followAfter && followAfter.localeCompare(after || '')) {
-        opts.after = followAfter;
-      } else {
-        opts.after = after;
-      }
-      console.log(opts);
+      if (followAfter && followAfter.localeCompare(after || '')) opts.after = followAfter;
+      else opts.after = after;
 
       // execute query
       const response = (await head.refetch(opts)).data.podLogHead;

--- a/frontend/src/lib/console/logfeed.tsx
+++ b/frontend/src/lib/console/logfeed.tsx
@@ -1181,6 +1181,8 @@ export const LogFeedViewer = () => {
       const client = loaderRef.current;
       if (!client) return;
 
+      let hasMoreAfter: boolean;
+
       const reset = () => {
         beforeBufferRef.current = [];
         afterBufferRef.current = [];
@@ -1202,7 +1204,10 @@ export const LogFeedViewer = () => {
 
           // update content
           setLogRecords(afterBufferRef.current.splice(0, batchSize));
-          setHasMoreAfter(afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current));
+
+          hasMoreAfter = afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current);
+          if (!hasMoreAfter) isSendFollowToBufferRef.current = false;
+          setHasMoreAfter(hasMoreAfter);
 
           contentRef.current?.scrollTo('first');
 
@@ -1242,7 +1247,10 @@ export const LogFeedViewer = () => {
 
           // update content
           setLogRecords(afterBufferRef.current.splice(0, batchSize));
-          setHasMoreAfter(afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current));
+
+          hasMoreAfter = afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current);
+          if (!hasMoreAfter) isSendFollowToBufferRef.current = false;
+          setHasMoreAfter(hasMoreAfter);
 
           contentRef.current?.scrollTo('first');
 
@@ -1259,7 +1267,7 @@ export const LogFeedViewer = () => {
           // update state
           cursorMapRef.current = response[1];
 
-          const hasMoreAfter = afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current);
+          hasMoreAfter = afterBufferRef.current.length > 0 || hasNextPageSome(cursorMapRef.current);
 
           if (!hasMoreAfter) isSendFollowToBufferRef.current = false;
           else isSendFollowToBufferRef.current = true;

--- a/frontend/src/pages/console.tsx
+++ b/frontend/src/pages/console.tsx
@@ -385,7 +385,7 @@ const Header = () => {
           <button
             className={buttonCN}
             title="Pause"
-            onClick={() => controls.setFollow(false)}
+            onClick={() => controls.pause()}
           >
             <PauseIcon size={24} strokeWidth={1.5} className="text-chrome-foreground" />
           </button>
@@ -393,7 +393,7 @@ const Header = () => {
           <button
             className={buttonCN}
             title="Play"
-            onClick={() => controls.setFollow(true)}
+            onClick={() => controls.play()}
           >
             <PlayIcon size={24} strokeWidth={1.5} className="text-chrome-foreground" />
           </button>


### PR DESCRIPTION
* Implements separate before/after buffers to better handle data retrieved that comes before/after logfeed content
* Adds `skipForward` internal method that allows treating unpause as a retrieval of more data
* Fixes bugs preventing follow on head/seek that returned all data
* Improves updates of start/end cursors on server fetches
