### PR TITLE
rgkl - reduce dev env Rust compile-time by moving build step to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,15 @@ It also contains the source code for the Kubetail Dashboard's frontend and the R
 
 ### Setting up the Development Environment
 
-Dependencies:
+#### Dependencies:
+
 * [Tilt](https://tilt.dev/)
 * [Go](https://go.dev/)
 * [pnpm](https://pnpm.io/)
 * [ctlptl](https://github.com/tilt-dev/ctlptl) (optional)
 
-1. Create a Kubernetes dev cluster:
+
+1. Create a Kubernetes Dev Cluster
 
 ```console
 ctlptl apply -f hack/ctlptl/minikube.yaml
@@ -218,7 +220,55 @@ pnpm install
 pnpm dev
 ```
 
-Now access the dashboard at [http://localhost:5173](http://localhost:5173). 
+Now access the dashboard at [http://localhost:5173](http://localhost:5173).
+
+
+---
+
+
+### (Optional) Fast Iteration for Rust Development
+
+If you want to iterate quickly on Rust components, you can build them locally instead of through the dev containers.
+
+**1. Install Rust and Required Targets**
+
+**macOS:**
+
+```sh
+brew install protobuf
+rustup install stable
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+brew install FiloSottile/musl-cross/musl-cross
+```
+
+Then add the following to `~/.cargo/config.toml`:
+
+```toml
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+```
+
+This ensures that `cargo` uses the correct linker when building for those targets.
+
+---
+
+**Linux:**
+
+```sh
+sudo apt-get update && sudo apt-get install -y protobuf-compiler musl-tools
+rustup install stable
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+```
+
+**2. Enable Local Rust Builds with Tilt**
+
+```sh
+BUILD_RUST_LOCALLY=true tilt up
+```
+
 
 ## Build
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -52,23 +52,87 @@ local_resource(
   ]
 )
 
-docker_build_with_restart(
-  'kubetail-cluster-agent',
-  dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent',
-  context='.',
-  entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
-  only=[
-    './crates/rgkl',
-    './proto',
-    './.tilt/cluster-agent'
-  ],
-  ignore=[
-    './crates/rgkl/target'
-  ],
-  live_update=[
-    sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
-  ]
-)
+build_rust_locally = os.getenv("BUILD_RUST_LOCALLY", default='false').lower() == 'true'
+if build_rust_locally:
+  local_resource(
+    "kubetail-rgkl",
+    '''
+    set -eu
+
+    cd crates/rgkl
+
+    # ---------- Determine Target Architecture ----------
+    arch=$(uname -m)
+    case "$arch" in
+      x86_64|amd64) target_arch="x86_64" ;;
+      arm64|aarch64) target_arch="aarch64" ;;
+      *) echo "Unsupported arch: $arch"; exit 1 ;;
+    esac
+    target="${target_arch}-unknown-linux-musl"
+    export CARGO_TARGET_DIR="target/.tilt"
+
+    # ---------- Ensure musl Target is Installed ----------
+    if ! rustup target list | grep -q "${target} (installed)"; then
+      echo "📦 Installing Rust target ${target}"
+      rustup target add "${target}"
+    fi
+
+    # ---------- Build Static Binary ----------
+    echo "🔨 cargo build --target=${target}"
+    cargo build --target "${target}"
+
+    bin_path="${CARGO_TARGET_DIR}/${target}/release/rgkl"
+    out_dir="../../.tilt"
+
+    # ---------- Package Static Binary ----------
+    mkdir -p "$out_dir"
+    install -Dm755 "$bin_path" "$out_dir"
+    echo "✅ Static binary packaged in $out_dir"
+    ''',
+    deps=[
+      "./crates/rgkl/src",
+      "./crates/rgkl/Cargo.toml",
+      "./crates/rgkl/Cargo.lock",
+      "./proto",
+    ],
+  )
+
+  docker_build_with_restart(
+    'kubetail-cluster-agent',
+    dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent-local',
+    context='.',
+    entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
+    only=[
+      './proto',
+      './.tilt/cluster-agent',
+      './.tilt/rgkl',
+    ],
+    live_update=[
+      sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
+      sync(
+        './.tilt/rgkl',
+        '/usr/local/bin/rgkl',
+      ),
+    ]
+  )
+else:
+  docker_build_with_restart(
+    'kubetail-cluster-agent',
+    dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent',
+    context='.',
+    entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
+    only=[
+      './crates/rgkl',
+      './proto',
+      './.tilt/cluster-agent'
+    ],
+    ignore=[
+      './crates/rgkl/target'
+    ],
+    live_update=[
+      sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
+    ]
+  )
 
 # kubetail-dashboard
 

--- a/build/package/Dockerfile.cluster-agent
+++ b/build/package/Dockerfile.cluster-agent
@@ -17,7 +17,7 @@ FROM rust:1.86.0 AS rustbuilder
 WORKDIR /work
 
 # System dependencies
-RUN apt-get update && apt-get install -yq patchelf protobuf-compiler
+RUN apt-get update && apt-get install -yq protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -28,28 +28,12 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Build
-RUN cd crates/rgkl && cargo build --release
-
-# Make bundle
-RUN \
-    ARCH="$(uname -m)" && \
-    if [ "$ARCH" = "x86_64" ]; then \
-      LIBC_PATH="/lib/x86_64-linux-gnu"; \
-      LINKER_PATH="/lib64/ld-linux-x86-64.so.2"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-      LIBC_PATH="/lib/aarch64-linux-gnu"; \
-      LINKER_PATH="/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"; \
-    else \
-      echo "Unsupported architecture: $ARCH"; exit 1; \
-    fi && \
-    mkdir -p /out/lib && \
-    cp -v /work/crates/rgkl/target/release/rgkl /out/rgkl && \
-    cp -v $LIBC_PATH/libc.so.6 /out/lib/ && \
-    cp -v $LIBC_PATH/libgcc_s.so.1 /out/lib/ && \
-    cp -v $LINKER_PATH /out/lib/ld-linux.so
-
-RUN patchelf --set-rpath "\$ORIGIN/lib" /out/rgkl
+# Build with dynamic linking against glibc
+RUN cd crates/rgkl && \
+    RUSTFLAGS="-C target-feature=-crt-static" \
+    cargo build --release && \
+    mkdir -p /out && \
+    cp target/release/rgkl /out/rgkl
 
 # -----------------------------------------------------------
 
@@ -74,12 +58,20 @@ RUN cd cluster-agent && go build -ldflags="-s -w" -o ../bin/cluster-agent ./cmd/
 
 # -----------------------------------------------------------
 
-FROM scratch AS final
+FROM debian:bookworm-slim AS final
 
-WORKDIR /cluster-agent
+WORKDIR /app
 
-COPY --from=rustbuilder /out /rgkl
-COPY --from=gobuilder /work/bin/cluster-agent .
+# Install required runtime dependencies for glibc binaries (if not already present)
+RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy binaries
+COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
+COPY --from=gobuilder /work/bin/cluster-agent ./cluster-agent
+
+# Set PATH to include /usr/local/bin
+ENV PATH="/usr/local/bin:${PATH}"
 
 ENTRYPOINT ["./cluster-agent"]
 CMD []

--- a/crates/rgkl/.cargo/config.toml
+++ b/crates/rgkl/.cargo/config.toml
@@ -1,0 +1,4 @@
+[profile.dev]
+incremental = true
+debug = true
+opt-level = 1

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -2,8 +2,7 @@ FROM rust:1.84.1 AS rustbuilder
 
 WORKDIR /work
 
-RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
-RUN apt-get update && apt-get install -yq musl-tools protobuf-compiler
+RUN apt-get update && apt-get install -yq protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -17,22 +16,27 @@ COPY . .
 # Detect architecture and build statically
 RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
-      TARGET="x86_64-unknown-linux-musl"; \
+      TARGET="x86_64-unknown-linux-gnu"; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      TARGET="aarch64-unknown-linux-musl"; \
+      TARGET="aarch64-unknown-linux-gnu"; \
     else \
       echo "Unsupported architecture: $ARCH"; exit 1; \
     fi && \
     cd crates/rgkl && \
+    RUSTFLAGS="-C target-feature=-crt-static" \
     cargo build --target=$TARGET && \
     mkdir -p /out && \
     cp target/$TARGET/debug/rgkl /out/rgkl
 
 # -----------------------------------------------------------
 
-FROM alpine:3.20.0
+FROM debian:bookworm-slim AS final
 
 WORKDIR /cluster-agent
+
+# Install required runtime dependencies for glibc binaries (if not already present)
+RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
 COPY .tilt/cluster-agent .

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -2,8 +2,8 @@ FROM rust:1.84.1 AS rustbuilder
 
 WORKDIR /work
 
-# System dependencies
-RUN apt-get update && apt-get install -yq patchelf protobuf-compiler
+RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+RUN apt-get update && apt-get install -yq musl-tools protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -14,28 +14,19 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Build
-RUN cd crates/rgkl && cargo build --release
-
-# Make bundle
-RUN \
-    ARCH="$(uname -m)" && \
+# Detect architecture and build statically
+RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
-      LIBC_PATH="/lib/x86_64-linux-gnu"; \
-      LINKER_PATH="/lib64/ld-linux-x86-64.so.2"; \
+      TARGET="x86_64-unknown-linux-musl"; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      LIBC_PATH="/lib/aarch64-linux-gnu"; \
-      LINKER_PATH="/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"; \
+      TARGET="aarch64-unknown-linux-musl"; \
     else \
       echo "Unsupported architecture: $ARCH"; exit 1; \
     fi && \
-    mkdir -p /out/lib && \
-    cp -v /work/crates/rgkl/target/release/rgkl /out/rgkl && \
-    cp -v $LIBC_PATH/libc.so.6 /out/lib/ && \
-    cp -v $LIBC_PATH/libgcc_s.so.1 /out/lib/ && \
-    cp -v $LINKER_PATH /out/lib/ld-linux.so
-
-RUN patchelf --set-rpath "\$ORIGIN/lib" /out/rgkl
+    cd crates/rgkl && \
+    cargo build --target=$TARGET && \
+    mkdir -p /out && \
+    cp target/$TARGET/debug/rgkl /out/rgkl
 
 # -----------------------------------------------------------
 
@@ -43,10 +34,7 @@ FROM alpine:3.20.0
 
 WORKDIR /cluster-agent
 
-RUN apk add libc6-compat
-
-COPY --from=rustbuilder /out /rgkl
+COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
 COPY .tilt/cluster-agent .
 
 ENTRYPOINT ["./cluster-agent"]
-CMD []

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent-local
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent-local
@@ -1,0 +1,6 @@
+FROM busybox
+
+COPY .tilt/cluster-agent /cluster-agent/
+COPY .tilt/rgkl /usr/local/bin/rgkl
+
+ENTRYPOINT ["/cluster-agent/cluster-agent", "-c", "/etc/kubetail/config.yaml"]

--- a/modules/cluster-agent/internal/services/logrecords/logrecords.go
+++ b/modules/cluster-agent/internal/services/logrecords/logrecords.go
@@ -80,7 +80,6 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 	}
 
 	args := []string{
-		"/rgkl/rgkl",
 		"stream-forward", pathname,
 		"--grep", req.Grep,
 		"--follow-from", strings.ToLower(req.FollowFrom.String()),
@@ -94,7 +93,7 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "/rgkl/lib/ld-linux.so", args...)
+	cmd := exec.CommandContext(ctx, "rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()
@@ -202,7 +201,6 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 	}
 
 	args := []string{
-		"/rgkl/rgkl",
 		"stream-backward", pathname,
 		"--grep", req.Grep,
 	}
@@ -215,7 +213,7 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "/rgkl/lib/ld-linux.so", args...)
+	cmd := exec.CommandContext(ctx, "rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Changes
1. Define rgkl build step as a local resource in the Tiltfile
2. Build in debug mode instead of release mode

## Results
### Pre-Change
#### Build-time (`cluster-agent` )
- ~60s on first build
- ~5s on subsequent builds (pulls cached binary)

#### Update time
- ~60s on full re-compile
- ~5s for source files that were cached (ie reverting a change to a previous state of the source file)

### Post Change (local build + debug mode)

#### Build-time
- `build-rgkl`
    - ~30s on first build
    - <1s on subsequent builds (pulls cached binary)
- `cluster-agent` (runs after `build-rgkl` )
    - ~4s always (Go build)

#### Update time
- `build-rgkl`
    - ~30s on full initial build
    - ~3s on code updates
- `cluster-agent` (runs after `build-rgkl` )
    - ~4s regardless

## Concerns
This does bring in a few more dependencies into setting up the dev environment. Namely, the user now needs to install a **protobuf compiler** and **cross-compilation tools targeting amd64** to their local machine. My apprehension is that, for someone not interested in developing the Rust sub-component, these dependencies will be irrelevant bloat to their system and extra headache that they don't really care about.

To address this, we can potentially set this up as an opt-in configuration of the dev-env, for people specifically developing the Rust code. Would be interested in approaches on how to achieve this.

## Further Improvements
Adding support for **sccache** can increase iteration speed even further, however I haven't been able to get it running locally (I think they might not support my WSL). I intend to re-visit this down the line as part of potentially another PR.