### PR TITLE
🎣 Bugfixes and improvements to publish-winget and issues workflows

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,8 +1,13 @@
-name: Add all issues to project
+name: Add issues to project
+
+permissions:
+  contents: read
+
 on:
   issues:
     types:
       - opened
+
 jobs:
   add-to-project:
     name: Add issue to project
@@ -11,4 +16,4 @@ jobs:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/kubetail-org/projects/1
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADD_ISSUES_TO_PROJECT_TOKEN }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,5 +1,8 @@
 name: publish-winget
 
+permissions:
+  contents: read
+
 on:
   release:
     types:


### PR DESCRIPTION
Fixes: 
https://github.com/kubetail-org/kubetail/security/code-scanning/33
https://github.com/kubetail-org/kubetail/security/code-scanning/34 

## Summary

This PR adds explicit repo-level permissions to the actions as recommended by dependabot and replaces the use of GITHUB_TOKEN which only grants repo-level permissions with a new GitHub Personal Access Token called ADD_ISSUES_TO_PROJECT_TOKEN with required repo and org level permissions.

## Changes

- Adds explicit repo content permissions to issues and publish-winget actions
- Renames issues.yml to add-issues-to-project.yml
- Replaces GITHUB_TOKEN in add-issues-to-project with new ADD_ISSUES_TO_PROJECT_TOKEN that grants required repo-level and org-level permissions

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
