### PR TITLE
Add environment control widget for developers, visible only in "dev" mode

### DIFF
--- a/dashboard-ui/src/components/widgets/EnvironmentControl.tsx
+++ b/dashboard-ui/src/components/widgets/EnvironmentControl.tsx
@@ -1,0 +1,106 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useSubscription } from "@apollo/client";
+import { Fragment, useEffect, useState } from "react";
+import {
+  RecoilRoot,
+  atom,
+  useRecoilValue,
+  useSetRecoilState,
+  type SetterOrUpdater,
+} from "recoil";
+import Form from "@kubetail/ui/elements/Form";
+import { useIsClusterAPIEnabled } from "@/lib/hooks";
+import Modal from "../elements/Modal";
+
+type EnvironmentControlWidgetProps = {
+  className?: string;
+};
+
+const EnvironmentControl = ({ className }: EnvironmentControlWidgetProps) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const [env, setEnv] = useState<string>(() => {
+    return localStorage.getItem("clusterAPIEnabled") || "";
+  });
+  const isClusterAPIEnabled = useIsClusterAPIEnabled(env);
+
+  /*const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(isClusterAPIEnabled);
+    const newEnv = e.target.value;
+    setEnv(newEnv);
+
+    localStorage.setItem("clusterAPIEnabled", newEnv);
+  };*/
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newEnv = e.target.value;
+    setEnv(newEnv);
+  };
+
+  useEffect(() => {
+    console.log("EnvironmentControl useEffect", env, isClusterAPIEnabled);
+    localStorage.setItem("clusterAPIEnabled", env);
+  }, [env]);
+
+  return (
+    <div>
+      <button
+        className={`text-xs text-chrome-500 hover:text-chrome-700 pr-3 ${className}`}
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Environment Control
+      </button>
+      <Modal
+        open={isDialogOpen}
+        onClose={() => setIsDialogOpen(false)}
+        className="!max-w-[550px]"
+      >
+        <Modal.Title className="flex items-center space-x-3">
+          <span>Environment control</span>
+        </Modal.Title>
+        <div className="mt-5 pb-8">
+          <Form.Group>
+            <Form.Label>
+              Switch between Kubernetes API and Kubetail API
+            </Form.Label>
+            <div className="pt-3 ">
+              <Form.Select
+                className={className}
+                value={env}
+                onChange={(ev) => {
+                  handleChange(ev);
+                }}
+              >
+                <Form.Option value="enabled">Kubetail api</Form.Option>
+                <Form.Option value="disabled">Kubernetes api</Form.Option>
+              </Form.Select>
+            </div>
+          </Form.Group>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+const EnvironmentControlWidgetWrapper = (
+  props: EnvironmentControlWidgetProps
+) => (
+  <RecoilRoot>
+    <EnvironmentControl {...props} />
+  </RecoilRoot>
+);
+
+export default EnvironmentControlWidgetWrapper;

--- a/dashboard-ui/src/components/widgets/EnvironmentControl.tsx
+++ b/dashboard-ui/src/components/widgets/EnvironmentControl.tsx
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useSubscription } from "@apollo/client";
-import { Fragment, useEffect, useState } from "react";
+import { useSubscription } from '@apollo/client';
+import { Fragment, useEffect, useState } from 'react';
 import {
   RecoilRoot,
   atom,
   useRecoilValue,
   useSetRecoilState,
   type SetterOrUpdater,
-} from "recoil";
-import Form from "@kubetail/ui/elements/Form";
-import { useIsClusterAPIEnabled } from "@/lib/hooks";
-import Modal from "../elements/Modal";
+} from 'recoil';
+import Form from '@kubetail/ui/elements/Form';
+import { useIsClusterAPIEnabled } from '@/lib/hooks';
+import Modal from '../elements/Modal';
 
 type EnvironmentControlWidgetProps = {
   className?: string;
@@ -33,7 +33,7 @@ const EnvironmentControl = ({ className }: EnvironmentControlWidgetProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const [env, setEnv] = useState<string>(() => {
-    return localStorage.getItem("clusterAPIEnabled") || "";
+    return localStorage.getItem('clusterAPIEnabled') || '';
   });
   const isClusterAPIEnabled = useIsClusterAPIEnabled(env);
 
@@ -51,8 +51,8 @@ const EnvironmentControl = ({ className }: EnvironmentControlWidgetProps) => {
   };
 
   useEffect(() => {
-    console.log("EnvironmentControl useEffect", env, isClusterAPIEnabled);
-    localStorage.setItem("clusterAPIEnabled", env);
+    console.log('EnvironmentControl useEffect', env, isClusterAPIEnabled);
+    localStorage.setItem('clusterAPIEnabled', env);
   }, [env]);
 
   return (

--- a/dashboard-ui/src/components/widgets/Footer.tsx
+++ b/dashboard-ui/src/components/widgets/Footer.tsx
@@ -16,6 +16,7 @@ import Form from '@kubetail/ui/elements/Form';
 
 import ServerStatus from '@/components/widgets/ServerStatus';
 import { useTheme, UserPreference } from '@/lib/theme';
+import EnvironmentControlWidgetWrapper from './EnvironmentControl';
 
 export default function Footer() {
   const { userPreference, setUserPreference } = useTheme();
@@ -36,6 +37,9 @@ export default function Footer() {
         <Form.Option value={UserPreference.Light}>light</Form.Option>
       </Form.Select>
       <ServerStatus />
+      {import.meta.env.MODE === "development" && (
+        <EnvironmentControlWidgetWrapper />
+      )}
     </div>
   );
 }

--- a/dashboard-ui/src/lib/hooks.ts
+++ b/dashboard-ui/src/lib/hooks.ts
@@ -437,10 +437,20 @@ export function useCounterQueryWithSubscription<
  */
 
 export function useIsClusterAPIEnabled(kubeContext: string | null) {
-  const status = useClusterAPIServerStatus(kubeContext || '');
+  const override = localStorage.getItem('clusterAPIEnabled');
+  if (override === 'enabled') return true;
+  if (override === 'disabled') return false;
+
+  const status = useClusterAPIServerStatus(kubeContext || "");
 
   // Return if running in cluster with ClusterAPI enabled
-  if (appConfig.environment === 'cluster') return appConfig.clusterAPIEnabled;
+  if (appConfig.environment === 'cluster') {
+    console.log(
+      '[ClusterAPI] Using appConfig default:',
+      appConfig.clusterAPIEnabled
+    );
+    return appConfig.clusterAPIEnabled;
+  }
 
   switch (status.status) {
     case Status.NotFound:


### PR DESCRIPTION
Fixes #326

## Summary

Created a widget on the footer that will allow developers to modify the environment they're developing in. Visible only on "dev". This will later be extended to add other options.

## Changes

Created a new component `EnvironmentControlWidgetWrapper`. And modified the `ClusterAPIEnabled` hook to take account for the changed made by the user on the UI.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

