### PR TITLE
Expose multiple pod containers in logging console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ lerna-debug.log*
 !/modules/dashboard/website/
 !/modules/dashboard/website/.gitkeep
 
+# pnpm
+.pnpm-store
+
 # vite
 .vite
 

--- a/dashboard-ui/src/pages/home.tsx
+++ b/dashboard-ui/src/pages/home.tsx
@@ -557,7 +557,7 @@ const DisplayItems = ({
 
         <DataTable.Body className="rounded-tbody">
           {visibleItems?.map((item) => {
-            const sourceString = `${item.metadata.namespace}:${workload}/${item.metadata.name}`;
+            const sourceString = `${item.metadata.namespace}:${workload}/${item.metadata.name}/*`;
             const fileInfo = logFileInfo.get(item.metadata.uid);
 
             // for last event

--- a/hack/tilt/multi-container.yaml
+++ b/hack/tilt/multi-container.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-container
+  namespace: default
+  labels:
+    app.kubernetes.io/name: multi-container
+    app.kubernetes.io/instance: kubetail-dev
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: multi-container
+      app.kubernetes.io/instance: kubetail-dev
+  replicas: 3
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: multi-container
+        app.kubernetes.io/instance: kubetail-dev
+    spec:
+      containers:
+      - name: loggen
+        image: docker.io/kubetail/loggen:0.1.2
+        resources: {}
+      - name: loggen-ansi
+        image: docker.io/kubetail/loggen:0.1.2
+        args: ["-ansi"]
+        resources: {}


### PR DESCRIPTION
* Change behavior in logging console to show logs from all pod containers by default
* Fix UI bug where pod with multiple containers was being listed multiple times in sidebar

Fixes https://github.com/kubetail-org/kubetail/issues/271
