### PR TITLE
new: add `--kubeconfig` to CLI

### DIFF
--- a/hack/tilt/loggen-ansi.yaml
+++ b/hack/tilt/loggen-ansi.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loggen-ansi
-  namespace: default
   labels:
     app.kubernetes.io/name: loggen
     app.kubernetes.io/instance: kubetail-dev-2

--- a/hack/tilt/loggen-ansi.yaml
+++ b/hack/tilt/loggen-ansi.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loggen-ansi
+  namespace: default
   labels:
     app.kubernetes.io/name: loggen
     app.kubernetes.io/instance: kubetail-dev-2

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -521,7 +521,6 @@ func init() {
 	flagset.SortFlags = false
 
 	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
-
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"
 	flagset.Int64P("tail", "t", 10, "Return last N records")

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -274,7 +274,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager(kubeconfig)
+		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(kubeconfig))
 		cli.ExitOnError(err)
 
 		kubeContextPtr := ptr.To(kubeContext)

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -194,6 +194,7 @@ var logsCmd = &cobra.Command{
 		flags := cmd.Flags()
 
 		kubeContext, _ := flags.GetString("kube-context")
+		kubeconfig, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
 		headVal, _ := flags.GetInt64("head")
@@ -273,7 +274,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager()
+		cm, err := k8shelpers.NewDesktopConnectionManager(kubeconfig)
 		cli.ExitOnError(err)
 
 		kubeContextPtr := ptr.To(kubeContext)

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -48,4 +48,6 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	flagset := rootCmd.Flags()
+	flagset.String("kubeconfig", "", "path to the kubeconfig file to use for CLI requests.")
 }

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	KubeconfigFlag = "kubeconfig"
+)
+
 var version = "dev" // default version for local builds
 
 // rootCmd represents the base command when called without any subcommands
