### PR TITLE
🎣 Fix problems when cluster-api-enabled is `false` in Dashboard UI

### DIFF
--- a/dashboard-ui/src/lib/hooks.ts
+++ b/dashboard-ui/src/lib/hooks.ts
@@ -440,7 +440,7 @@ export function useIsClusterAPIEnabled(kubeContext: string | null) {
   const status = useClusterAPIServerStatus(kubeContext || '');
 
   // Return if running in cluster with ClusterAPI enabled
-  if (appConfig.environment === 'cluster' && appConfig.clusterAPIEnabled) return true;
+  if (appConfig.environment === 'cluster') return appConfig.clusterAPIEnabled;
 
   switch (status.status) {
     case Status.NotFound:
@@ -473,6 +473,7 @@ export function useLogMetadata(options?: LogMetadataHookOptions) {
   };
 
   const readyWait = useSubscription(dashboardOps.CLUSTER_API_READY_WAIT, {
+    skip: !options?.enabled,
     variables: connectArgs,
   });
 

--- a/dashboard-ui/src/lib/server-status.ts
+++ b/dashboard-ui/src/lib/server-status.ts
@@ -16,6 +16,7 @@ import { useSubscription } from '@apollo/client';
 import { useEffect, useState } from 'react';
 
 import { dashboardWSClient } from '@/apollo-client';
+import appConfig from '@/app-config';
 import * as dashboardOps from '@/lib/graphql/dashboard/ops';
 import { HealthCheckStatus, type HealthCheckResponse } from '@/lib/graphql/dashboard/__generated__/graphql';
 
@@ -108,6 +109,7 @@ export function useClusterAPIServerStatus(kubeContext: string) {
   const [status, setStatus] = useState<ServerStatus>(new ServerStatus());
 
   useSubscription(dashboardOps.SERVER_STATUS_CLUSTER_API_HEALTHZ_WATCH, {
+    skip: !appConfig.clusterAPIEnabled,
     variables: { kubeContext },
     onData: ({ data }) => setStatus(ServerStatus.fromHealthCheckResponse(data.data?.clusterAPIHealthzWatch)),
   });


### PR DESCRIPTION
Fixes #311 

## Summary

This PR fixes issues in the Dashboard UI related to improper handling of the `clusterAPIEnalbed` runtime config option.

## Changes

- Removes unnecessary ClusterAPI health checks that were throwing errors
- Fixes error in useIsClusterAPIEnabled() hook that wasn't returning a value when `clusterAPIEnabled` is set to false in dashboard runtime config

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
