### PR TITLE
[Low Hanging Fruit] rgkl - Run Rust formatter and linter (clippy), incorporate changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   crates-lint:
-    name: Rust fmt & Clippy
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,26 @@ on:
       - '**'
 
 jobs:
+  crates-lint:
+    name: Rust fmt & Clippy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: rustfmt
+        working-directory: ./crates/rgkl
+        run: cargo fmt --all -- --check
+
+      - name: clippy
+        working-directory: ./crates/rgkl
+        run: cargo clippy --all -- -D warnings
+
   crates-test:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
+      - uses: arduino/setup-protoc@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/crates/rgkl/src/main.rs
+++ b/crates/rgkl/src/main.rs
@@ -110,10 +110,10 @@ fn main() -> ExitCode {
             let mut stdout = stdout().lock();
             match stream_forward::run(
                 file,
-                start_time.clone(),
-                stop_time.clone(),
+                *start_time,
+                *stop_time,
                 grep,
-                follow_from.clone(),
+                *follow_from,
                 term_rx,
                 &mut stdout,
             ) {
@@ -133,8 +133,8 @@ fn main() -> ExitCode {
             let mut stdout = stdout().lock();
             match stream_backward::run(
                 file,
-                start_time.clone(),
-                stop_time.clone(),
+                *start_time,
+                *stop_time,
                 grep,
                 term_rx,
                 &mut stdout,

--- a/crates/rgkl/src/main.rs
+++ b/crates/rgkl/src/main.rs
@@ -129,14 +129,7 @@ fn main() -> ExitCode {
             grep,
         } => {
             let mut stdout = stdout().lock();
-            match stream_backward::run(
-                file,
-                *start_time,
-                *stop_time,
-                grep,
-                term_rx,
-                &mut stdout,
-            ) {
+            match stream_backward::run(file, *start_time, *stop_time, grep, term_rx, &mut stdout) {
                 Ok(_) => ExitCode::SUCCESS,
                 Err(err) => {
                     eprintln!("Error: {:#}", err);

--- a/crates/rgkl/src/main.rs
+++ b/crates/rgkl/src/main.rs
@@ -84,9 +84,8 @@ fn main() -> ExitCode {
     match Signals::new([SIGINT, SIGTERM]) {
         Ok(mut signals) => {
             thread::spawn(move || {
-                for _sig in signals.forever() {
-                    //let _ = term_tx.send(());
-                    break;
+                if signals.forever().next().is_some() {
+                    let _ = term_tx.send(());
                 }
                 drop(term_tx);
             });

--- a/crates/rgkl/src/main.rs
+++ b/crates/rgkl/src/main.rs
@@ -85,9 +85,8 @@ fn main() -> ExitCode {
         Ok(mut signals) => {
             thread::spawn(move || {
                 if signals.forever().next().is_some() {
-                    let _ = term_tx.send(());
+                    drop(term_tx);
                 }
-                drop(term_tx);
             });
         }
         Err(err) => {

--- a/crates/rgkl/src/stream_forward.rs
+++ b/crates/rgkl/src/stream_forward.rs
@@ -148,7 +148,7 @@ pub fn run<W: Write>(
     }
 
     // Exit if we didn't read to end
-    if let Some(_) = take_length {
+    if take_length.is_some() {
         return Ok(());
     }
 

--- a/crates/rgkl/src/util/format.rs
+++ b/crates/rgkl/src/util/format.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /// Represents the format of log files
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FileFormat {
     /// Docker JSON format logs

--- a/crates/rgkl/src/util/offset.rs
+++ b/crates/rgkl/src/util/offset.rs
@@ -39,7 +39,14 @@ pub fn find_nearest_offset_since(
     max_offset: u64,
     format: FileFormat,
 ) -> Result<Option<Offset>, Box<dyn Error>> {
-    find_nearest_offset(file, target_time, min_offset, max_offset, FindMode::Since, format)
+    find_nearest_offset(
+        file,
+        target_time,
+        min_offset,
+        max_offset,
+        FindMode::Since,
+        format,
+    )
 }
 
 /// Finds the nearest offset to a given timestamp between `min_offset` and
@@ -51,7 +58,14 @@ pub fn find_nearest_offset_until(
     max_offset: u64,
     format: FileFormat,
 ) -> Result<Option<Offset>, Box<dyn Error>> {
-    find_nearest_offset(file, target_time, min_offset, max_offset, FindMode::Until, format)
+    find_nearest_offset(
+        file,
+        target_time,
+        min_offset,
+        max_offset,
+        FindMode::Until,
+        format,
+    )
 }
 
 enum FindMode {
@@ -163,7 +177,10 @@ fn scan_timestamp(
 /// Attempts to parse a timestamp from the beginning of the log line.
 /// The log line is expected to start with an RFC 3339 formatted timestamp
 /// or be in Docker JSON format with a "timestamp" field.
-fn parse_timestamp(line: &str, format: FileFormat) -> Result<DateTime<Utc>, Box<dyn std::error::Error>> {
+fn parse_timestamp(
+    line: &str,
+    format: FileFormat,
+) -> Result<DateTime<Utc>, Box<dyn std::error::Error>> {
     match format {
         FileFormat::Docker => {
             // Parse the JSON
@@ -176,7 +193,7 @@ fn parse_timestamp(line: &str, format: FileFormat) -> Result<DateTime<Utc>, Box<
             } else {
                 Err(format!("missing timestamp field in JSON log: {}", line).into())
             }
-        },
+        }
         FileFormat::CRI => {
             // Original CRI format parsing
             let parts: Vec<&str> = line.splitn(2, ' ').collect();
@@ -278,7 +295,8 @@ mod tests_find_nearest_offset_since {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -339,7 +357,8 @@ mod tests_find_nearest_offset_since {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::Docker)?;
+            let offset =
+                find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::Docker)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -371,7 +390,8 @@ mod tests_find_nearest_offset_since {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -453,7 +473,8 @@ mod tests_find_nearest_offset_since {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -492,7 +513,8 @@ mod tests_find_nearest_offset_since {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_since(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -560,7 +582,8 @@ mod tests_find_nearest_offset_until {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -592,7 +615,8 @@ mod tests_find_nearest_offset_until {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -674,7 +698,8 @@ mod tests_find_nearest_offset_until {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 
@@ -713,7 +738,8 @@ mod tests_find_nearest_offset_until {
 
         for (target_str, expected) in test_cases {
             let target_time = DateTime::parse_from_rfc3339(target_str)?.with_timezone(&Utc);
-            let offset = find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
+            let offset =
+                find_nearest_offset_until(&file, target_time, 0, max_offset, FileFormat::CRI)?;
             assert_eq!(offset.as_ref(), expected, "target: {}", target_str);
         }
 

--- a/crates/rgkl/src/util/writer.rs
+++ b/crates/rgkl/src/util/writer.rs
@@ -20,8 +20,8 @@ use std::{
 use prost_wkt_types::Timestamp;
 use serde_json;
 
-use cluster_agent::LogRecord;
 use crate::util::format::FileFormat;
+use cluster_agent::LogRecord;
 
 pub mod cluster_agent {
     tonic::include_proto!("cluster_agent");
@@ -99,7 +99,9 @@ pub fn process_output<W: Write>(chunk: &[u8], writer: &mut W, format: FileFormat
                                 (log_json["time"].as_str(), log_json["log"].as_str())
                             {
                                 let record = LogRecord {
-                                    timestamp: Some(Timestamp::from_str(time_str).unwrap_or_default()),
+                                    timestamp: Some(
+                                        Timestamp::from_str(time_str).unwrap_or_default(),
+                                    ),
                                     message: log_msg.trim_end().to_string(),
                                 };
 


### PR DESCRIPTION
 Mostly stylistic changes to adhere to Rust coding standards outlined by `cargo fmt` and `cargo clippy`. I thought most of the clippy suggestions were good, except for its complaint on using all caps on CRI (I think that is a pedantic warning and not really applicable here where CRI is a standard abbreviation), so I've explicitly suppressed that warning.

The only functional change is un-commenting `term_tx.send()` in `main.rs`, as the early-termination logic of `TermReader` relies on this. @amorey please do to let me know if there was a specific reason why that part was commented out.

Thanks!