### PR TITLE
🎣 Pass through container ids to Cluster Agent to fix file identification issue

### DIFF
--- a/modules/cluster-agent/internal/services/logrecords/helpers_test.go
+++ b/modules/cluster-agent/internal/services/logrecords/helpers_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logrecords
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripRuntimePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "with prefix",
+			input:    "runtime://abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "without prefix",
+			input:    "containerd://xyz456",
+			expected: "xyz456",
+		},
+		{
+			name:     "with multiple separators",
+			input:    "runtime://xxx://xyz456",
+			expected: "xxx://xyz456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripRuntimePrefix(tt.input)
+			assert.Equal(t, tt.expected, result, "stripRuntimePrefix(%q) should return %q", tt.input, tt.expected)
+		})
+	}
+}
+
+func TestFindLogFile(t *testing.T) {
+	// Create a temporary directory for tests
+	tempDir, err := os.MkdirTemp("", "test-find-log-files")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Add files
+	fileNames := []string{
+		"pn1_ns1_cn1-id1.log",
+		"pn2_ns1_cn1-id2.log",
+		"pn2_ns1_cn2-id3.log",
+		"pn2_ns1_cn2-id4.log",
+	}
+
+	for _, fileName := range fileNames {
+		if err := os.WriteFile(filepath.Join(tempDir, fileName), []byte("t"), 0644); err != nil {
+			t.Fatalf("Failed to create test log file: %v", err)
+		}
+	}
+
+	// Test cases
+	tests := []struct {
+		name          string
+		namespace     string
+		podName       string
+		containerName string
+		containerID   string
+		wantPathname  string
+		wantErr       error
+	}{
+		{
+			name:          "match pod with only one entry",
+			namespace:     "ns1",
+			podName:       "pn1",
+			containerName: "cn1",
+			containerID:   "id1",
+			wantPathname:  filepath.Join(tempDir, fileNames[0]),
+			wantErr:       nil,
+		},
+		{
+			name:          "match pod with two containers with different names",
+			namespace:     "ns1",
+			podName:       "pn2",
+			containerName: "cn1",
+			containerID:   "id2",
+			wantPathname:  filepath.Join(tempDir, fileNames[1]),
+			wantErr:       nil,
+		},
+		{
+			name:          "match pod with two containers with same name",
+			namespace:     "ns1",
+			podName:       "pn2",
+			containerName: "cn2",
+			containerID:   "id3",
+			wantPathname:  filepath.Join(tempDir, fileNames[2]),
+			wantErr:       nil,
+		},
+		{
+			name:          "return err if file doesn't exist",
+			namespace:     "x",
+			podName:       "x",
+			containerName: "x",
+			containerID:   "x",
+			wantPathname:  "",
+			wantErr:       fmt.Errorf("log file not found: %s", filepath.Join(tempDir, "x_x_x-x.log")),
+		},
+		{
+			name:          "return err if id is mismatched",
+			namespace:     "ns1",
+			podName:       "pn1",
+			containerName: "cn1",
+			containerID:   "id2",
+			wantPathname:  "",
+			wantErr:       fmt.Errorf("log file not found: %s", filepath.Join(tempDir, "pn1_ns1_cn1-id2.log")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := findLogFile(tempDir, tt.namespace, tt.podName, tt.containerName, tt.containerID)
+			assert.Equal(t, tt.wantPathname, result)
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}

--- a/modules/cluster-agent/internal/services/logrecords/logrecords.go
+++ b/modules/cluster-agent/internal/services/logrecords/logrecords.go
@@ -74,7 +74,7 @@ func (s *LogRecordsService) StreamForward(req *clusteragentpb.LogRecordsStreamRe
 		return err
 	}
 
-	pathname, err := findLogFile(s.containerLogsDir, req.Namespace, req.PodName, req.ContainerName)
+	pathname, err := findLogFile(s.containerLogsDir, req.Namespace, req.PodName, req.ContainerName, req.ContainerId)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (s *LogRecordsService) StreamBackward(req *clusteragentpb.LogRecordsStreamR
 		return err
 	}
 
-	pathname, err := findLogFile(s.containerLogsDir, req.Namespace, req.PodName, req.ContainerName)
+	pathname, err := findLogFile(s.containerLogsDir, req.Namespace, req.PodName, req.ContainerName, req.ContainerId)
 	if err != nil {
 		return err
 	}

--- a/modules/shared/clusteragentpb/cluster_agent.pb.go
+++ b/modules/shared/clusteragentpb/cluster_agent.pb.go
@@ -462,10 +462,11 @@ type LogRecordsStreamRequest struct {
 	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	PodName       string                 `protobuf:"bytes,2,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
 	ContainerName string                 `protobuf:"bytes,3,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
-	StartTime     string                 `protobuf:"bytes,4,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	StopTime      string                 `protobuf:"bytes,5,opt,name=stop_time,json=stopTime,proto3" json:"stop_time,omitempty"`
-	Grep          string                 `protobuf:"bytes,6,opt,name=grep,proto3" json:"grep,omitempty"`
-	FollowFrom    FollowFrom             `protobuf:"varint,7,opt,name=follow_from,json=followFrom,proto3,enum=cluster_agent.FollowFrom" json:"follow_from,omitempty"`
+	ContainerId   string                 `protobuf:"bytes,4,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
+	StartTime     string                 `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	StopTime      string                 `protobuf:"bytes,6,opt,name=stop_time,json=stopTime,proto3" json:"stop_time,omitempty"`
+	Grep          string                 `protobuf:"bytes,7,opt,name=grep,proto3" json:"grep,omitempty"`
+	FollowFrom    FollowFrom             `protobuf:"varint,8,opt,name=follow_from,json=followFrom,proto3,enum=cluster_agent.FollowFrom" json:"follow_from,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -517,6 +518,13 @@ func (x *LogRecordsStreamRequest) GetPodName() string {
 func (x *LogRecordsStreamRequest) GetContainerName() string {
 	if x != nil {
 		return x.ContainerName
+	}
+	return ""
+}
+
+func (x *LogRecordsStreamRequest) GetContainerId() string {
+	if x != nil {
+		return x.ContainerId
 	}
 	return ""
 }
@@ -631,16 +639,17 @@ const file_cluster_agent_proto_rawDesc = "" +
 	"namespaces\"_\n" +
 	"\x15LogMetadataWatchEvent\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x122\n" +
-	"\x06object\x18\x02 \x01(\v2\x1a.cluster_agent.LogMetadataR\x06object\"\x85\x02\n" +
+	"\x06object\x18\x02 \x01(\v2\x1a.cluster_agent.LogMetadataR\x06object\"\xa8\x02\n" +
 	"\x17LogRecordsStreamRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x19\n" +
 	"\bpod_name\x18\x02 \x01(\tR\apodName\x12%\n" +
-	"\x0econtainer_name\x18\x03 \x01(\tR\rcontainerName\x12\x1d\n" +
+	"\x0econtainer_name\x18\x03 \x01(\tR\rcontainerName\x12!\n" +
+	"\fcontainer_id\x18\x04 \x01(\tR\vcontainerId\x12\x1d\n" +
 	"\n" +
-	"start_time\x18\x04 \x01(\tR\tstartTime\x12\x1b\n" +
-	"\tstop_time\x18\x05 \x01(\tR\bstopTime\x12\x12\n" +
-	"\x04grep\x18\x06 \x01(\tR\x04grep\x12:\n" +
-	"\vfollow_from\x18\a \x01(\x0e2\x19.cluster_agent.FollowFromR\n" +
+	"start_time\x18\x05 \x01(\tR\tstartTime\x12\x1b\n" +
+	"\tstop_time\x18\x06 \x01(\tR\bstopTime\x12\x12\n" +
+	"\x04grep\x18\a \x01(\tR\x04grep\x12:\n" +
+	"\vfollow_from\x18\b \x01(\x0e2\x19.cluster_agent.FollowFromR\n" +
 	"followFrom\"_\n" +
 	"\tLogRecord\x128\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +

--- a/modules/shared/logs/log-fetcher.go
+++ b/modules/shared/logs/log-fetcher.go
@@ -347,6 +347,7 @@ func (f *AgentLogFetcher) StreamForward(ctx context.Context, source LogSource, o
 			Namespace:     source.Namespace,
 			PodName:       source.PodName,
 			ContainerName: source.ContainerName,
+			ContainerId:   source.ContainerID,
 			Grep:          opts.Grep,
 		}
 
@@ -443,6 +444,7 @@ func (f *AgentLogFetcher) StreamBackward(ctx context.Context, source LogSource, 
 			Namespace:     source.Namespace,
 			PodName:       source.PodName,
 			ContainerName: source.ContainerName,
+			ContainerId:   source.ContainerID,
 			Grep:          opts.Grep,
 		}
 

--- a/proto/cluster_agent.proto
+++ b/proto/cluster_agent.proto
@@ -74,10 +74,11 @@ message LogRecordsStreamRequest {
   string namespace = 1;
   string pod_name = 2;
   string container_name = 3;
-  string start_time = 4;
-  string stop_time = 5;
-  string grep = 6;
-  FollowFrom follow_from = 7;
+  string container_id = 4;
+  string start_time = 5;
+  string stop_time = 6;
+  string grep = 7;
+  FollowFrom follow_from = 8;
 }
 
 message LogRecord {


### PR DESCRIPTION
Fixes #298

## Summary

This PR passes through container ids to the Cluster Agent at log-fetch time so that the Cluster Agent can use them to identify individual container log files on disk. Previously, the Cluster Agent was using a glob pattern with namespace, pod name and container name which was causing problems with multi-container pods where the containers shared the same prefix.

One issue that came up is that container ids returned by the Kubernetes API are prefixed with a `"<runtime>://"` string which isn't present in the file names on disk so we had to strip them first. We should keep an eye out for any situations where the runtime prefix has a different format than `"<runtime>://"`.

## Changes

- Add `container_id` to logrecords service streaming request protobuf definition
- Modify log-fetcher in modules/shared so that it passes along container id when requesting logs from cluster-agent
- Add method to strip "<runtime>://" prefix from container ids passed to `findLogFile()`
- Modify `findLogFile()` so it accepts container id and uses it to verify the file exists
- Add unit tests for `stripRuntimePrefix()` and `findLogFile()`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
