### PR TITLE
Change scope of `--kubeconfig` CLI flag from global to local for `logs` and `serve` sub-commands

### DIFF
--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -521,6 +521,7 @@ func init() {
 	flagset := logsCmd.Flags()
 	flagset.SortFlags = false
 
+	flagset.String(KubeconfigFlag, "", "Path to kubeconfig file")
 	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -194,6 +194,7 @@ var logsCmd = &cobra.Command{
 		flags := cmd.Flags()
 
 		kubeContext, _ := flags.GetString("kube-context")
+		kubeconfig, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
 		headVal, _ := flags.GetInt64("head")
@@ -273,7 +274,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager()
+		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(kubeconfig))
 		cli.ExitOnError(err)
 
 		kubeContextPtr := ptr.To(kubeContext)
@@ -521,7 +522,6 @@ func init() {
 	flagset.SortFlags = false
 
 	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
-
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"
 	flagset.Int64P("tail", "t", 10, "Return last N records")

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	KubeconfigFlag = "kubeconfig"
+)
+
 var version = "dev" // default version for local builds
 
 // rootCmd represents the base command when called without any subcommands
@@ -48,4 +52,6 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	flagset := rootCmd.PersistentFlags()
+	flagset.String(KubeconfigFlag, "", "path to the kubeconfig file to use for CLI requests.")
 }

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -52,6 +52,4 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	flagset := rootCmd.PersistentFlags()
-	flagset.String(KubeconfigFlag, "", "path to the kubeconfig file to use for CLI requests.")
 }

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -247,6 +247,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := serveCmd.Flags()
 	flagset.SortFlags = false
+	flagset.String(KubeconfigFlag, "", "Path to kubeconfig file")
 	flagset.IntP("port", "p", 7500, "Port number to listen on")
 	flagset.String("host", "localhost", "Host address to bind to")
 	flagset.StringP("log-level", "l", "info", "Log level (debug, info, warn, error, disabled)")

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -76,6 +76,7 @@ var serveCmd = &cobra.Command{
 		if err != nil {
 			zlog.Fatal().Caller().Err(err).Send()
 		}
+		cfg.Kubeconfig, _ = cmd.Flags().GetString(KubeconfigFlag)
 
 		cfg.Dashboard.Environment = config.EnvironmentDesktop
 		cfg.Dashboard.Logging.AccessLog.Enabled = false

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -73,7 +73,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment)
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.Kubeconfig))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Auth-mode
@@ -54,7 +55,7 @@ const (
 // Application configuration
 type Config struct {
 	AllowedNamespaces []string `mapstructure:"allowed-namespaces"`
-
+	Kubeconfig        string   `mapstructure:"kubeconfig"`
 	// dashboard options
 	Dashboard struct {
 		Addr               string   `validate:"omitempty,hostname_port"`
@@ -236,7 +237,7 @@ func DefaultConfig() *Config {
 	cfg := &Config{}
 
 	cfg.AllowedNamespaces = []string{}
-
+	cfg.Kubeconfig = clientcmd.RecommendedHomeFile
 	cfg.Dashboard.Addr = ":8080"
 	cfg.Dashboard.AuthMode = AuthModeAuto
 	cfg.Dashboard.BasePath = "/"

--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -33,11 +33,22 @@ type KubeConfigWatcher struct {
 }
 
 // Creates new KubeConfigWatcher instance
-func NewKubeConfigWatcher() (*KubeConfigWatcher, error) {
+func NewKubeConfigWatcher(kubeconfigPath string) (*KubeConfigWatcher, error) {
 	// Initialize kube config
 	// TODO: Handle missing kube config files more gracefully
-	kubeConfig, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	var kubeConfig *api.Config
+	var err error
+
+	if kubeconfigPath != "" {
+		zlog.Info().Msgf("Loaded kubeconfig %s", kubeconfigPath)
+		kubeConfig, err = clientcmd.LoadFromFile(kubeconfigPath)
+	} else {
+		zlog.Info().Msgf("Loaded default kubeconfig: %s", clientcmd.RecommendedHomeFile)
+		kubeConfig, err = clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	}
+
 	if err != nil {
+		zlog.Error().Msg("Kubeconfig is corrupted or missing. Please provide a valid kubeconfig.")
 		return nil, err
 	}
 


### PR DESCRIPTION
Co-author @rxinui