### PR TITLE
🎣 Fix uninitialized config bug and refactor kubeconfig handling code

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -79,5 +79,11 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.9"
   },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild"
+    ]
+  }
 }

--- a/modules/cli/cmd/cluster_install.go
+++ b/modules/cli/cmd/cluster_install.go
@@ -39,7 +39,7 @@ var clusterInstallCmd = &cobra.Command{
 	Long:  clusterInstallHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeconfigPath, _ := cmd.Flags().GetString(KubeconfigFlag)
 		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
@@ -47,7 +47,7 @@ var clusterInstallCmd = &cobra.Command{
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeconfigPath(kubeconfigPath), helm.WithKubeContext(kubeContext))
 
 		// Install
 		release, err := client.InstallLatest(namespace, name)

--- a/modules/cli/cmd/cluster_list.go
+++ b/modules/cli/cmd/cluster_list.go
@@ -37,11 +37,11 @@ var clusterListCmd = &cobra.Command{
 	Long:  clusterListHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeconfigPath, _ := cmd.Flags().GetString(KubeconfigFlag)
 		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 
 		// Init client
-		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeconfigPath(kubeconfigPath), helm.WithKubeContext(kubeContext))
 
 		// Get releases
 		releases, err := client.ListReleases()

--- a/modules/cli/cmd/cluster_uninstall.go
+++ b/modules/cli/cmd/cluster_uninstall.go
@@ -35,7 +35,7 @@ var clusterUninstallCmd = &cobra.Command{
 	Long:  clusterUninstallHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeconfigPath, _ := cmd.Flags().GetString(KubeconfigFlag)
 		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
@@ -43,7 +43,7 @@ var clusterUninstallCmd = &cobra.Command{
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeconfigPath(kubeconfigPath), helm.WithKubeContext(kubeContext))
 
 		// Uninstall
 		response, err := client.UninstallRelease(namespace, name)

--- a/modules/cli/cmd/cluster_upgrade.go
+++ b/modules/cli/cmd/cluster_upgrade.go
@@ -35,7 +35,7 @@ var clusterUpgradeCmd = &cobra.Command{
 	Long:  clusterUpgradeHelp,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get flags
-		Kubeconfig, _ := cmd.Flags().GetString(KubeconfigFlag)
+		kubeconfigPath, _ := cmd.Flags().GetString(KubeconfigFlag)
 		kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
 		//name, _ := cmd.Flags().GetString("name")
 		//namespace, _ := cmd.Flags().GetString("namespace")
@@ -43,7 +43,7 @@ var clusterUpgradeCmd = &cobra.Command{
 		namespace := helm.DefaultNamespace
 
 		// Init client
-		client := helm.NewClient(helm.WithKubeContext(kubeContext), helm.WithKubeconfig(Kubeconfig))
+		client := helm.NewClient(helm.WithKubeconfigPath(kubeconfigPath), helm.WithKubeContext(kubeContext))
 
 		// Upgrade
 		release, err := client.UpgradeRelease(namespace, name)

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -27,7 +27,9 @@ import (
 	"github.com/sosodev/duration"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
+	"github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 
@@ -193,7 +195,7 @@ var logsCmd = &cobra.Command{
 		flags := cmd.Flags()
 
 		kubeContext, _ := flags.GetString(KubeContextFlag)
-		kubeconfigPath, _ := flags.GetString(KubeconfigFlag)
+		kubeConfig, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
 		headVal, _ := flags.GetInt64("head")
@@ -227,6 +229,15 @@ var logsCmd = &cobra.Command{
 		withCursors, _ := flags.GetBool("with-cursors")
 
 		hideHeader, _ := flags.GetBool("hide-header")
+
+		v := viper.New()
+		v.Set(KubeconfigFlag, kubeConfig)
+
+		// init config
+		cfg, err := config.NewConfig(v, "")
+		if err != nil {
+			cli.ExitOnError(err)
+		}
 
 		// Stream mode
 		streamMode := logsStreamModeUnknown
@@ -273,7 +284,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(kubeconfigPath), k8shelpers.WithLazyConnect(true))
+		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(&cfg.APIConfig), k8shelpers.WithLazyConnect(true), k8shelpers.WithKubeConfigPath(cfg.KubeconfigPath))
 		cli.ExitOnError(err)
 
 		// Init stream

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -27,9 +27,7 @@ import (
 	"github.com/sosodev/duration"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
-	"github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 
@@ -195,7 +193,7 @@ var logsCmd = &cobra.Command{
 		flags := cmd.Flags()
 
 		kubeContext, _ := flags.GetString(KubeContextFlag)
-		kubeConfig, _ := flags.GetString(KubeconfigFlag)
+		kubeconfigPath, _ := flags.GetString(KubeconfigFlag)
 
 		head := flags.Changed("head")
 		headVal, _ := flags.GetInt64("head")
@@ -229,15 +227,6 @@ var logsCmd = &cobra.Command{
 		withCursors, _ := flags.GetBool("with-cursors")
 
 		hideHeader, _ := flags.GetBool("hide-header")
-
-		v := viper.New()
-		v.Set(KubeconfigFlag, kubeConfig)
-
-		// init config
-		cfg, err := config.NewConfig(v, "")
-		if err != nil {
-			cli.ExitOnError(err)
-		}
 
 		// Stream mode
 		streamMode := logsStreamModeUnknown
@@ -284,7 +273,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		// Init connection manager
-		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfig(&cfg.APIConfig), k8shelpers.WithLazyConnect(true), k8shelpers.WithKubeConfigPath(cfg.KubeconfigPath))
+		cm, err := k8shelpers.NewDesktopConnectionManager(k8shelpers.WithKubeconfigPath(kubeconfigPath), k8shelpers.WithLazyConnect(true))
 		cli.ExitOnError(err)
 
 		// Init stream

--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
-	rootCmd.PersistentFlags().String(KubeconfigFlag, clientcmd.RecommendedHomeFile, "Path to kubeconfig file")
+	rootCmd.PersistentFlags().String(KubeconfigFlag, "", "Path to kubeconfig file")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/modules/cli/internal/tunnel/tunnel.go
+++ b/modules/cli/internal/tunnel/tunnel.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -56,13 +57,8 @@ func (t *Tunnel) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func NewTunnel(kubeconfigPath, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
-	kubeconfigConf, err := clientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	clientConfig := clientcmd.NewDefaultClientConfig(*kubeconfigConf, &clientcmd.ConfigOverrides{})
+func NewTunnel(apiConfig api.Config, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
+	clientConfig := clientcmd.NewDefaultClientConfig(apiConfig, &clientcmd.ConfigOverrides{})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/modules/cli/internal/tunnel/tunnel.go
+++ b/modules/cli/internal/tunnel/tunnel.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -57,8 +56,13 @@ func (t *Tunnel) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func NewTunnel(apiConfig api.Config, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
-	clientConfig := clientcmd.NewDefaultClientConfig(apiConfig, &clientcmd.ConfigOverrides{})
+func NewTunnel(kubeconfigPath string, namespace, serviceName string, remotePort, localPort int) (*Tunnel, error) {
+	// Use loading rules from clientcmd
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+
+	// Use clientcmd to generate config object (supports KUBECONFIG env var automatically)
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -130,7 +130,7 @@ func (r *mutationResolver) HelmInstallLatest(ctx context.Context, kubeContext *s
 	}
 
 	// Init client
-	client := helm.NewClient(helm.WithKubeContext(kubeContextVal), helm.WithKubeconfig(r.config.KubeconfigPath))
+	client := helm.NewClient(helm.WithKubeconfigPath(r.config.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
 
 	// Install
 	release, err := client.InstallLatest(helm.DefaultNamespace, helm.DefaultReleaseName)
@@ -531,7 +531,7 @@ func (r *queryResolver) HelmListReleases(ctx context.Context, kubeContext *strin
 	kubeContextVal := r.cm.DerefKubeContext(kubeContext)
 
 	// Init client
-	client := helm.NewClient(helm.WithKubeContext(kubeContextVal), helm.WithKubeconfig(r.config.KubeconfigPath))
+	client := helm.NewClient(helm.WithKubeconfigPath(r.config.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
 
 	// Get list
 	releases, err := client.ListReleases()

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -74,7 +74,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(&cfg.APIConfig))
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfigPath(cfg.KubeconfigPath))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -74,7 +74,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.Use(gin.Recovery())
 
 		// Init connection manager
-		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(cfg.KubeconfigPath))
+		cm, err := k8shelpers.NewConnectionManager(cfg.Dashboard.Environment, k8shelpers.WithKubeconfig(&cfg.APIConfig))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -34,6 +34,7 @@ import (
 	zlog "github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // Auth-mode
@@ -54,8 +55,10 @@ const (
 
 // Application configuration
 type Config struct {
-	AllowedNamespaces []string `mapstructure:"allowed-namespaces"`
-	KubeconfigPath    string   `mapstructure:"kubeconfig"`
+	// API config
+	APIConfig         api.Config `mapstructure:"api-config"`
+	AllowedNamespaces []string   `mapstructure:"allowed-namespaces"`
+	KubeconfigPath    string     `mapstructure:"kubeconfig"`
 	// dashboard options
 	Dashboard struct {
 		Addr               string   `validate:"omitempty,hostname_port"`
@@ -233,11 +236,49 @@ func (cfg *Config) validate() error {
 	return validator.New().Struct(cfg)
 }
 
+// SetKubeConfigPrecedence sets the kubeconfig precedence
+//  1. if the given kubeconfig path is not equal to the default
+//     set to the given kubeconfig path
+//  2. if the KUBECONFIG env var is set, set kubeconfig to the
+//     first file from the KUBECONFIG env var
+//  3. if KUBECONFIG env var is not set, set to
+//     the default kubeconfig path (~/.kube/config)
+func (cfg *Config) SetKubeConfigPath(kubeConfigPath string) {
+
+	switch {
+	// check if the given kubeconfig path is not equal to the default
+	case kubeConfigPath != clientcmd.RecommendedHomeFile:
+		cfg.KubeconfigPath = kubeConfigPath
+	// check KUBECONFIG env var
+	case os.Getenv("KUBECONFIG") != "":
+		// NewDefaultPathOptions is only used to read the KUBECONFIG env var and get
+		// a deduplicated list of kubeconfig files
+		pathOptions := clientcmd.NewDefaultPathOptions()
+		// set the kubeconfig path to the first file in the KUBECONFIG env var
+		// TODO: handle multiple kubeconfig files
+		cfg.KubeconfigPath = pathOptions.GetEnvVarFiles()[0]
+	default:
+		cfg.KubeconfigPath = clientcmd.RecommendedHomeFile
+	}
+}
+
+func (cfg *Config) generateKubeAPIConfig(loader clientcmd.ClientConfigLoader) error {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{})
+	rawConfig, err := clientConfig.RawConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg.APIConfig = rawConfig
+
+	return nil
+}
+
 func DefaultConfig() *Config {
 	cfg := &Config{}
 
+	cfg.APIConfig = api.Config{}
 	cfg.AllowedNamespaces = []string{}
-	cfg.KubeconfigPath = clientcmd.RecommendedHomeFile
 	cfg.Dashboard.Addr = ":8080"
 	cfg.Dashboard.AuthMode = AuthModeAuto
 	cfg.Dashboard.BasePath = "/"
@@ -417,6 +458,11 @@ func NewConfig(v *viper.Viper, f string) (*Config, error) {
 	}
 
 	cfg := DefaultConfig()
+
+	// set cfg.SetKubeConfigPath in config
+	cfg.SetKubeConfigPath(v.GetString(clientcmd.RecommendedConfigPathFlag))
+	// overwrite kubeconfig path in viper
+	v.Set(clientcmd.RecommendedConfigPathFlag, cfg.KubeconfigPath)
 
 	// unmarshal
 	hookFunc := mapstructure.ComposeDecodeHookFunc(

--- a/modules/shared/config/config_test.go
+++ b/modules/shared/config/config_test.go
@@ -3,11 +3,14 @@ package config
 import (
 	"net/http"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var cfg1 = `
@@ -31,4 +34,167 @@ func TestConfig(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, EnvironmentCluster, cfg.Dashboard.Environment)
 	assert.Equal(t, http.SameSiteStrictMode, cfg.Dashboard.Session.Cookie.SameSite)
+}
+
+func TestNewConfig(t *testing.T) {
+	type args struct {
+		v *viper.Viper
+		f string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Config
+		wantErr bool
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewConfig(tt.args.v, tt.args.f)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestKubeConfigPrecedence tests the precedence of kubeconfig files
+// based on the KUBECONFIG environment variable and the kubeconfig flag.
+func TestKubeConfigPath(t *testing.T) {
+
+	homedir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	type args struct {
+		v       func() *viper.Viper
+		envVars map[string]string
+		f       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "default - no KUBECONFIG set and kubeconfig flag use default",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
+
+					return v
+				},
+				f:       "",
+				envVars: map[string]string{},
+			},
+			want:    filepath.Join(homedir, ".kube", "config"),
+			wantErr: false,
+		},
+		{
+			name: "KUBECONFIG set and kubeconfig flag use default",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
+
+					return v
+				},
+				f: "",
+				envVars: map[string]string{
+					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml",
+				},
+			},
+			want:    "/tmp/kubie-configeTtA1B.yaml",
+			wantErr: false,
+		},
+		{
+			name: "multiple files in KUBECONFIG set - expect first file",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
+
+					return v
+				},
+				f: "",
+				envVars: map[string]string{
+					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml:/tmp/kubie-configR2D2.yaml",
+				},
+			},
+			want:    "/tmp/kubie-configeTtA1B.yaml",
+			wantErr: false,
+		},
+		{
+			name: "KUBECONFIG set and flag set to non-default file location",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, "/tmp/configeTtA1B.yaml")
+
+					return v
+				},
+				f: "",
+				envVars: map[string]string{
+					"KUBECONFIG": "/tmp/config-g9kJ8.yaml",
+				},
+			},
+			want:    "/tmp/configeTtA1B.yaml",
+			wantErr: false,
+		},
+		{
+			name: "flag set to non-default file location",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, "/tmp/configeTtA1B.yaml")
+
+					return v
+				},
+				f:       "",
+				envVars: map[string]string{},
+			},
+			want:    "/tmp/configeTtA1B.yaml",
+			wantErr: false,
+		},
+		{
+			name: "KUBECONFIG var contains trailing slash which is not a valid file",
+			args: args{
+				v: func() *viper.Viper {
+					v := viper.New()
+					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
+
+					return v
+				},
+				f: "",
+				envVars: map[string]string{
+					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml:/tmp/kubie-configR2D2.yaml:/",
+				},
+			},
+			want:    "/tmp/kubie-configeTtA1B.yaml",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// set environment variables
+			for k, v := range tt.args.envVars {
+				t.Setenv(k, v)
+			}
+
+			got, err := NewConfig(tt.args.v(), tt.args.f)
+
+			switch tt.wantErr {
+			case true:
+				assert.Error(t, err)
+			case false:
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got.KubeconfigPath)
+			}
+		})
+	}
 }

--- a/modules/shared/config/config_test.go
+++ b/modules/shared/config/config_test.go
@@ -3,14 +3,12 @@ package config
 import (
 	"net/http"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var cfg1 = `
@@ -56,144 +54,6 @@ func TestNewConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewConfig() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestKubeConfigPrecedence tests the precedence of kubeconfig files
-// based on the KUBECONFIG environment variable and the kubeconfig flag.
-func TestKubeConfigPath(t *testing.T) {
-
-	homedir, err := os.UserHomeDir()
-	require.NoError(t, err)
-
-	type args struct {
-		v       func() *viper.Viper
-		envVars map[string]string
-		f       string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "default - no KUBECONFIG set and kubeconfig flag use default",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
-
-					return v
-				},
-				f:       "",
-				envVars: map[string]string{},
-			},
-			want:    filepath.Join(homedir, ".kube", "config"),
-			wantErr: false,
-		},
-		{
-			name: "KUBECONFIG set and kubeconfig flag use default",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
-
-					return v
-				},
-				f: "",
-				envVars: map[string]string{
-					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml",
-				},
-			},
-			want:    "/tmp/kubie-configeTtA1B.yaml",
-			wantErr: false,
-		},
-		{
-			name: "multiple files in KUBECONFIG set - expect first file",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
-
-					return v
-				},
-				f: "",
-				envVars: map[string]string{
-					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml:/tmp/kubie-configR2D2.yaml",
-				},
-			},
-			want:    "/tmp/kubie-configeTtA1B.yaml",
-			wantErr: false,
-		},
-		{
-			name: "KUBECONFIG set and flag set to non-default file location",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, "/tmp/configeTtA1B.yaml")
-
-					return v
-				},
-				f: "",
-				envVars: map[string]string{
-					"KUBECONFIG": "/tmp/config-g9kJ8.yaml",
-				},
-			},
-			want:    "/tmp/configeTtA1B.yaml",
-			wantErr: false,
-		},
-		{
-			name: "flag set to non-default file location",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, "/tmp/configeTtA1B.yaml")
-
-					return v
-				},
-				f:       "",
-				envVars: map[string]string{},
-			},
-			want:    "/tmp/configeTtA1B.yaml",
-			wantErr: false,
-		},
-		{
-			name: "KUBECONFIG var contains trailing slash which is not a valid file",
-			args: args{
-				v: func() *viper.Viper {
-					v := viper.New()
-					v.Set(clientcmd.RecommendedConfigPathFlag, clientcmd.RecommendedHomeFile)
-
-					return v
-				},
-				f: "",
-				envVars: map[string]string{
-					"KUBECONFIG": "/tmp/kubie-configeTtA1B.yaml:/tmp/kubie-configR2D2.yaml:/",
-				},
-			},
-			want:    "/tmp/kubie-configeTtA1B.yaml",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			// set environment variables
-			for k, v := range tt.args.envVars {
-				t.Setenv(k, v)
-			}
-
-			got, err := NewConfig(tt.args.v(), tt.args.f)
-
-			switch tt.wantErr {
-			case true:
-				assert.Error(t, err)
-			case false:
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got.KubeconfigPath)
 			}
 		})
 	}

--- a/modules/shared/helm/helm.go
+++ b/modules/shared/helm/helm.go
@@ -389,10 +389,10 @@ func NewClient(options ...ClientOption) *Client {
 	return c
 }
 
-// Option Kubeconfig
-func WithKubeconfig(kubeconfig string) ClientOption {
+// Option KubeconfigPath
+func WithKubeconfigPath(kubeconfigPath string) ClientOption {
 	return func(c *Client) {
-		c.KubeConfig = kubeconfig
+		c.EnvSettings.KubeConfig = kubeconfigPath
 	}
 
 }

--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -96,7 +96,7 @@ func NewDesktopConnectionManager(options ...ConnectionManagerOption) (*DesktopCo
 	}
 
 	// Init KubeConfigWatcher
-	kfw, err := NewKubeConfigWatcher(cm.kubeconfigPath)
+	kfw, err := NewKubeConfigWatcher(cm.kubeConfig, cm.kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -698,11 +698,11 @@ func NewConnectionManager(env config.Environment, options ...ConnectionManagerOp
 type ConnectionManagerOption func(cm ConnectionManager)
 
 // WithKubeconfig sets kubeconfig file path
-func WithKubeconfig(kubeconfig string) ConnectionManagerOption {
+func WithKubeconfig(kubeConfig *api.Config) ConnectionManagerOption {
 	return func(cm ConnectionManager) {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
-			t.kubeconfigPath = kubeconfig
+			t.kubeConfig = kubeConfig
 		case *InClusterConnectionManager:
 			break
 		}
@@ -715,6 +715,18 @@ func WithLazyConnect(isLazy bool) ConnectionManagerOption {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
 			t.isLazy = isLazy
+		case *InClusterConnectionManager:
+			break
+		}
+	}
+}
+
+// WithKubeconfigPath sets kubeconfig file path
+func WithKubeConfigPath(kubeConfigPath string) ConnectionManagerOption {
+	return func(cm ConnectionManager) {
+		switch t := cm.(type) {
+		case *DesktopConnectionManager:
+			t.kubeconfigPath = kubeConfigPath
 		case *InClusterConnectionManager:
 			break
 		}

--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -60,8 +60,8 @@ type ConnectionManager interface {
 // Represents DesktopConnectionManager
 type DesktopConnectionManager struct {
 	KubeConfigWatcher *KubeConfigWatcher
-	kubeConfig        *api.Config
 	kubeconfigPath    string
+	kubeConfig        *api.Config
 	isLazy            bool
 	authorizer        DesktopAuthorizer
 	rcCache           map[string]*rest.Config
@@ -96,7 +96,7 @@ func NewDesktopConnectionManager(options ...ConnectionManagerOption) (*DesktopCo
 	}
 
 	// Init KubeConfigWatcher
-	kfw, err := NewKubeConfigWatcher(cm.kubeConfig, cm.kubeconfigPath)
+	kfw, err := NewKubeConfigWatcher(cm.kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -697,12 +697,12 @@ func NewConnectionManager(env config.Environment, options ...ConnectionManagerOp
 // Represents variadic option type for ConnectionManager
 type ConnectionManagerOption func(cm ConnectionManager)
 
-// WithKubeconfig sets kubeconfig file path
-func WithKubeconfig(kubeConfig *api.Config) ConnectionManagerOption {
+// WithKubeconfigPath sets kubeconfig file path
+func WithKubeconfigPath(kubeconfigPath string) ConnectionManagerOption {
 	return func(cm ConnectionManager) {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
-			t.kubeConfig = kubeConfig
+			t.kubeconfigPath = kubeconfigPath
 		case *InClusterConnectionManager:
 			break
 		}
@@ -715,18 +715,6 @@ func WithLazyConnect(isLazy bool) ConnectionManagerOption {
 		switch t := cm.(type) {
 		case *DesktopConnectionManager:
 			t.isLazy = isLazy
-		case *InClusterConnectionManager:
-			break
-		}
-	}
-}
-
-// WithKubeconfigPath sets kubeconfig file path
-func WithKubeConfigPath(kubeConfigPath string) ConnectionManagerOption {
-	return func(cm ConnectionManager) {
-		switch t := cm.(type) {
-		case *DesktopConnectionManager:
-			t.kubeconfigPath = kubeConfigPath
 		case *InClusterConnectionManager:
 			break
 		}

--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -15,9 +15,6 @@
 package k8shelpers
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 
 	evbus "github.com/asaskevich/EventBus"
@@ -39,29 +36,7 @@ type KubeConfigWatcher struct {
 }
 
 // Creates new KubeConfigWatcher instance
-func NewKubeConfigWatcher(kubeconfigPath string) (*KubeConfigWatcher, error) {
-	// Initialize kube config
-	// TODO: Handle missing kube config files more gracefully
-	var kubeConfig *api.Config
-	var err error
-
-	if kubeconfigPath == "" {
-		kubeconfigPath = clientcmd.RecommendedHomeFile
-	} else if strings.HasPrefix(kubeconfigPath, HOMEPATH_TILDE) {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			zlog.Error().Msg("Kubeconfig path is corrupted. Please provide a valid path")
-			return nil, err
-		}
-		kubeconfigPath = filepath.Join(homeDir, kubeconfigPath[2:])
-	}
-
-	kubeConfig, err = clientcmd.LoadFromFile(kubeconfigPath)
-
-	if err != nil {
-		zlog.Error().Msg("Kubeconfig is corrupted or missing. Please provide a valid kubeconfig.")
-		return nil, err
-	}
+func NewKubeConfigWatcher(kubeConfig *api.Config, kubeConfigPath string) (*KubeConfigWatcher, error) {
 
 	// Initialize watcher
 	watcher, err := fsnotify.NewWatcher()
@@ -69,14 +44,15 @@ func NewKubeConfigWatcher(kubeconfigPath string) (*KubeConfigWatcher, error) {
 		return nil, err
 	}
 
-	err = watcher.Add(kubeconfigPath)
+	// watch the kubeconfig path
+	err = watcher.Add(kubeConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize
 	w := &KubeConfigWatcher{
-		kubeconfigPath: kubeconfigPath,
+		kubeconfigPath: kubeConfigPath,
 		kubeConfig:     kubeConfig,
 		watcher:        watcher,
 		eventbus:       evbus.New(),
@@ -138,7 +114,7 @@ func (w *KubeConfigWatcher) start() {
 			case fsEv.Op&fsnotify.Create == fsnotify.Create:
 				// Load config
 				w.mu.Lock()
-				kubeConfig, err := clientcmd.LoadFromFile(w.kubeconfigPath)
+				kubeConfig, err := clientcmd.LoadFromFile(fsEv.Name)
 				if err != nil {
 					w.mu.Unlock()
 					zlog.Error().Err(err).Caller().Send()
@@ -153,7 +129,7 @@ func (w *KubeConfigWatcher) start() {
 				// Load config
 				w.mu.Lock()
 				oldConfig := w.kubeConfig
-				newConfig, err := clientcmd.LoadFromFile(w.kubeconfigPath)
+				newConfig, err := clientcmd.LoadFromFile(fsEv.Name)
 				if err != nil {
 					w.mu.Unlock()
 					zlog.Error().Err(err).Caller().Send()

--- a/modules/shared/k8shelpers/kube-config-watcher_test.go
+++ b/modules/shared/k8shelpers/kube-config-watcher_test.go
@@ -79,7 +79,7 @@ func TestKubeConfigWatcherGet(t *testing.T) {
 	}
 
 	// Initialize watcher
-	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	watcher, err := NewKubeConfigWatcher(cfgExpected, kubeconfigPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestKubeConfigWatcherSubscribeModified(t *testing.T) {
 	}
 
 	// Initialize watcher
-	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	watcher, err := NewKubeConfigWatcher(cfgOrig, kubeconfigPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestKubeConfigWatcherSubscribeDeleted(t *testing.T) {
 	}
 
 	// Initialize watcher
-	watcher, err := NewKubeConfigWatcher(kubeconfigPath)
+	watcher, err := NewKubeConfigWatcher(cfgOrig, kubeconfigPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #225

## Summary

This PR reverts to @bavarianbidi original strategy to add support for KUBECONFIG env var by utilitzing the Kubernetes clientcmd library at config generation time, and in the process solves an uninitialized kube config bug in the previous commit. As where in the previous commit, we were doing `--kubeconfig` flag and `KUBECONFIG` env handling in the command loop, this PR offloads the loading logic to the Kubernetes clientcmd library at the time the kube config object is needed.

## Changes

- Removes use of default value for `--kubeconfig` value (now default is "")
- Switches to use of `kubeconfigPath` and `WithKubeconfigPath()` where appropriate to avoid confusion with kube config object instances
- Command loops pass through value of `--kubeconfig` to lower level code that initializes kube config objects when needed
- Modifies CLI `NewTunnel()` method (modules/cli/internal/tunnel/tunnel.go) to use Kubernetes clientcmd library to initialize config so `KUBECONFIG` env var is handled automatically
- Modifies `KubeConfigWatcher` to use Kubernetes clientcmd library to obtain list of config files from `--kubeconfig` value and `KUBECONFIG` env var but currently only utilizes the first file rather than all the files
- Temporarily disables flaky `KubeConfigWatcher` tests
- Whitelists "@swc/core", "esbuild" in pnpm build instructions to avoid unrelated dashboard interactive build issue

Notes:
- We need to add support for multiple files to `KubeConfigWatcher` in a followup PR
- We need to add back `KubeConfigWatcher` async tests and fix flakiness issue

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
