### PR TITLE
Fix broken link in README (Tilt docs cluster setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Dependencies:
 ctlptl apply -f hack/ctlptl/minikube.yaml
 ```
 
-You can use any type of cluster that [works with Tilt](https://docs.tilt.dev/choosing_clusters#microk8s).
+You can use any type of cluster that [works with Tilt](https://docs.tilt.dev/choosing_clusters.html).
 
 2. Start the dev environment:
 


### PR DESCRIPTION
I've noticed that the link https://docs.tilt.dev/choosing_clusters#microk8s is broken!
Here is the correct link: https://docs.tilt.dev/choosing_clusters.html#microk8s but we can also link to the general page:  https://docs.tilt.dev/choosing_clusters.html