### PR TITLE
feat: add oidc plugin for k8s client

### DIFF
--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"


### PR DESCRIPTION
Hello ! 

Just a simple fix that permit to handle OIDC connection with the kubernetes client !

Without this fix any oidc cluster will be failed with error : `Error: no Auth Provider found for name "oidc"` 

Its a very simple fix and hope you will approve it 

thanks you