### PR TITLE
📜 Improvements to PR template and related documentation

### DIFF
--- a/.github/pull-request-commits.md
+++ b/.github/pull-request-commits.md
@@ -1,0 +1,32 @@
+# Pull Request Commits
+
+We request that changes in Pull Requests be squashed into one signed, single commit with this format:
+
+```
+<type>: commit title goes here (all lowercase)
+
+* <type>: Main change 1
+...
+* <type>: Main change N
+
+Signed-off-by: Your Name <you@example.com>
+Co-authored-by: John Smith <john@example.com>
+Co-authored-by: Jane Smith <jane@example.com>
+```
+
+With these types:
+
+- `new` - for new feature
+- `fix` - for bugfix
+- `doc` - for documentation 
+- `test` - for test
+- `ref` - for refactoring
+- `wip` - work in progress
+
+To squash commits or to add a signature to an existing commit you can use `git reset` and then create a new commit (replace `N` with the number of commits in your PR):
+
+```console
+git reset HEAD~N
+git commit -a -s -m "new: add hug-mode to skynet"
+git push origin --force
+```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,24 @@
 <!-- 
-Put the emoji in your PR title to indicate the type of PR
-
-🎣 bug fix
-🐋 new feature
-📜 documentation
- -->
+Put one of these emojis in your title to indicate the type of PR:
+- 🎣 Bug fix
+- 🐋 New feature
+- 📜 Documentation
+-->
 
 Fixes # 
 
 ## Summary
 
-*explain the goal of your PR*
+<-- Explain the goal of your PR  -->
 
 ## Changes
 
-*explain the goal of your PR*
+<-- Explain the changes in your PR -->
 
 ## Submitter checklist
 
-- [ ] Add the correct emoji to PR title
+- [ ] Add the correct emoji to the PR title
 - [ ] Link the issue number to *Fixes #*
-- [ ] Explain the changes made
-- [ ] Sign the commit using for [DCO](https://github.com/apps/dco) 
+- [ ] Add summary and explain changes in the PR description
 - [ ] Rebase branch to HEAD
+- [ ] Squash changes into one signed, single commit ([suggested format](/.github/pull-request-commits.md))


### PR DESCRIPTION
## Summary

This PR makes improvements to the PR template that users see when they create new PR's and adds a new README with commit message format and instructions on how to squash commits.

## Changes

* Improve template markup
* Add squashed, single commit to PR submitter checklist
* Add documentation to help users make PR commits

## Submitter checklist

- [x] Add the correct emoji to PR title
- [ ] Link the issue number to *Fixes #*
- [x] Explain the changes made
- [x] Sign the commit using for [DCO](https://github.com/apps/dco) 
- [x] Rebase branch to HEAD
