### PR TITLE
Remove custom audience from Dashboard token request and Cluster API playground url change

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -170,5 +170,5 @@ k8s_resource(
 
 k8s_resource(
   'echoserver',
-  port_forwards='8080:8080',
+  port_forwards='4502:8080',
 )

--- a/modules/cluster-api/internal/app/app.go
+++ b/modules/cluster-api/internal/app/app.go
@@ -137,15 +137,10 @@ func NewApp(cfg *config.Config) (*App, error) {
 	}
 	app.dynamicRoutes = dynamicRoutes // for unit tests
 
-	// Serve GraphQL playground at root
-	sub, err := fs.Sub(clusterapi.StaticEmbedFS, "static")
-	if err != nil {
-		return nil, err
-	}
-	staticFS := http.FS(sub)
-	root.StaticFileFS("/", "/graphiql.html", staticFS)
-	root.StaticFileFS("/favicon.ico", "/favicon.ico", staticFS)
-	root.StaticFileFS("/favicon.svg", "/favicon.svg", staticFS)
+	// Root endpoint
+	root.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "Kubetail Cluster API")
+	})
 
 	// Health endpoint
 	root.GET("/healthz", func(c *gin.Context) {
@@ -153,6 +148,19 @@ func NewApp(cfg *config.Config) (*App, error) {
 			"status": "ok",
 		})
 	})
+
+	// Init staticFS
+	sub, err := fs.Sub(clusterapi.StaticEmbedFS, "static")
+	if err != nil {
+		return nil, err
+	}
+	staticFS := http.FS(sub)
+
+	// GraphQL Playground
+	root.StaticFileFS("/graphiql", "/graphiql.html", staticFS)
+
+	root.StaticFileFS("/favicon.ico", "/favicon.ico", staticFS)
+	root.StaticFileFS("/favicon.svg", "/favicon.svg", staticFS)
 
 	return app, nil
 }

--- a/modules/dashboard/internal/k8shelpers/service-account-token.go
+++ b/modules/dashboard/internal/k8shelpers/service-account-token.go
@@ -16,7 +16,6 @@ package k8shelpers
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -78,12 +77,7 @@ func (sat *ServiceAccountToken) refreshToken_UNSAFE(ctx context.Context) error {
 	// Prepare the TokenRequest object
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			//ExpirationSeconds: ptr.To[int64](3600), // Token validity (e.g., 1 hour)
-			ExpirationSeconds: ptr.To[int64](600), // Token validity (e.g., 1 hour)
-			Audiences: []string{
-				"https://kubernetes.default.svc.cluster.local",
-				fmt.Sprintf("http://kubetail-cluster-api.%s.svc.cluster.local", sat.namespace),
-			},
+			ExpirationSeconds: ptr.To[int64](3600), // Token validity (e.g., 1 hour)
 		},
 	}
 


### PR DESCRIPTION
* Remove custom audience claim from CLI token request in Dashboard
* Move GraphQL playground url to "/graphiql" in Cluster API
