### PR TITLE
Improvements to tilt yaml

### DIFF
--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -337,34 +337,6 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: cluster-agent
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kubetail-cluster-agent
-  labels:
-    app.kubernetes.io/name: kubetail
-    app.kubernetes.io/component: cluster-agent
-rules:
-- apiGroups: [""]
-  resources: [pods/log]
-  verbs: [list, watch]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kubetail-cluster-agent
-  labels:
-    app.kubernetes.io/name: kubetail
-    app.kubernetes.io/component: cluster-agent
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubetail-cluster-agent
-subjects:
-- kind: ServiceAccount
-  name: kubetail-cluster-agent
-  namespace: kubetail-system
----
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -20,7 +20,7 @@ data:
       session:
         secret: REPLACEME
         cookie:
-          name: session
+          name: kubetail_dashboard_session
           path: /
           max-age: 2592000
           secure: false
@@ -103,12 +103,12 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: dashboard
 rules:
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, namespaces, nodes, pods, pods/log, replicasets, statefulsets]
+- apiGroups: [""]
+  resources: [namespaces, nodes]
   verbs: [get, list, watch]
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
+- apiGroups: ["", apps, batch]
+  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
+  verbs: [get, list, watch]
 - apiGroups: [authentication.k8s.io]
   resources: [tokenreviews]
   verbs: [create]
@@ -128,6 +128,36 @@ subjects:
 - kind: ServiceAccount
   name: kubetail-dashboard
   namespace: kubetail-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubetail-dashboard
+  namespace: kubetail-system
+  labels:
+    app.kubernetes.io/name: kubetail
+    app.kubernetes.io/component: dashboard
+rules:
+- apiGroups: [discovery.k8s.io]
+  resources: [endpointslices]
+  verbs: [list, watch]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubetail-dashboard
+  namespace: kubetail-system
+  labels:
+    app.kubernetes.io/name: kubetail
+    app.kubernetes.io/component: dashboard
+roleRef:
+  kind: Role
+  name: kubetail-dashboard
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kubetail-dashboard
+  namespace: kubetail-system    
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
Changes to hack/tilt/kubetail.yaml
* Makes cookie names more specific
* Makes Dashboard's endpointslices permissions namespace-scoped
* Removes unnecessary ClusterRole permissions for Cluster Agent
