### PR TITLE
Block desktop-only requests in non-desktop environment

### DIFF
--- a/modules/dashboard/graph/schema.resolvers_test.go
+++ b/modules/dashboard/graph/schema.resolvers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/utils/ptr"
 
+	"github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/errors"
 
 	k8shelpersmock "github.com/kubetail-org/kubetail/modules/dashboard/internal/k8shelpers/mock"
@@ -133,4 +134,29 @@ func TestAllowedNamespacesListQueries(t *testing.T) {
 			assert.Equal(t, err, errors.ErrForbidden)
 		})
 	}
+}
+
+func TestDesktopOnlyRequests(t *testing.T) {
+	resolver := &Resolver{environment: config.EnvironmentCluster}
+
+	t.Run("kubeConfigGet", func(t *testing.T) {
+		r := &queryResolver{resolver}
+		_, err := r.KubeConfigGet(context.Background())
+		assert.NotNil(t, err)
+		assert.Equal(t, err, errors.ErrForbidden)
+	})
+
+	t.Run("kubeConfigWatch", func(t *testing.T) {
+		r := &subscriptionResolver{resolver}
+		_, err := r.KubeConfigWatch(context.Background())
+		assert.NotNil(t, err)
+		assert.Equal(t, err, errors.ErrForbidden)
+	})
+
+	t.Run("kubetailClusterAPIInstall", func(t *testing.T) {
+		r := &mutationResolver{resolver}
+		_, err := r.KubetailClusterAPIInstall(context.Background(), nil)
+		assert.NotNil(t, err)
+		assert.Equal(t, err, errors.ErrForbidden)
+	})
 }

--- a/modules/shared/graphql/errors/errors.go
+++ b/modules/shared/graphql/errors/errors.go
@@ -21,7 +21,7 @@ var (
 	ErrValidationError     = NewError("KUBETAIL_VALIDATION_ERROR", "Validation error")
 	ErrRecordNotFound      = NewError("KUBETAIL_RECORD_NOT_FOUND", "Record not found")
 	ErrUnauthenticated     = NewError("KUBETAIL_UNAUTHENTICATED", "Authentication required")
-	ErrForbidden           = NewError("KUBETAIL_FORBIDDEN", "Access forbidden")
+	ErrForbidden           = NewError("KUBETAIL_FORBIDDEN", "Forbidden")
 	ErrWatchError          = NewError("KUBETAIL_WATCH_ERROR", "Watch error")
 	ErrInternalServerError = NewError("INTERNAL_SERVER_ERROR", "Internal server error")
 )


### PR DESCRIPTION
This PR blocks the following Dashboard requests in a non-desktop environment:
- KubeConfigGet
- KubeConfigWatch
- KubetailClusterAPIInstall
