### PR TITLE
🎣 Improve pin-to-bottom behavior when tailing in logging console

### DIFF
--- a/dashboard-ui/src/lib/hooks.ts
+++ b/dashboard-ui/src/lib/hooks.ts
@@ -15,7 +15,7 @@
 import { useApolloClient, useQuery, useSubscription } from '@apollo/client';
 import type { TypedDocumentNode, OperationVariables, Unmasked, MaybeMasked } from '@apollo/client';
 import distinctColors from 'distinct-colors';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import appConfig from '@/app-config';
 import { getClusterAPIClient } from '@/apollo-client';
@@ -114,6 +114,49 @@ export function useRetryOnError() {
       }
     }, RETRY_TIMEOUT);
   };
+}
+
+/**
+ * Runs queued callbacks on the next reactive cycle
+ * (commit → paint), then clears the queue.
+ *
+ * @returns schedule – call with a callback to run next tick.
+ *
+ * Usage:
+ * const nextTick = useNextTick();
+ * nextTick(() => console.log('I run after the next render + paint'));
+ */
+
+export function useNextTick(): (fn: () => void) => void {
+  const queueRef = useRef<(() => void)[]>([]);
+
+  /** Enqueue a callback for the next tick */
+  const schedule = useCallback((fn: () => void) => {
+    queueRef.current.push(fn);
+  }, []);
+
+  // Flush the queue on every commit; actual execution is deferred
+  // to the next paint using requestAnimationFrame.
+  useEffect(() => {
+    if (queueRef.current.length === 0) return;
+
+    const id = requestAnimationFrame(() => {
+      const queued = queueRef.current.splice(0);
+      queued.forEach((cb) => {
+        try {
+          cb();
+        } catch (err) {
+          // Surface errors so they are not swallowed
+          setTimeout(() => { throw err; });
+        }
+      });
+    });
+
+    // If the component unmounts before RAF fires, cancel it.
+    return () => cancelAnimationFrame(id);
+  });
+
+  return schedule;
 }
 
 /**

--- a/dashboard-ui/src/lib/util.ts
+++ b/dashboard-ui/src/lib/util.ts
@@ -80,6 +80,37 @@ export class MapSet<K = string, T = string> extends Map<K, Set<T>> {
 }
 
 /**
+ * Go-like WaitGroup class
+ */
+
+export class WaitGroup {
+  private counter = 0;
+
+  /**
+   * Increment internal counter
+   */
+  add(n: number = 1): void {
+    if (n <= 0) throw new Error('must be positive');
+    this.counter += n;
+  }
+
+  /**
+   * Decrement the counter by 1
+   */
+  done(): void {
+    if (this.counter <= 0) throw new Error('done() called more times than add()');
+    this.counter -= 1;
+  }
+
+  /**
+   * Return true if wait group is empty
+   */
+  isEmpty(): boolean {
+    return this.counter === 0;
+  }
+}
+
+/**
  * Classname merger
  */
 


### PR DESCRIPTION
Fixes #268

## Summary

This PR fixes an issue with the pin-to-bottom tailing behavior in the logging console that was causing the logs to lose their "pin". The root cause was a race condition where sometimes the scroll update was being requested before the UI had updated and a secondary issue related to how "pin-to-bottom" was being turned off.

## Changes

* Added a generic `useNextTick()` hook that allows you to execute a callback after a React finishes the next commit and the browser has painted
* Used `useNextTick()` to ensure that programmatic scrolling events are triggered after log records have been added to DOM
* Modified behavior of "pin-to-bottom" logic so that behavior is turned off based on direction (scroll-up) instead of position

## Submitter checklist

- [x] Add the correct emoji to PR title
- [x] Link the issue number to *Fixes #*
- [x] Explain the changes made
- [x] Sign the commit using for [DCO](https://github.com/apps/dco) 
- [x] Rebase branch to HEAD