@@ -48,6 +52,6 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	flagset := rootCmd.Flags()
-	flagset.String("kubeconfig", "", "path to the kubeconfig file to use for CLI requests.")
+	flagset := rootCmd.PersistentFlags()
+	flagset.String(KubeconfigFlag, "", "path to the kubeconfig file to use for CLI requests.")
 }

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -76,6 +76,7 @@ var serveCmd = &cobra.Command{
 		if err != nil {
 			zlog.Fatal().Caller().Err(err).Send()
 		}
+		cfg.Kubeconfig, _ = cmd.Flags().GetString(KubeconfigFlag)
 
 		cfg.Dashboard.Environment = config.EnvironmentDesktop
 		cfg.Dashboard.Logging.AccessLog.Enabled = false

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -73,7 +73,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment)
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, cfg.Kubeconfig)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -73,7 +73,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, cfg.Kubeconfig)
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.Kubeconfig))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Auth-mode
@@ -54,7 +55,7 @@ const (
 // Application configuration
 type Config struct {
 	AllowedNamespaces []string `mapstructure:"allowed-namespaces"`
-
+	Kubeconfig        string   `mapstructure:"kubeconfig"`
 	// dashboard options
 	Dashboard struct {
 		Addr               string   `validate:"omitempty,hostname_port"`
@@ -236,7 +237,7 @@ func DefaultConfig() *Config {
 	cfg := &Config{}
 
 	cfg.AllowedNamespaces = []string{}
-
+	cfg.Kubeconfig = clientcmd.RecommendedHomeFile
 	cfg.Dashboard.Addr = ":8080"
 	cfg.Dashboard.AuthMode = AuthModeAuto
 	cfg.Dashboard.BasePath = "/"

--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -48,6 +48,7 @@ type ConnectionManager interface {
 type DesktopConnectionManager struct {
 	KubeConfigWatcher *KubeConfigWatcher
 	kubeConfig        *api.Config
+	kubeconfigPath    string
 	rcCache           map[string]*rest.Config
 	csCache           map[string]*kubernetes.Clientset
 	dcCache           map[string]*dynamic.DynamicClient
@@ -59,7 +60,7 @@ type DesktopConnectionManager struct {
 }
 
 // Initialize new DesktopConnectionManager instance
-func NewDesktopConnectionManager(kubeconfigPath string) (*DesktopConnectionManager, error) {
+func NewDesktopConnectionManager(options ...ConnectionManagerOption) (*DesktopConnectionManager, error) {
 	cm := &DesktopConnectionManager{
 		rcCache:    make(map[string]*rest.Config),
 		csCache:    make(map[string]*kubernetes.Clientset),
@@ -72,8 +73,12 @@ func NewDesktopConnectionManager(kubeconfigPath string) (*DesktopConnectionManag
 	// Init root context
 	cm.rootCtx, cm.rootCtxCancel = context.WithCancel(context.Background())
 
+	for _, option := range options {
+		option(cm)
+	}
+
 	// Init KubeConfigWatcher
-	kfw, err := NewKubeConfigWatcher(kubeconfigPath)
+	kfw, err := NewKubeConfigWatcher(cm.kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +329,7 @@ type InClusterConnectionManager struct {
 }
 
 // Initialize new InClusterConnectionManager instance
-func NewInClusterConnectionManager() (*InClusterConnectionManager, error) {
+func NewInClusterConnectionManager(options ...ConnectionManagerOption) (*InClusterConnectionManager, error) {
 	return &InClusterConnectionManager{}, nil
 }
 
@@ -435,14 +440,30 @@ func (cm *InClusterConnectionManager) getOrCreateRestConfig_UNSAFE() (*rest.Conf
 	return restConfig, nil
 }
 
+type ConnectionManagerOption func(cm ConnectionManager)
+
+func WithKubeconfig(kubeconfig string) ConnectionManagerOption {
+	return func(cm ConnectionManager) {
+		switch t := cm.(type) {
+		case *DesktopConnectionManager:
+			t.kubeconfigPath = kubeconfig
+		case *InClusterConnectionManager:
+			break
+		}
+	}
+}
+
 // Initialize new ConnectionManager depending on environment
-func NewConnectionManager(env config.Environment, kubeconfigPath string) (ConnectionManager, error) {
+func NewConnectionManager(env config.Environment, options ...ConnectionManagerOption) (ConnectionManager, error) {
+	var cm ConnectionManager
+	var err error
 	switch env {
 	case config.EnvironmentDesktop:
-		return NewDesktopConnectionManager(kubeconfigPath)
+		cm, err = NewDesktopConnectionManager(options...)
 	case config.EnvironmentCluster:
-		return NewInClusterConnectionManager()
+		cm, err = NewInClusterConnectionManager(options...)
 	default:
 		panic("not supported")
 	}
+	return cm, err
 }

--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -59,7 +59,7 @@ type DesktopConnectionManager struct {
 }
 
 // Initialize new DesktopConnectionManager instance
-func NewDesktopConnectionManager() (*DesktopConnectionManager, error) {
+func NewDesktopConnectionManager(kubeconfigPath string) (*DesktopConnectionManager, error) {
 	cm := &DesktopConnectionManager{
 		rcCache:    make(map[string]*rest.Config),
 		csCache:    make(map[string]*kubernetes.Clientset),
@@ -73,7 +73,7 @@ func NewDesktopConnectionManager() (*DesktopConnectionManager, error) {
 	cm.rootCtx, cm.rootCtxCancel = context.WithCancel(context.Background())
 
 	// Init KubeConfigWatcher
-	kfw, err := NewKubeConfigWatcher()
+	kfw, err := NewKubeConfigWatcher(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -436,10 +436,10 @@ func (cm *InClusterConnectionManager) getOrCreateRestConfig_UNSAFE() (*rest.Conf
 }
 
 // Initialize new ConnectionManager depending on environment
-func NewConnectionManager(env config.Environment) (ConnectionManager, error) {
+func NewConnectionManager(env config.Environment, kubeconfigPath string) (ConnectionManager, error) {
 	switch env {
 	case config.EnvironmentDesktop:
-		return NewDesktopConnectionManager()
+		return NewDesktopConnectionManager(kubeconfigPath)
 	case config.EnvironmentCluster:
 		return NewInClusterConnectionManager()
 	default:

--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -33,10 +33,16 @@ type KubeConfigWatcher struct {
 }
 
 // Creates new KubeConfigWatcher instance
-func NewKubeConfigWatcher() (*KubeConfigWatcher, error) {
+func NewKubeConfigWatcher(filename string) (*KubeConfigWatcher, error) {
 	// Initialize kube config
 	// TODO: Handle missing kube config files more gracefully
-	kubeConfig, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	var kubeConfig *api.Config
+	var err error
+	if filename != "" {
+		kubeConfig, err = clientcmd.LoadFromFile(filename)
+	} else {
+		kubeConfig, err = clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -33,17 +33,22 @@ type KubeConfigWatcher struct {
 }
 
 // Creates new KubeConfigWatcher instance
-func NewKubeConfigWatcher(filename string) (*KubeConfigWatcher, error) {
+func NewKubeConfigWatcher(kubeconfigPath string) (*KubeConfigWatcher, error) {
 	// Initialize kube config
 	// TODO: Handle missing kube config files more gracefully
 	var kubeConfig *api.Config
 	var err error
-	if filename != "" {
-		kubeConfig, err = clientcmd.LoadFromFile(filename)
+
+	if kubeconfigPath != "" {
+		zlog.Info().Msgf("Loaded kubeconfig %s", kubeconfigPath)
+		kubeConfig, err = clientcmd.LoadFromFile(kubeconfigPath)
 	} else {
+		zlog.Info().Msgf("Loaded default kubeconfig: %s", clientcmd.RecommendedHomeFile)
 		kubeConfig, err = clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
 	}
+
 	if err != nil {
+		zlog.Error().Msg("Kubeconfig is corrupted or missing. Please provide a valid kubeconfig.")
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #184 

## Changes

Include `--kubeconfig` as a global flag to kubetail CLI.

⚠️ `--kubeconfig` only works on `logs` and `serve` sub-command at the moment, but is visible globally.

## Release notes

```
add `--kubeconfig` global flag to kubetail CLI for `logs` and `serve` subcommands
```