### PR TITLE
🎣 Handle Cluster API 'not available' in dashbard frontend

### DIFF
--- a/dashboard-ui/src/lib/server-status.ts
+++ b/dashboard-ui/src/lib/server-status.ts
@@ -111,7 +111,18 @@ export function useClusterAPIServerStatus(kubeContext: string) {
   useSubscription(dashboardOps.SERVER_STATUS_CLUSTER_API_HEALTHZ_WATCH, {
     skip: !appConfig.clusterAPIEnabled,
     variables: { kubeContext },
-    onData: ({ data }) => setStatus(ServerStatus.fromHealthCheckResponse(data.data?.clusterAPIHealthzWatch)),
+    onData: ({ data }) => {
+      setStatus(ServerStatus.fromHealthCheckResponse(data.data?.clusterAPIHealthzWatch));
+    },
+    onError: (err) => {
+      if (err.message === 'not available') {
+        setStatus(new ServerStatus({
+          status: Status.NotFound,
+          message: 'Not available',
+          lastUpdatedAt: new Date(),
+        }));
+      }
+    },
   });
 
   return status;


### PR DESCRIPTION
## Summary

Update dashboard frontend to handle Cluster API "not available" health check response

## Changes

- Modify server-status.ts to handle "not available" response that is emitted by `noopHealthMonitorWorker` in backend

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
