### PR TITLE
🐋 KUBECONFIG support on serve and logs command

### DIFF
--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
-	rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
+	rootCmd.PersistentFlags().String(KubeconfigFlag, "", "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/internal/tunnel/tunnel.go
+++ b/modules/cli/internal/tunnel/tunnel.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -56,13 +57,8 @@ func (t *Tunnel) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func NewTunnel(kubeconfigPath, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
-	kubeconfigConf, err := clientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	clientConfig := clientcmd.NewDefaultClientConfig(*kubeconfigConf, &clientcmd.ConfigOverrides{})
+func NewTunnel(apiConfig api.Config, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
+	clientConfig := clientcmd.NewDefaultClientConfig(apiConfig, &clientcmd.ConfigOverrides{})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -74,7 +74,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.KubeconfigPath))
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(&cfg.APIConfig))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -61,7 +61,7 @@ type ConnectionManager interface {
 type DesktopConnectionManager struct {
 	KubeConfigWatcher *KubeConfigWatcher
 	kubeConfig        *api.Config
-	kubeconfigPath    string
+	kubeconfigPath    []string
 	isLazy            bool
 	authorizer        DesktopAuthorizer
 	rcCache           map[string]*rest.Config
@@ -96,7 +96,7 @@ func NewDesktopConnectionManager(options ...ConnectionManagerOption) (*DesktopCo
 	}
 
 	// Init KubeConfigWatcher
-	kfw, err := NewKubeConfigWatcher(cm.kubeconfigPath)
+	kfw, err := NewKubeConfigWatcher(cm.kubeConfig, cm.kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -698,11 +698,11 @@ func NewConnectionManager(env config.Environment, options ...ConnectionManagerOp
 type ConnectionManagerOption func(cm ConnectionManager)
 
 // WithKubeconfig sets kubeconfig file path
-func WithKubeconfig(kubeconfig string) ConnectionManagerOption {
+func WithKubeconfig(kubeConfig *api.Config) ConnectionManagerOption {
 	return func(cm ConnectionManager) {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
-			t.kubeconfigPath = kubeconfig
+			t.kubeConfig = kubeConfig
 		case *InClusterConnectionManager:
 			break
 		}
@@ -715,6 +715,18 @@ func WithLazyConnect(isLazy bool) ConnectionManagerOption {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
 			t.isLazy = isLazy
+		case *InClusterConnectionManager:
+			break
+		}
+	}
+}
+
+// WithKubeconfigPath sets kubeconfig file path
+func WithKubeConfigPath(kubeConfigPaths []string) ConnectionManagerOption {
+	return func(cm ConnectionManager) {
+		switch t := cm.(type) {
+		case *DesktopConnectionManager:
+			t.kubeconfigPath = kubeConfigPaths
 		case *InClusterConnectionManager:
 			break
 		}


### PR DESCRIPTION
initial support on the serve and logs subcommand for KUBECONFIG environment variable. As per spec it supports multiple files (defined in the KUBECONFIG environment variable)

<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
-  New feature
- 📜 Documentation
-->

Fixes #225 

## Summary

For the `serve` and `logs` subcommand it's it's now possible to either:
* explicitly set the path to the kube-config file via the `kube-config` flag
* or use the default kube-config file location (which is `$HOME/.kube/config`)
* or use all the config-files which are defined in the `$KUBECONFIG` environment variable

For the `helm` related subcommands it's not possible to use the multi-file support of the `$KUBECONFIG` variable due to the missing support in the `helm` go client (xref: https://github.com/helm/helm/issues/12742#issuecomment-2883905104)

## Changes

The type [ClientConfigLoadingRules](https://github.com/kubernetes/client-go/blob/master/tools/clientcmd/loader.go#L107-L133) of `client-go/clientcmd` (already used in the code-base) is getting introduced to get the context loading precedence (as described in the summary)

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit ([suggested format](/.github/pull-request-commits.md))
