### PR TITLE
🎣 Allow dashboard to accept bearer tokens in auth-mode 'auto'

### DIFF
--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -28,18 +28,14 @@ import (
 
 func authenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// continue if not in token mode
-		if mode != config.AuthModeToken {
-			c.Next()
-			return
-		}
-
 		var token string
 
-		// check cookie session
-		session := sessions.Default(c)
-		if val, ok := session.Get(k8sTokenSessionKey).(string); ok {
-			token = val
+		// Use cookie session in "token" mode
+		if mode == config.AuthModeToken {
+			session := sessions.Default(c)
+			if val, ok := session.Get(k8sTokenSessionKey).(string); ok {
+				token = val
+			}
 		}
 
 		// check Authorization header

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -37,8 +37,8 @@ func TestAuthenticationMiddleware(t *testing.T) {
 	}{
 		{"auto-mode without tokens", config.AuthModeAuto, false, false, false},
 		{"auto-mode with session token", config.AuthModeAuto, true, false, false},
-		{"auto-mode with bearer token", config.AuthModeAuto, false, true, false},
-		{"auto-mode with both tokens", config.AuthModeAuto, true, true, false},
+		{"auto-mode with bearer token", config.AuthModeAuto, false, true, true},
+		{"auto-mode with both tokens", config.AuthModeAuto, true, true, true},
 		{"token-mode without tokens", config.AuthModeToken, false, false, false},
 		{"token-mode with session token", config.AuthModeToken, true, false, true},
 		{"token-mode with bearer token", config.AuthModeToken, false, true, true},


### PR DESCRIPTION
## Summary

This PR fixes an issue in the dashboard with `auth-mode: auto` where it would ignore bearer tokens sent in the Authentication header. Now, in `auth-mode: auto`, the dashboard will use bearer tokens for authentication or fall back to the dashboard's own serviceaccount otherwise.

## Changes

- Modified dashboard's authentication middleware and removed early exit when `auth-mode: auto`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
