### PR TITLE
[bugfix] rgkl - resolve bug where signal await thread joins too early, breaking search

### DIFF
--- a/crates/rgkl/src/main.rs
+++ b/crates/rgkl/src/main.rs
@@ -84,9 +84,8 @@ fn main() -> ExitCode {
     match Signals::new([SIGINT, SIGTERM]) {
         Ok(mut signals) => {
             thread::spawn(move || {
-                if signals.forever().next().is_some() {
-                    drop(term_tx);
-                }
+                let _ = signals.wait().next();
+                drop(term_tx);
             });
         }
         Err(err) => {


### PR DESCRIPTION
Quick bugfix to the search feature.

The following piece of code: is non-blocking:
```rust
if signals.forever().next().is_some() {
    drop(term_tx);
}
```
`signals.forever().next().is_some()` instead of blocking the thread (as I had initially thought) instead promptly returns a boolean, causing the program to fall through and break the search functionality.

The correct approach is to use `wait()` here as it [blocks the thread until a signal is received](https://docs.rs/signal-hook/latest/signal_hook/iterator/struct.SignalsInfo.html#method.wait), after which `term_tx` is dropped.