### PR TITLE
Bug/240: --kubeconfig is correctly supported on serve

### DIFF
--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -522,7 +522,6 @@ func init() {
 	flagset := logsCmd.Flags()
 	flagset.SortFlags = false
 
-	flagset.String(KubeconfigFlag, "", "Path to kubeconfig file")
 	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sosodev/duration"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
@@ -193,7 +194,7 @@ var logsCmd = &cobra.Command{
 		flags := cmd.Flags()
 
 		kubeContext, _ := flags.GetString("kube-context")
-		kubeconfig, _ := flags.GetString(KubeconfigFlag)
+		kubeconfigPath, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
 		headVal, _ := flags.GetInt64("head")
@@ -273,7 +274,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(kubeconfig))
+		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(kubeconfigPath))
 		cli.ExitOnError(err)
 
 		// Init stream
@@ -522,6 +523,7 @@ func init() {
 	flagset := logsCmd.Flags()
 	flagset.SortFlags = false
 
+	flagset.String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
 	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -18,13 +18,15 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
-	KubeconfigFlag = "kubeconfig"
+	KubeconfigFlag = clientcmd.RecommendedConfigPathFlag
 )
 
 var version = "dev" // default version for local builds
+var kubeconfigFlagValue = clientcmd.RecommendedHomeFile
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -48,6 +50,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
+	rootCmd.PersistentFlags().StringVar(&kubeconfigFlagValue, KubeconfigFlag, "", "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -26,7 +26,6 @@ const (
 )
 
 var version = "dev" // default version for local builds
-var kubeconfigFlagValue = clientcmd.RecommendedHomeFile
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -50,7 +49,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
-	rootCmd.PersistentFlags().StringVar(&kubeconfigFlagValue, KubeconfigFlag, "", "Path to kubeconfig file")
+	rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -49,7 +49,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
-	rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
+	// rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/internal/tunnel/tunnel.go
+++ b/modules/cli/internal/tunnel/tunnel.go
@@ -56,8 +56,8 @@ func (t *Tunnel) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func NewTunnel(kubeconfig, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
-	kubeconfigConf, err := clientcmd.LoadFromFile(kubeconfig)
+func NewTunnel(kubeconfigPath, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
+	kubeconfigConf, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/cli/internal/tunnel/tunnel.go
+++ b/modules/cli/internal/tunnel/tunnel.go
@@ -56,13 +56,13 @@ func (t *Tunnel) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func NewTunnel(namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
-	kubeConfig, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+func NewTunnel(kubeconfig, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
+	kubeconfigConf, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	clientConfig := clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{})
+	clientConfig := clientcmd.NewDefaultClientConfig(*kubeconfigConf, &clientcmd.ConfigOverrides{})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -74,7 +74,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.Kubeconfig))
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.KubeconfigPath))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -55,7 +55,7 @@ const (
 // Application configuration
 type Config struct {
 	AllowedNamespaces []string `mapstructure:"allowed-namespaces"`
-	Kubeconfig        string   `mapstructure:"kubeconfig"`
+	KubeconfigPath    string   `mapstructure:"kubeconfig"`
 	// dashboard options
 	Dashboard struct {
 		Addr               string   `validate:"omitempty,hostname_port"`
@@ -237,7 +237,7 @@ func DefaultConfig() *Config {
 	cfg := &Config{}
 
 	cfg.AllowedNamespaces = []string{}
-	cfg.Kubeconfig = clientcmd.RecommendedHomeFile
+	cfg.KubeconfigPath = clientcmd.RecommendedHomeFile
 	cfg.Dashboard.Addr = ":8080"
 	cfg.Dashboard.AuthMode = AuthModeAuto
 	cfg.Dashboard.BasePath = "/"


### PR DESCRIPTION
Fixes #240 

## Changes

`Tunnel` and `KubeconfigWatcher` now acts on `--kubeconfig` flag value. Moreover, the usage of `~` is supported.