### PR TITLE
Fix issue parsing "statefulsets" in source strings

### DIFF
--- a/hack/tilt/statefulset-example.yaml
+++ b/hack/tilt/statefulset-example.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: statefulset-example
+  namespace: default
+  labels:
+    app.kubernetes.io/name: statefulset-example
+    app.kubernetes.io/instance: kubetail-dev
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-example
+  namespace: default
+  labels:
+    app.kubernetes.io/name: statefulset-example
+    app.kubernetes.io/instance: kubetail-dev
+spec:
+  serviceName: statefulset-example
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: statefulset-example
+      app.kubernetes.io/instance: kubetail-dev
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: statefulset-example
+        app.kubernetes.io/instance: kubetail-dev
+    spec:
+      containers:
+      - name: loggen
+        image: docker.io/kubetail/loggen:0.1.2
+        resources: {}

--- a/modules/shared/logs/helpers.go
+++ b/modules/shared/logs/helpers.go
@@ -117,7 +117,7 @@ func (w WorkloadType) Key(args ...string) string {
 
 // Parse string and return corresponding workload
 func parseWorkloadType(workloadStr string) WorkloadType {
-	switch strings.Trim(strings.ToLower(workloadStr), "s") {
+	switch strings.TrimRight(strings.ToLower(workloadStr), "s") {
 	case "cronjob":
 		return WorkloadTypeCronJob
 	case "daemonset":

--- a/modules/shared/logs/helpers_test.go
+++ b/modules/shared/logs/helpers_test.go
@@ -321,3 +321,59 @@ func TestNewLogRecordFromLogLine(t *testing.T) {
 		})
 	}
 }
+
+func TestParseWorkloadType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected WorkloadType
+	}{
+		// Test exact matches
+		{name: "cronjob", input: "cronjob", expected: WorkloadTypeCronJob},
+		{name: "daemonset", input: "daemonset", expected: WorkloadTypeDaemonSet},
+		{name: "deployment", input: "deployment", expected: WorkloadTypeDeployment},
+		{name: "job", input: "job", expected: WorkloadTypeJob},
+		{name: "pod", input: "pod", expected: WorkloadTypePod},
+		{name: "replicaset", input: "replicaset", expected: WorkloadTypeReplicaSet},
+		{name: "statefulset", input: "statefulset", expected: WorkloadTypeStatefulSet},
+
+		// Test with trailing 's'
+		{name: "cronjobs", input: "cronjobs", expected: WorkloadTypeCronJob},
+		{name: "daemonsets", input: "daemonsets", expected: WorkloadTypeDaemonSet},
+		{name: "deployments", input: "deployments", expected: WorkloadTypeDeployment},
+		{name: "jobs", input: "jobs", expected: WorkloadTypeJob},
+		{name: "pods", input: "pods", expected: WorkloadTypePod},
+		{name: "replicasets", input: "replicasets", expected: WorkloadTypeReplicaSet},
+		{name: "statefulsets", input: "statefulsets", expected: WorkloadTypeStatefulSet},
+
+		// Test with mixed case
+		{name: "CronJob", input: "CronJob", expected: WorkloadTypeCronJob},
+		{name: "DaemonSet", input: "DaemonSet", expected: WorkloadTypeDaemonSet},
+		{name: "Deployment", input: "Deployment", expected: WorkloadTypeDeployment},
+		{name: "Job", input: "Job", expected: WorkloadTypeJob},
+		{name: "Pod", input: "Pod", expected: WorkloadTypePod},
+		{name: "ReplicaSet", input: "ReplicaSet", expected: WorkloadTypeReplicaSet},
+		{name: "StatefulSet", input: "StatefulSet", expected: WorkloadTypeStatefulSet},
+
+		// Test with mixed case and trailing 's'
+		{name: "CronJobs", input: "CronJobs", expected: WorkloadTypeCronJob},
+		{name: "DaemonSets", input: "DaemonSets", expected: WorkloadTypeDaemonSet},
+		{name: "Deployments", input: "Deployments", expected: WorkloadTypeDeployment},
+		{name: "Jobs", input: "Jobs", expected: WorkloadTypeJob},
+		{name: "Pods", input: "Pods", expected: WorkloadTypePod},
+		{name: "ReplicaSets", input: "ReplicaSets", expected: WorkloadTypeReplicaSet},
+		{name: "StatefulSets", input: "StatefulSets", expected: WorkloadTypeStatefulSet},
+
+		// Test unknown workload types
+		{name: "unknown", input: "unknown", expected: WorkloadTypeUknown},
+		{name: "empty string", input: "", expected: WorkloadTypeUknown},
+		{name: "random string", input: "randomstring", expected: WorkloadTypeUknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseWorkloadType(tt.input)
+			assert.Equal(t, tt.expected, result, "parseWorkloadType(%q) should return %v", tt.input, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
* Fix issue parsing "statefulsets" in source strings due to use of .Trim() instead of .TrimRight() to remove trailing "s"
* Add unit tests for parseWorkload() helper function

Fixes https://github.com/kubetail-org/kubetail/issues/273
