### PR TITLE
new: implement kubeconfig flag as global to CLI

### DIFF
--- a/modules/cli/cmd/cluster_install.go
+++ b/modules/cli/cmd/cluster_install.go
@@ -40,14 +40,14 @@ var clusterInstallCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
 		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
-		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Install
 		release, err := client.InstallLatest(namespace, name)
@@ -65,7 +65,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterInstallCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
+	flagset.String(KubeContextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Release name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/cluster_install.go
+++ b/modules/cli/cmd/cluster_install.go
@@ -39,15 +39,15 @@ var clusterInstallCmd = &cobra.Command{
 	Long:  clusterInstallHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		kubeContext, _ := cmd.Flags().GetString("kube-context")
+		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client, err := helm.NewClient(kubeContext)
-		cli.ExitOnError(err)
+		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Install
 		release, err := client.InstallLatest(namespace, name)
@@ -65,7 +65,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterInstallCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String("kube-context", "", "Name of the kubeconfig context to use")
+	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Release name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/cluster_list.go
+++ b/modules/cli/cmd/cluster_list.go
@@ -38,10 +38,10 @@ var clusterListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
 		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
-		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 
 		// Init client
-		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Get releases
 		releases, err := client.ListReleases()
@@ -72,5 +72,5 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterListCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
+	flagset.String(KubeContextFlag, "", "Name of the kubeconfig context to use")
 }

--- a/modules/cli/cmd/cluster_list.go
+++ b/modules/cli/cmd/cluster_list.go
@@ -37,11 +37,11 @@ var clusterListCmd = &cobra.Command{
 	Long:  clusterListHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		kubeContext, _ := cmd.Flags().GetString("kube-context")
+		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
 
 		// Init client
-		client, err := helm.NewClient(kubeContext)
-		cli.ExitOnError(err)
+		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Get releases
 		releases, err := client.ListReleases()
@@ -72,5 +72,5 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterListCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String("kube-context", "", "Name of the kubeconfig context to use")
+	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
 }

--- a/modules/cli/cmd/cluster_repo_add.go
+++ b/modules/cli/cmd/cluster_repo_add.go
@@ -35,11 +35,10 @@ var clusterRepoAddCmd = &cobra.Command{
 	Long:  clusterRepoAddHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Init client
-		client, err := helm.NewClient("")
-		cli.ExitOnError(err)
+		client := helm.NewClient()
 
 		// Update repo
-		err = client.AddRepo()
+		err := client.AddRepo()
 		cli.ExitOnError(err)
 
 		fmt.Println("Added repository 'kubetail'")

--- a/modules/cli/cmd/cluster_repo_remove.go
+++ b/modules/cli/cmd/cluster_repo_remove.go
@@ -35,11 +35,10 @@ var clusterRepoRemoveCmd = &cobra.Command{
 	Long:  clusterRepoRemoveHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Init client
-		client, err := helm.NewClient("")
-		cli.ExitOnError(err)
+		client := helm.NewClient()
 
 		// Update repo
-		err = client.RemoveRepo()
+		err := client.RemoveRepo()
 		cli.ExitOnError(err)
 
 		fmt.Println("Removed repository 'kubetail'")

--- a/modules/cli/cmd/cluster_repo_update.go
+++ b/modules/cli/cmd/cluster_repo_update.go
@@ -35,11 +35,10 @@ var clusterRepoUpdateCmd = &cobra.Command{
 	Long:  clusterRepoUpdateHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Init client
-		client, err := helm.NewClient("")
-		cli.ExitOnError(err)
+		client := helm.NewClient()
 
 		// Update repo
-		err = client.UpdateRepo()
+		err := client.UpdateRepo()
 		cli.ExitOnError(err)
 
 		fmt.Println("Updated repository 'kubetail'")

--- a/modules/cli/cmd/cluster_uninstall.go
+++ b/modules/cli/cmd/cluster_uninstall.go
@@ -36,14 +36,14 @@ var clusterUninstallCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
 		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
-		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Uninstall
 		response, err := client.UninstallRelease(namespace, name)
@@ -61,7 +61,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterUninstallCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
+	flagset.String(KubeContextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Release name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/cluster_uninstall.go
+++ b/modules/cli/cmd/cluster_uninstall.go
@@ -35,15 +35,15 @@ var clusterUninstallCmd = &cobra.Command{
 	Long:  clusterUninstallHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		kubeContext, _ := cmd.Flags().GetString("kube-context")
+		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client, err := helm.NewClient(kubeContext)
-		cli.ExitOnError(err)
+		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Uninstall
 		response, err := client.UninstallRelease(namespace, name)
@@ -61,7 +61,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterUninstallCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String("kube-context", "", "Name of the kubeconfig context to use")
+	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Release name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/cluster_upgrade.go
+++ b/modules/cli/cmd/cluster_upgrade.go
@@ -35,15 +35,15 @@ var clusterUpgradeCmd = &cobra.Command{
 	Long:  clusterUpgradeHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		kubeContext, _ := cmd.Flags().GetString("kube-context")
+		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client, err := helm.NewClient(kubeContext)
-		cli.ExitOnError(err)
+		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Upgrade
 		release, err := client.UpgradeRelease(namespace, name)
@@ -61,7 +61,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterUpgradeCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String("kube-context", "", "Name of the kubeconfig context to use")
+	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Relase name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/cluster_upgrade.go
+++ b/modules/cli/cmd/cluster_upgrade.go
@@ -36,14 +36,14 @@ var clusterUpgradeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
 		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
-		kubeContext, _ := cmd.Flags().GetString(KubecontextFlag)
+		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
 		name := helm.DefaultReleaseName
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
 
 		// Upgrade
 		release, err := client.UpgradeRelease(namespace, name)
@@ -61,7 +61,7 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := clusterUpgradeCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String(KubecontextFlag, "", "Name of the kubeconfig context to use")
+	flagset.String(KubeContextFlag, "", "Name of the kubeconfig context to use")
 	//flagset.String("name", helm.DefaultReleaseName, "Relase name")
 	//flagset.StringP("namespace", "n", helm.DefaultNamespace, "Namespace to install into")
 }

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -192,7 +192,7 @@ var logsCmd = &cobra.Command{
 		// Get flags
 		flags := cmd.Flags()
 
-		kubeContext, _ := flags.GetString(KubecontextFlag)
+		kubeContext, _ := flags.GetString(KubeContextFlag)
 		kubeconfigPath, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
@@ -522,7 +522,7 @@ func init() {
 	flagset := logsCmd.Flags()
 	flagset.SortFlags = false
 
-	flagset.String(KubecontextFlag, "", "Specify the kubeconfig context to use")
+	flagset.String(KubeContextFlag, "", "Specify the kubeconfig context to use")
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"
 	flagset.Int64P("tail", "t", 10, "Return last N records")

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sosodev/duration"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
@@ -193,7 +192,7 @@ var logsCmd = &cobra.Command{
 		// Get flags
 		flags := cmd.Flags()
 
-		kubeContext, _ := flags.GetString("kube-context")
+		kubeContext, _ := flags.GetString(KubecontextFlag)
 		kubeconfigPath, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
@@ -523,8 +522,7 @@ func init() {
 	flagset := logsCmd.Flags()
 	flagset.SortFlags = false
 
-	flagset.String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
-	flagset.String("kube-context", "", "Specify the kubeconfig context to use")
+	flagset.String(KubecontextFlag, "", "Specify the kubeconfig context to use")
 	flagset.Int64P("head", "h", 10, "Return first N records")
 	flagset.Lookup("head").NoOptDefVal = "10"
 	flagset.Int64P("tail", "t", 10, "Return last N records")

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	KubeconfigFlag = clientcmd.RecommendedConfigPathFlag
+	KubeconfigFlag  = clientcmd.RecommendedConfigPathFlag
+	KubecontextFlag = "kube-context"
 )
 
 var version = "dev" // default version for local builds
@@ -49,7 +50,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
-	// rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
+	rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	KubeconfigFlag  = clientcmd.RecommendedConfigPathFlag
-	KubecontextFlag = "kube-context"
+	KubeContextFlag = "kube-context"
 )
 
 var version = "dev" // default version for local builds

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -34,7 +34,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	k8sruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/app"
@@ -269,7 +268,6 @@ func init() {
 	// serveCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	flagset := serveCmd.Flags()
 	flagset.SortFlags = false
-	flagset.String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
 	flagset.IntP("port", "p", 7500, "Port number to listen on")
 	flagset.String("host", "localhost", "Host address to bind to")
 	flagset.StringP("log-level", "l", "info", "Log level (debug, info, warn, error, disabled)")

--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -130,10 +130,7 @@ func (r *mutationResolver) HelmInstallLatest(ctx context.Context, kubeContextPtr
 	}
 
 	// Init client
-	client, err := helm.NewClient(kubeContext)
-	if err != nil {
-		return nil, err
-	}
+	client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
 
 	// Install
 	release, err := client.InstallLatest(helm.DefaultNamespace, helm.DefaultReleaseName)
@@ -534,10 +531,7 @@ func (r *queryResolver) HelmListReleases(ctx context.Context, kubeContextPtr *st
 	kubeContext := r.cm.DerefKubeContext(kubeContextPtr)
 
 	// Init client
-	client, err := helm.NewClient(kubeContext)
-	if err != nil {
-		return nil, err
-	}
+	client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
 
 	// Get list
 	releases, err := client.ListReleases()

--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -130,7 +130,7 @@ func (r *mutationResolver) HelmInstallLatest(ctx context.Context, kubeContextPtr
 	}
 
 	// Init client
-	client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
+	client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
 
 	// Install
 	release, err := client.InstallLatest(helm.DefaultNamespace, helm.DefaultReleaseName)
@@ -531,7 +531,7 @@ func (r *queryResolver) HelmListReleases(ctx context.Context, kubeContextPtr *st
 	kubeContext := r.cm.DerefKubeContext(kubeContextPtr)
 
 	// Init client
-	client := helm.NewClient(helm.WithKubecontext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
+	client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(r.config.KubeconfigPath))
 
 	// Get list
 	releases, err := client.ListReleases()

--- a/modules/shared/helm/helm.go
+++ b/modules/shared/helm/helm.go
@@ -50,7 +50,7 @@ func noopLogger(format string, v ...interface{}) {}
 
 // Client
 type Client struct {
-	settings *cli.EnvSettings
+	*cli.EnvSettings
 }
 
 // InstallLatest creates a new release from the latest chart
@@ -203,7 +203,7 @@ func (c *Client) AddRepo() error {
 		return err
 	}
 
-	repoFile := c.settings.RepositoryConfig
+	repoFile := c.RepositoryConfig
 
 	// Load the Helm repository file
 	repoFileContent, err := repo.LoadFile(repoFile)
@@ -225,11 +225,11 @@ func (c *Client) AddRepo() error {
 	}
 
 	// Initialize the new repository
-	chartRepo, err := repo.NewChartRepository(newEntry, getter.All(c.settings))
+	chartRepo, err := repo.NewChartRepository(newEntry, getter.All(c.EnvSettings))
 	if err != nil {
 		return fmt.Errorf("failed to initialize chart repository: %w", err)
 	}
-	chartRepo.CachePath = c.settings.RepositoryCache
+	chartRepo.CachePath = c.RepositoryCache
 
 	// Download the repository index to verify it’s accessible
 	if _, err := chartRepo.DownloadIndexFile(); err != nil {
@@ -247,7 +247,7 @@ func (c *Client) AddRepo() error {
 
 // UpdateRepo updates the repository
 func (c *Client) UpdateRepo() error {
-	repoFile := c.settings.RepositoryConfig
+	repoFile := c.RepositoryConfig
 
 	// Read the repository file
 	repoFileContent, err := repo.LoadFile(repoFile)
@@ -269,11 +269,11 @@ func (c *Client) UpdateRepo() error {
 	}
 
 	// Set up the repository chart
-	chartRepo, err := repo.NewChartRepository(entry, getter.All(c.settings))
+	chartRepo, err := repo.NewChartRepository(entry, getter.All(c.EnvSettings))
 	if err != nil {
 		return fmt.Errorf("failed to initialize chart repository: %w", err)
 	}
-	chartRepo.CachePath = c.settings.RepositoryCache
+	chartRepo.CachePath = c.RepositoryCache
 
 	// Download the latest index file for the repository
 	if _, err := chartRepo.DownloadIndexFile(); err != nil {
@@ -285,7 +285,7 @@ func (c *Client) UpdateRepo() error {
 
 // RemoveRepo removes the repository
 func (c *Client) RemoveRepo() error {
-	repoFile := c.settings.RepositoryConfig
+	repoFile := c.RepositoryConfig
 
 	// Load the Helm repository file
 	repoFileContent, err := repo.LoadFile(repoFile)
@@ -326,7 +326,7 @@ func (c *Client) RemoveRepo() error {
 // newActionConfig
 func (c *Client) newActionConfig(namespace string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(c.settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER"), noopLogger); err != nil {
+	if err := actionConfig.Init(c.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER"), noopLogger); err != nil {
 		return nil, fmt.Errorf("failed to initialize Helm action configuration: %v", err)
 	}
 	return actionConfig, nil
@@ -334,7 +334,7 @@ func (c *Client) newActionConfig(namespace string) (*action.Configuration, error
 
 // ensureEnv ensures helm environment is up
 func (c *Client) ensureEnv() error {
-	repoFile := c.settings.RepositoryConfig
+	repoFile := c.RepositoryConfig
 
 	// Check if the repositories.yaml file exists
 	if _, err := os.Stat(repoFile); os.IsNotExist(err) {
@@ -364,7 +364,7 @@ func (c *Client) ensureEnv() error {
 func (c *Client) getChart(pathOptions action.ChartPathOptions) (*chart.Chart, error) {
 	// Get the latest version of the chart
 	chartID := fmt.Sprintf("%s/%s", targetRepoName, targetChartName)
-	chartPath, err := pathOptions.LocateChart(chartID, c.settings)
+	chartPath, err := pathOptions.LocateChart(chartID, c.EnvSettings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate chart '%s': %w", chartID, err)
 	}
@@ -392,14 +392,14 @@ func NewClient(options ...ClientOption) *Client {
 // Option Kubeconfig
 func WithKubeconfig(kubeconfig string) ClientOption {
 	return func(c *Client) {
-		c.settings.KubeConfig = kubeconfig
+		c.KubeConfig = kubeconfig
 	}
 
 }
 
-// Option Kubecontext
-func WithKubecontext(kubeContext string) ClientOption {
+// Option KubeContext
+func WithKubeContext(kubeContext string) ClientOption {
 	return func(c *Client) {
-		c.settings.KubeContext = kubeContext
+		c.KubeContext = kubeContext
 	}
 }

--- a/modules/shared/helm/helm.go
+++ b/modules/shared/helm/helm.go
@@ -378,13 +378,28 @@ func (c *Client) getChart(pathOptions action.ChartPathOptions) (*chart.Chart, er
 	return chart, err
 }
 
-// Return new client
-func NewClient(kubeContext string) (*Client, error) {
-	settings := cli.New()
+type ClientOption func(c *Client)
 
-	if kubeContext != "" {
-		settings.KubeContext = kubeContext
+// Return new client
+func NewClient(options ...ClientOption) *Client {
+	c := &Client{cli.New()}
+	for _, option := range options {
+		option(c)
+	}
+	return c
+}
+
+// Option Kubeconfig
+func WithKubeconfig(kubeconfig string) ClientOption {
+	return func(c *Client) {
+		c.settings.KubeConfig = kubeconfig
 	}
 
-	return &Client{settings}, nil
+}
+
+// Option Kubecontext
+func WithKubecontext(kubeContext string) ClientOption {
+	return func(c *Client) {
+		c.settings.KubeContext = kubeContext
+	}
 }


### PR DESCRIPTION
## Summary

Pre-work: add `kubeconfig` flag as persistent/global to all kubetail CLI commands.

## Help wanted

shared helm.go is using `helm` cli which makes use of `*cli.EnvSettings`. This settings is used to define `kubeContext` from `--kube-context` flag. Is that the way `helm` makes use of the context? If so, I believe this _must be_ the same logic to give helm a kubeconfig.

Could you please double check @amorey 