### PR TITLE
🎣 Add initial set of tests for kube-config-watcher

### DIFF
--- a/modules/shared/go.mod
+++ b/modules/shared/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gin-contrib/requestid v1.0.4
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-playground/validator/v10 v10.25.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/csrf v1.7.2
 	github.com/kubetail-org/grpc-dispatcher-go v0.1.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -92,7 +93,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -101,12 +101,12 @@ func (w *KubeConfigWatcher) Get() *api.Config {
 }
 
 // Subscribe
-func (w *KubeConfigWatcher) Subscribe(topic string, fn interface{}) {
+func (w *KubeConfigWatcher) Subscribe(topic string, fn any) {
 	w.eventbus.SubscribeAsync(topic, fn, true)
 }
 
 // Unsubscribe
-func (w *KubeConfigWatcher) Unsubscribe(topic string, fn interface{}) {
+func (w *KubeConfigWatcher) Unsubscribe(topic string, fn any) {
 	w.eventbus.Unsubscribe(topic, fn)
 }
 

--- a/modules/shared/k8shelpers/kube-config-watcher_test.go
+++ b/modules/shared/k8shelpers/kube-config-watcher_test.go
@@ -1,0 +1,250 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8shelpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Helper function to create a temporary directory with a sample kubeconfig file
+func createKubeConfig(kubeconfigPath string) (*clientcmdapi.Config, error) {
+	uuid := uuid.New().String()
+
+	cluster := fmt.Sprintf("cluster-%s", uuid)
+	user := fmt.Sprintf("user-%s", uuid)
+	context := fmt.Sprintf("context-%s", uuid)
+
+	// Create a new empty config
+	cfg := clientcmdapi.NewConfig()
+
+	// Populate the config
+	cfg.Clusters[cluster] = &clientcmdapi.Cluster{}
+	cfg.AuthInfos[user] = &clientcmdapi.AuthInfo{}
+	cfg.Contexts[context] = &clientcmdapi.Context{}
+	cfg.CurrentContext = context
+
+	// Write the config to a file
+	if err := clientcmd.WriteToFile(*cfg, kubeconfigPath); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Helper function to assert that two maps have the same keys
+func compareMaps[K comparable, V any](t *testing.T, m1 map[K]*V, m2 map[K]*V) {
+	assert.Equal(t, len(m1), len(m2))
+	for k := range m1 {
+		_, ok := m2[k]
+		assert.True(t, ok)
+	}
+}
+
+func TestKubeConfigWatcherGet(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "kube-config-watcher-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Create pathname
+	kubeconfigPath := filepath.Join(tempDir, fmt.Sprintf("config-%s", uuid.New().String()))
+
+	// Create config file
+	cfgExpected, err := createKubeConfig(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize watcher
+	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+
+	// Check config
+	cfgActual := watcher.Get()
+	compareMaps(t, cfgExpected.Clusters, cfgActual.Clusters)
+	compareMaps(t, cfgExpected.AuthInfos, cfgActual.AuthInfos)
+	compareMaps(t, cfgExpected.Contexts, cfgActual.Contexts)
+	assert.Equal(t, cfgExpected.CurrentContext, cfgActual.CurrentContext)
+}
+
+/*
+TODO: Currently KubeConfigWatcher throws an erro when file doesn't exist
+
+func TestKubeConfigWatcherSubscribeAdded(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "kube-config-watcher-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Create pathname
+	kubeconfigPath := filepath.Join(tempDir, fmt.Sprintf("config-%s", uuid.New().String()))
+
+	// Initialize watcher
+	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Subscribe
+	var cfgActual *clientcmdapi.Config
+	watcher.Subscribe("ADDED", func(cfg *clientcmdapi.Config) {
+		defer wg.Done()
+		cfgActual = cfg
+	})
+
+	// Create config file
+	cfgExpected, err := createKubeConfig(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+
+	// Check config
+	compareMaps(t, cfgExpected.Clusters, cfgActual.Clusters)
+	compareMaps(t, cfgExpected.AuthInfos, cfgActual.AuthInfos)
+	compareMaps(t, cfgExpected.Contexts, cfgActual.Contexts)
+	assert.Equal(t, cfgExpected.CurrentContext, cfgActual.CurrentContext)
+}
+*/
+
+func TestKubeConfigWatcherSubscribeModified(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "kube-config-watcher-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Create pathname
+	kubeconfigPath := filepath.Join(tempDir, fmt.Sprintf("config-%s", uuid.New().String()))
+
+	// Create config file
+	cfgOrig, err := createKubeConfig(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize watcher
+	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Subscribe
+	var cfgActual *clientcmdapi.Config
+	fn := func(oldCfg, newCfg *clientcmdapi.Config) {
+		defer wg.Done()
+
+		// Check old config
+		compareMaps(t, cfgOrig.Clusters, oldCfg.Clusters)
+		compareMaps(t, cfgOrig.AuthInfos, oldCfg.AuthInfos)
+		compareMaps(t, cfgOrig.Contexts, oldCfg.Contexts)
+		assert.Equal(t, cfgOrig.CurrentContext, oldCfg.CurrentContext)
+
+		cfgActual = newCfg
+	}
+	watcher.Subscribe("MODIFIED", fn)
+
+	// Create config file
+	cfgExpected, err := createKubeConfig(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+
+	// Check new config
+	compareMaps(t, cfgExpected.Clusters, cfgActual.Clusters)
+	compareMaps(t, cfgExpected.AuthInfos, cfgActual.AuthInfos)
+	compareMaps(t, cfgExpected.Contexts, cfgActual.Contexts)
+	assert.Equal(t, cfgExpected.CurrentContext, cfgActual.CurrentContext)
+
+	watcher.Unsubscribe("MODIFIED", fn)
+}
+
+func TestKubeConfigWatcherSubscribeDeleted(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "kube-config-watcher-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Create pathname
+	kubeconfigPath := filepath.Join(tempDir, fmt.Sprintf("config-%s", uuid.New().String()))
+
+	// Create config file
+	cfgOrig, err := createKubeConfig(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize watcher
+	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Subscribe
+	fn := func(oldCfg *clientcmdapi.Config) {
+		defer wg.Done()
+
+		// Check old config
+		compareMaps(t, cfgOrig.Clusters, oldCfg.Clusters)
+		compareMaps(t, cfgOrig.AuthInfos, oldCfg.AuthInfos)
+		compareMaps(t, cfgOrig.Contexts, oldCfg.Contexts)
+		assert.Equal(t, cfgOrig.CurrentContext, oldCfg.CurrentContext)
+	}
+	watcher.Subscribe("DELETED", fn)
+
+	// Delete file
+	err = os.Remove(kubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+
+	watcher.Unsubscribe("DELETED", fn)
+}


### PR DESCRIPTION
## Summary

This PR adds an initial set of tests for the KubeConfigWatcher. Having some base set of tests should make it easier to modify the code to handle multiple files later. The test for the "Added" event is commented out because currently, KubeConfigWatcher throws an error when it is initialized with a file that doesn't exist.

## Changes

- Adds unit tests to `KubeConfigWatcher`
- Ran `mod tidy` in `modules/shared` to upgrade `github.com/google/uuid` to direct import

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
