### PR TITLE
🎣 Add worker to cache only after successful start in DesktopHealthMonitor

### DIFF
--- a/modules/dashboard/internal/cluster-api/health-monitor.go
+++ b/modules/dashboard/internal/cluster-api/health-monitor.go
@@ -169,13 +169,13 @@ func (hm *DesktopHealthMonitor) getOrCreateWorker(ctx context.Context, kubeConte
 			}
 		}
 
-		// Add to cache
-		hm.workerCache.Store(k, worker)
-
 		// Start background processes and wait for cache to sync
 		if err := worker.Start(ctx); err != nil {
 			return nil, err
 		}
+
+		// Add to cache
+		hm.workerCache.Store(k, worker)
 	}
 
 	return worker, nil


### PR DESCRIPTION
## Summary

Previously, we added the worker to the cache before starting it. If start failed, then non-working worker would still remain in cache, which could lead to returning a broken instance later. I don't think it is right behavior.

Now, we only store the worker in the cache after it has successfully started

## Changes

- Moved caching to occur only after successful start

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [ ] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
