### PR TITLE
🐋 Add option to dev environment to compile Rust code incrementally on host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,14 @@ It also contains the source code for the Kubetail Dashboard's frontend and the R
 
 ### Setting up the Development Environment
 
-#### Dependencies:
+#### Dependencies
 
 * [Tilt](https://tilt.dev/)
 * [Go](https://go.dev/)
 * [pnpm](https://pnpm.io/)
 * [ctlptl](https://github.com/tilt-dev/ctlptl) (optional)
 
+#### Next steps
 
 1. Create a Kubernetes Dev Cluster
 
@@ -223,28 +224,38 @@ pnpm dev
 
 Now access the dashboard at [http://localhost:5173](http://localhost:5173).
 
+### Optimize Environment for Rust Development (Optional)
 
----
+By default, the dev environment compiles "release" builds of the Rust components when you run run `tilt up`. If you want to iterate more quickly, you can have tilt compile the rust code locally using "debug" builds instead.
 
+#### Dependencies
 
-### (Optional) Fast Iteration for Rust Development
+* [rustup](https://rustup.rs)
+* [protobuf](https://protobuf.dev/installation/)
 
-If you want to iterate quickly on Rust components, you can build them locally instead of through the dev containers.
+Install the Rust target required for your architecture:
 
-**1. Install Rust and Required Targets**
+```console
+# x86_64
+rustup target add x86_64-unknown-linux-musl
 
-**macOS:**
-
-```sh
-brew install protobuf
-rustup install stable
-rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
-brew install FiloSottile/musl-cross/musl-cross
+# aarch64
+rustup target add aarch64-unknown-linux-musl
 ```
 
-Then add the following to `~/.cargo/config.toml`:
+Install tools required by Rust cross compiler:
 
-```toml
+```console
+# macOS (Homebrew)
+brew install FiloSottile/musl-cross/musl-cross
+
+# Linux (Ubuntu)
+apt-get install musl-tools
+```
+
+On macOS, add this to your `~/.cargo/config.toml` file:
+
+```
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
 
@@ -252,24 +263,13 @@ linker = "x86_64-linux-musl-gcc"
 linker = "aarch64-linux-musl-gcc"
 ```
 
-This ensures that `cargo` uses the correct linker when building for those targets.
+#### Next steps
 
----
+To use the local compiler, just run Tilt using using the `KUBETAIL_DEV_RUST_LOCAL` env flag:
 
-**Linux:**
-
-```sh
-sudo apt-get update && sudo apt-get install -y protobuf-compiler musl-tools
-rustup install stable
-rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+```console
+KUBETAIL_DEV_RUST_LOCAL=true tilt up
 ```
-
-**2. Enable Local Rust Builds with Tilt**
-
-```sh
-BUILD_RUST_LOCALLY=true tilt up
-```
-
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -184,13 +184,15 @@ It also contains the source code for the Kubetail Dashboard's frontend and the R
 
 ### Setting up the Development Environment
 
-Dependencies:
+#### Dependencies:
+
 * [Tilt](https://tilt.dev/)
 * [Go](https://go.dev/)
 * [pnpm](https://pnpm.io/)
 * [ctlptl](https://github.com/tilt-dev/ctlptl) (optional)
 
-1. Create a Kubernetes dev cluster:
+
+1. Create a Kubernetes Dev Cluster
 
 ```console
 ctlptl apply -f hack/ctlptl/minikube.yaml
@@ -219,7 +221,55 @@ pnpm install
 pnpm dev
 ```
 
-Now access the dashboard at [http://localhost:5173](http://localhost:5173). 
+Now access the dashboard at [http://localhost:5173](http://localhost:5173).
+
+
+---
+
+
+### (Optional) Fast Iteration for Rust Development
+
+If you want to iterate quickly on Rust components, you can build them locally instead of through the dev containers.
+
+**1. Install Rust and Required Targets**
+
+**macOS:**
+
+```sh
+brew install protobuf
+rustup install stable
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+brew install FiloSottile/musl-cross/musl-cross
+```
+
+Then add the following to `~/.cargo/config.toml`:
+
+```toml
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+```
+
+This ensures that `cargo` uses the correct linker when building for those targets.
+
+---
+
+**Linux:**
+
+```sh
+sudo apt-get update && sudo apt-get install -y protobuf-compiler musl-tools
+rustup install stable
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+```
+
+**2. Enable Local Rust Builds with Tilt**
+
+```sh
+BUILD_RUST_LOCALLY=true tilt up
+```
+
 
 ## Build
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -52,23 +52,87 @@ local_resource(
   ]
 )
 
-docker_build_with_restart(
-  'kubetail-cluster-agent',
-  dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent',
-  context='.',
-  entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
-  only=[
-    './crates/rgkl',
-    './proto',
-    './.tilt/cluster-agent'
-  ],
-  ignore=[
-    './crates/rgkl/target'
-  ],
-  live_update=[
-    sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
-  ]
-)
+build_rust_locally = os.getenv("BUILD_RUST_LOCALLY", default='false').lower() == 'true'
+if build_rust_locally:
+  local_resource(
+    "kubetail-rgkl",
+    '''
+    set -eu
+
+    cd crates/rgkl
+
+    # ---------- Determine Target Architecture ----------
+    arch=$(uname -m)
+    case "$arch" in
+      x86_64|amd64) target_arch="x86_64" ;;
+      arm64|aarch64) target_arch="aarch64" ;;
+      *) echo "Unsupported arch: $arch"; exit 1 ;;
+    esac
+    target="${target_arch}-unknown-linux-musl"
+    export CARGO_TARGET_DIR="target/.tilt"
+
+    # ---------- Ensure musl Target is Installed ----------
+    if ! rustup target list | grep -q "${target} (installed)"; then
+      echo "📦 Installing Rust target ${target}"
+      rustup target add "${target}"
+    fi
+
+    # ---------- Build Static Binary ----------
+    echo "🔨 cargo build --target=${target}"
+    cargo build --target "${target}"
+
+    bin_path="${CARGO_TARGET_DIR}/${target}/release/rgkl"
+    out_dir="../../.tilt"
+
+    # ---------- Package Static Binary ----------
+    mkdir -p "$out_dir"
+    install -Dm755 "$bin_path" "$out_dir"
+    echo "✅ Static binary packaged in $out_dir"
+    ''',
+    deps=[
+      "./crates/rgkl/src",
+      "./crates/rgkl/Cargo.toml",
+      "./crates/rgkl/Cargo.lock",
+      "./proto",
+    ],
+  )
+
+  docker_build_with_restart(
+    'kubetail-cluster-agent',
+    dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent-local',
+    context='.',
+    entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
+    only=[
+      './proto',
+      './.tilt/cluster-agent',
+      './.tilt/rgkl',
+    ],
+    live_update=[
+      sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
+      sync(
+        './.tilt/rgkl',
+        '/usr/local/bin/rgkl',
+      ),
+    ]
+  )
+else:
+  docker_build_with_restart(
+    'kubetail-cluster-agent',
+    dockerfile='hack/tilt/Dockerfile.kubetail-cluster-agent',
+    context='.',
+    entrypoint="/cluster-agent/cluster-agent -c /etc/kubetail/config.yaml",
+    only=[
+      './crates/rgkl',
+      './proto',
+      './.tilt/cluster-agent'
+    ],
+    ignore=[
+      './crates/rgkl/target'
+    ],
+    live_update=[
+      sync('./.tilt/cluster-agent', '/cluster-agent/cluster-agent'),
+    ]
+  )
 
 # kubetail-dashboard
 

--- a/build/package/Dockerfile.cluster-agent
+++ b/build/package/Dockerfile.cluster-agent
@@ -17,7 +17,7 @@ FROM rust:1.86.0 AS rustbuilder
 WORKDIR /work
 
 # System dependencies
-RUN apt-get update && apt-get install -yq patchelf protobuf-compiler
+RUN apt-get update && apt-get install -yq protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -28,28 +28,12 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Build
-RUN cd crates/rgkl && cargo build --release
-
-# Make bundle
-RUN \
-    ARCH="$(uname -m)" && \
-    if [ "$ARCH" = "x86_64" ]; then \
-      LIBC_PATH="/lib/x86_64-linux-gnu"; \
-      LINKER_PATH="/lib64/ld-linux-x86-64.so.2"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-      LIBC_PATH="/lib/aarch64-linux-gnu"; \
-      LINKER_PATH="/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"; \
-    else \
-      echo "Unsupported architecture: $ARCH"; exit 1; \
-    fi && \
-    mkdir -p /out/lib && \
-    cp -v /work/crates/rgkl/target/release/rgkl /out/rgkl && \
-    cp -v $LIBC_PATH/libc.so.6 /out/lib/ && \
-    cp -v $LIBC_PATH/libgcc_s.so.1 /out/lib/ && \
-    cp -v $LINKER_PATH /out/lib/ld-linux.so
-
-RUN patchelf --set-rpath "\$ORIGIN/lib" /out/rgkl
+# Build with dynamic linking against glibc
+RUN cd crates/rgkl && \
+    RUSTFLAGS="-C target-feature=-crt-static" \
+    cargo build --release && \
+    mkdir -p /out && \
+    cp target/release/rgkl /out/rgkl
 
 # -----------------------------------------------------------
 
@@ -74,12 +58,20 @@ RUN cd cluster-agent && go build -ldflags="-s -w" -o ../bin/cluster-agent ./cmd/
 
 # -----------------------------------------------------------
 
-FROM scratch AS final
+FROM debian:bookworm-slim AS final
 
-WORKDIR /cluster-agent
+WORKDIR /app
 
-COPY --from=rustbuilder /out /rgkl
-COPY --from=gobuilder /work/bin/cluster-agent .
+# Install required runtime dependencies for glibc binaries (if not already present)
+RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy binaries
+COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
+COPY --from=gobuilder /work/bin/cluster-agent ./cluster-agent
+
+# Set PATH to include /usr/local/bin
+ENV PATH="/usr/local/bin:${PATH}"
 
 ENTRYPOINT ["./cluster-agent"]
 CMD []

--- a/build/package/Dockerfile.cluster-agent
+++ b/build/package/Dockerfile.cluster-agent
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.86.0 AS rustbuilder
+FROM rust:1.86.0-slim AS rustbuilder
 
 WORKDIR /work
 
@@ -28,12 +28,28 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Build with dynamic linking against glibc
-RUN cd crates/rgkl && \
-    RUSTFLAGS="-C target-feature=-crt-static" \
-    cargo build --release && \
-    mkdir -p /out && \
-    cp target/release/rgkl /out/rgkl
+# Build
+RUN cd crates/rgkl && cargo build --release
+
+# Cross-platform trickery
+RUN \
+    ARCH="$(uname -m)" && \
+    if [ "$ARCH" = "x86_64" ]; then \
+      mkdir -p /lib/aarch64-linux-gnu; \
+      touch /lib/aarch64-linux-gnu/libgcc_s.so.1; \
+      touch /lib/aarch64-linux-gnu/libpthread.so.0; \
+      touch /lib/aarch64-linux-gnu/libdl.so.2; \
+      touch /lib/aarch64-linux-gnu/libc.so.6; \
+      touch /lib/ld-linux-aarch64.so.1; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+      mkdir -p /lib/x86_64-linux-gnu/; \
+      touch /lib/x86_64-linux-gnu/libgcc_s.so.1; \
+      touch /lib/x86_64-linux-gnu/libc.so.6; \
+      mkdir /lib64; \
+      touch /lib64/ld-linux-x86-64.so.2; \
+    else \
+      echo "Unsupported architecture: $ARCH"; exit 1; \
+    fi
 
 # -----------------------------------------------------------
 
@@ -58,20 +74,25 @@ RUN cd cluster-agent && go build -ldflags="-s -w" -o ../bin/cluster-agent ./cmd/
 
 # -----------------------------------------------------------
 
-FROM debian:bookworm-slim AS final
+FROM scratch AS final
 
-WORKDIR /app
+WORKDIR /cluster-agent
 
-# Install required runtime dependencies for glibc binaries (if not already present)
-RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
-    rm -rf /var/lib/apt/lists/*
+# copy glibc runtime libraries and dynamic loader (aarch64)
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libgcc_s.so.1 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libpthread.so.0 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libdl.so.2 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libc.so.6 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/ld-linux-aarch64.so.1 /lib/
 
-# Copy binaries
-COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
-COPY --from=gobuilder /work/bin/cluster-agent ./cluster-agent
+# copy glibc runtime libraries and dynamic loader (x86_64)
+COPY --from=rustbuilder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=rustbuilder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=rustbuilder /lib64/ld-linux-x86-64.so.2 /lib64/
 
-# Set PATH to include /usr/local/bin
-ENV PATH="/usr/local/bin:${PATH}"
+# copy executables
+COPY --from=rustbuilder /work/crates/rgkl/target/release/rgkl .
+COPY --from=gobuilder /work/bin/cluster-agent .
 
 ENTRYPOINT ["./cluster-agent"]
 CMD []

--- a/crates/rgkl/.cargo/config.toml
+++ b/crates/rgkl/.cargo/config.toml
@@ -1,0 +1,4 @@
+[profile.dev]
+incremental = true
+debug = true
+opt-level = 1

--- a/crates/rgkl/.cargo/config.toml
+++ b/crates/rgkl/.cargo/config.toml
@@ -1,4 +1,0 @@
-[profile.dev]
-incremental = true
-debug = true
-opt-level = 1

--- a/crates/rgkl/Cargo.toml
+++ b/crates/rgkl/Cargo.toml
@@ -41,6 +41,11 @@ version = "0.5.4"
 name = "rgkl"
 path = "src/main.rs"
 
+[profile.dev]
+incremental = true
+debug = true
+opt-level = 1
+
 [profile.release]
 opt-level = 3
 debug = "none"

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -1,8 +1,9 @@
-FROM rust:1.84.1 AS rustbuilder
+FROM rust:1.86.0-slim AS rustbuilder
 
 WORKDIR /work
 
-RUN apt-get update && apt-get install -yq protobuf-compiler
+# System dependencies
+RUN apt-get update && apt-get install -yq patchelf protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -13,32 +14,50 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Detect architecture and build statically
-RUN ARCH="$(uname -m)" && \
+# Build
+RUN cd crates/rgkl && cargo build --release
+
+# Cross-platform trickery
+RUN \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
-      TARGET="x86_64-unknown-linux-gnu"; \
+      mkdir -p /lib/aarch64-linux-gnu; \
+      touch /lib/aarch64-linux-gnu/libgcc_s.so.1; \
+      touch /lib/aarch64-linux-gnu/libpthread.so.0; \
+      touch /lib/aarch64-linux-gnu/libdl.so.2; \
+      touch /lib/aarch64-linux-gnu/libc.so.6; \
+      touch /lib/ld-linux-aarch64.so.1; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      TARGET="aarch64-unknown-linux-gnu"; \
+      mkdir -p /lib/x86_64-linux-gnu/; \
+      touch /lib/x86_64-linux-gnu/libgcc_s.so.1; \
+      touch /lib/x86_64-linux-gnu/libc.so.6; \
+      mkdir /lib64; \
+      touch /lib64/ld-linux-x86-64.so.2; \
     else \
       echo "Unsupported architecture: $ARCH"; exit 1; \
-    fi && \
-    cd crates/rgkl && \
-    RUSTFLAGS="-C target-feature=-crt-static" \
-    cargo build --target=$TARGET && \
-    mkdir -p /out && \
-    cp target/$TARGET/debug/rgkl /out/rgkl
+    fi
 
 # -----------------------------------------------------------
 
-FROM debian:bookworm-slim AS final
+FROM alpine:3.21.3
 
 WORKDIR /cluster-agent
 
-# Install required runtime dependencies for glibc binaries (if not already present)
-RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=rustbuilder /work/crates/rgkl/target/release/rgkl .
 
-COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
+# copy glibc runtime libraries and dynamic loader (aarch64)
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libgcc_s.so.1 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libpthread.so.0 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libdl.so.2 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/aarch64-linux-gnu/libc.so.6 /lib/aarch64-linux-gnu/
+COPY --from=rustbuilder /lib/ld-linux-aarch64.so.1 /lib/
+
+# copy glibc runtime libraries and dynamic loader (x86_64)
+COPY --from=rustbuilder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=rustbuilder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=rustbuilder /lib64/ld-linux-x86-64.so.2 /lib64/
+
 COPY .tilt/cluster-agent .
 
 ENTRYPOINT ["./cluster-agent"]
+CMD []

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -2,8 +2,7 @@ FROM rust:1.84.1 AS rustbuilder
 
 WORKDIR /work
 
-# System dependencies
-RUN apt-get update && apt-get install -yq patchelf protobuf-compiler
+RUN apt-get update && apt-get install -yq protobuf-compiler
 
 # Install Rust dependencies (for cache)
 COPY crates/rgkl/Cargo.toml ./crates/rgkl/Cargo.toml
@@ -14,39 +13,32 @@ RUN cd crates/rgkl && cargo fetch
 # Copy code
 COPY . .
 
-# Build
-RUN cd crates/rgkl && cargo build --release
-
-# Make bundle
-RUN \
-    ARCH="$(uname -m)" && \
+# Detect architecture and build statically
+RUN ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; then \
-      LIBC_PATH="/lib/x86_64-linux-gnu"; \
-      LINKER_PATH="/lib64/ld-linux-x86-64.so.2"; \
+      TARGET="x86_64-unknown-linux-gnu"; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      LIBC_PATH="/lib/aarch64-linux-gnu"; \
-      LINKER_PATH="/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"; \
+      TARGET="aarch64-unknown-linux-gnu"; \
     else \
       echo "Unsupported architecture: $ARCH"; exit 1; \
     fi && \
-    mkdir -p /out/lib && \
-    cp -v /work/crates/rgkl/target/release/rgkl /out/rgkl && \
-    cp -v $LIBC_PATH/libc.so.6 /out/lib/ && \
-    cp -v $LIBC_PATH/libgcc_s.so.1 /out/lib/ && \
-    cp -v $LINKER_PATH /out/lib/ld-linux.so
-
-RUN patchelf --set-rpath "\$ORIGIN/lib" /out/rgkl
+    cd crates/rgkl && \
+    RUSTFLAGS="-C target-feature=-crt-static" \
+    cargo build --target=$TARGET && \
+    mkdir -p /out && \
+    cp target/$TARGET/debug/rgkl /out/rgkl
 
 # -----------------------------------------------------------
 
-FROM alpine:3.20.0
+FROM debian:bookworm-slim AS final
 
 WORKDIR /cluster-agent
 
-RUN apk add libc6-compat
+# Install required runtime dependencies for glibc binaries (if not already present)
+RUN apt-get update && apt-get install -y --no-install-recommends libc6 && \
+    rm -rf /var/lib/apt/lists/*
 
-COPY --from=rustbuilder /out /rgkl
+COPY --from=rustbuilder /out/rgkl /usr/local/bin/rgkl
 COPY .tilt/cluster-agent .
 
 ENTRYPOINT ["./cluster-agent"]
-CMD []

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent-local
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent-local
@@ -1,6 +1,8 @@
-FROM busybox
+FROM alpine:3.21.3
 
-COPY .tilt/cluster-agent /cluster-agent/
-COPY .tilt/rgkl /usr/local/bin/rgkl
+WORKDIR /cluster-agent
 
-ENTRYPOINT ["/cluster-agent/cluster-agent", "-c", "/etc/kubetail/config.yaml"]
+COPY .tilt/cluster-agent .
+COPY .tilt/rgkl .
+
+ENTRYPOINT ["./cluster-agent", "-c", "/etc/kubetail/config.yaml"]

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent-local
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent-local
@@ -1,0 +1,6 @@
+FROM busybox
+
+COPY .tilt/cluster-agent /cluster-agent/
+COPY .tilt/rgkl /usr/local/bin/rgkl
+
+ENTRYPOINT ["/cluster-agent/cluster-agent", "-c", "/etc/kubetail/config.yaml"]

--- a/modules/cluster-agent/internal/services/logrecords/logrecords.go
+++ b/modules/cluster-agent/internal/services/logrecords/logrecords.go
@@ -80,7 +80,6 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 	}
 
 	args := []string{
-		"/rgkl/rgkl",
 		"stream-forward", pathname,
 		"--grep", req.Grep,
 		"--follow-from", strings.ToLower(req.FollowFrom.String()),
@@ -94,7 +93,7 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "/rgkl/lib/ld-linux.so", args...)
+	cmd := exec.CommandContext(ctx, "rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()
@@ -202,7 +201,6 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 	}
 
 	args := []string{
-		"/rgkl/rgkl",
 		"stream-backward", pathname,
 		"--grep", req.Grep,
 	}
@@ -215,7 +213,7 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "/rgkl/lib/ld-linux.so", args...)
+	cmd := exec.CommandContext(ctx, "rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()

--- a/modules/cluster-agent/internal/services/logrecords/logrecords.go
+++ b/modules/cluster-agent/internal/services/logrecords/logrecords.go
@@ -93,7 +93,7 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "rgkl", args...)
+	cmd := exec.CommandContext(ctx, "./rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()
@@ -213,7 +213,7 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 		args = append(args, "--stop-time", req.StopTime)
 	}
 
-	cmd := exec.CommandContext(ctx, "rgkl", args...)
+	cmd := exec.CommandContext(ctx, "./rgkl", args...)
 
 	// Get a pipe
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary

Added an optional flag to tilt up that allows use of local builds for rgkl as opposed to containerized builds, increasing initial compile time by about 2x (60s -> 30s) and subsequent compile-times by 30x (60s -> ~2s). This will hopefully provide a solid base for growth in and contribution to the Rust sub-component(s) of the project.

## Changes

- Modify dev and production cluster-agent docker images to copy executable binary and shared libraries so `rgkl` can be called without explicit call to linker 
- ⁠Use static compilation (musl) in local builds. This allows us to standardize on the executable itself. 
- ⁠⁠Call executable directly instead of using a loader in containerized builds (dev and prod). This change was required as loaders do not use musl and we have a single entrypoint (⁠ logrecords.go ⁠) in the system as a whole.
- ⁠Provide documentation on how to use this feature.

## Submitter checklist

- [x] Add the correct emoji to PR title
- [ ] Link the issue number to *Fixes #*
- [x] Explain the changes made
- [x] Sign the commit using for [DCO](https://github.com/apps/dco) 
- [x] Rebase branch to HEAD

---

Co-authored-by: Sinan Can Gulan @sinancang 