### PR TITLE
Add typed SyncMap wrapper

### DIFF
--- a/modules/dashboard/internal/cluster-api/health-monitor.go
+++ b/modules/dashboard/internal/cluster-api/health-monitor.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
+	"github.com/kubetail-org/kubetail/modules/shared/util"
 )
 
 // Represents HealthStatus enum
@@ -68,7 +69,7 @@ func NewHealthMonitor(cfg *config.Config, cm k8shelpers.ConnectionManager) Healt
 // Represents DesktopHealthMonitor
 type DesktopHealthMonitor struct {
 	cm          k8shelpers.ConnectionManager
-	workerCache sync.Map
+	workerCache util.SyncMap[string, healthMonitorWorker]
 	contextMu   map[string]*sync.Mutex
 	mu          sync.Mutex
 }
@@ -77,7 +78,7 @@ type DesktopHealthMonitor struct {
 func NewDesktopHealthMonitor(cm k8shelpers.ConnectionManager) *DesktopHealthMonitor {
 	return &DesktopHealthMonitor{
 		cm:          cm,
-		workerCache: sync.Map{},
+		workerCache: util.SyncMap[string, healthMonitorWorker]{},
 		contextMu:   make(map[string]*sync.Mutex),
 	}
 }
@@ -85,12 +86,12 @@ func NewDesktopHealthMonitor(cm k8shelpers.ConnectionManager) *DesktopHealthMoni
 // Shutdown all managed monitors
 func (hm *DesktopHealthMonitor) Shutdown() {
 	var wg sync.WaitGroup
-	hm.workerCache.Range(func(key, value interface{}) bool {
+	hm.workerCache.Range(func(_ string, worker healthMonitorWorker) bool {
 		wg.Add(1)
-		go func(worker healthMonitorWorker) {
+		go func() {
 			defer wg.Done()
 			worker.Shutdown()
-		}(value.(healthMonitorWorker))
+		}()
 		return true
 	})
 	wg.Wait()
@@ -145,11 +146,8 @@ func (hm *DesktopHealthMonitor) getOrCreateWorker(ctx context.Context, kubeConte
 	k := fmt.Sprintf("%s::%s::%s", kubeContext, namespace, serviceName)
 
 	// Check cache
-	var worker healthMonitorWorker
-	value, ok := hm.workerCache.Load(k)
-	if ok {
-		worker = value.(healthMonitorWorker)
-	} else {
+	worker, ok := hm.workerCache.Load(k)
+	if !ok {
 		// Get clientset
 		clientset, err := hm.cm.GetOrCreateClientset(kubeContext)
 		if err != nil {

--- a/modules/shared/k8shelpers/authorizer_test.go
+++ b/modules/shared/k8shelpers/authorizer_test.go
@@ -17,10 +17,10 @@ package k8shelpers
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/kubetail-org/kubetail/modules/shared/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -252,14 +252,14 @@ func TestDesktopAuthorizer_IsAllowedInformer_CacheExpiry(t *testing.T) {
 
 	// Create authorizer and test
 	authorizer := &DefaultDesktopAuthorizer{
-		cache: sync.Map{},
+		cache: util.SyncMap[cacheKey, cacheValue]{},
 	}
 	err := authorizer.IsAllowedInformer(context.Background(), clientset, setNamespace, setGVR)
 	assert.NoError(t, err)
 
 	// Check call and cache
 	var count int
-	authorizer.cache.Range(func(key, value any) bool {
+	authorizer.cache.Range(func(key cacheKey, value cacheValue) bool {
 		count++
 		return true
 	})
@@ -273,10 +273,9 @@ func TestDesktopAuthorizer_IsAllowedInformer_CacheExpiry(t *testing.T) {
 	assert.Equal(t, 2, len(capturedSARs))
 
 	// Expire cache and try again
-	authorizer.cache.Range(func(key, value any) bool {
-		v := value.(cacheValue)
-		v.expiration = time.Now().Add(-1 * time.Minute)
-		authorizer.cache.Store(key, v) // Store the updated value back in the map
+	authorizer.cache.Range(func(key cacheKey, value cacheValue) bool {
+		value.expiration = time.Now().Add(-1 * time.Minute)
+		authorizer.cache.Store(key, value) // Store the updated value back in the map
 		return true
 	})
 
@@ -335,7 +334,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_CorrectBearerToken(t *testing.T) 
 	// Create authorizer with mock
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -408,7 +407,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_ListPermissionDenied(t *testing.T
 	// Create authorizer with mock and test
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -472,7 +471,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_WatchPermissionDenied(t *testing.
 	// Create authorizer with mock and test
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -521,7 +520,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_Error(t *testing.T) {
 	// Create authorizer with mock and test
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -573,7 +572,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_CacheExpiry(t *testing.T) {
 	// Create authorizer with mock and test
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -586,7 +585,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_CacheExpiry(t *testing.T) {
 
 	// Check call and cache
 	var count int
-	authorizer.cache.Range(func(key, value any) bool {
+	authorizer.cache.Range(func(key string, value cacheValue) bool {
 		count++
 		return true
 	})
@@ -606,10 +605,9 @@ func TestInClusterAuthorizer_IsAllowedInformer_CacheExpiry(t *testing.T) {
 	mockClientsetInitializer.AssertNumberOfCalls(t, "newClientset", 2)
 
 	// Expire cache and try again
-	authorizer.cache.Range(func(key, value any) bool {
-		v := value.(cacheValue)
-		v.expiration = time.Now().Add(-1 * time.Minute)
-		authorizer.cache.Store(key, v) // Store the updated value back in the map
+	authorizer.cache.Range(func(key string, value cacheValue) bool {
+		value.expiration = time.Now().Add(-1 * time.Minute)
+		authorizer.cache.Store(key, value) // Store the updated value back in the map
 		return true
 	})
 
@@ -638,7 +636,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_ClientsetInitializerError(t *test
 	// Create authorizer with mock
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test
@@ -693,7 +691,7 @@ func TestInClusterAuthorizer_IsAllowedInformer_Success(t *testing.T) {
 	// Create authorizer with mock and test
 	authorizer := &DefaultInClusterAuthorizer{
 		clientsetInitializer: mockClientsetInitializer,
-		cache:                sync.Map{},
+		cache:                util.SyncMap[string, cacheValue]{},
 	}
 
 	// Use a dummy rest.Config for the test

--- a/modules/shared/util/syncmap.go
+++ b/modules/shared/util/syncmap.go
@@ -1,0 +1,87 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "sync"
+
+// SyncMap is a typed wrapper around sync.Map.
+// The zero value is ready for use.
+type SyncMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Load returns the value stored in the map for a key, or zero value if none.
+// The ok result indicates whether value was found in the map.
+func (m *SyncMap[K, V]) Load(key K) (V, bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// Store sets the value for a key.
+func (m *SyncMap[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+func (m *SyncMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	v, loaded := m.m.LoadOrStore(key, value)
+	if loaded {
+		return v.(V), true
+	}
+	return value, false
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous value if any.
+func (m *SyncMap[K, V]) LoadAndDelete(key K) (V, bool) {
+	v, loaded := m.m.LoadAndDelete(key)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// Delete deletes the value for a key.
+func (m *SyncMap[K, V]) Delete(key K) {
+	m.m.Delete(key)
+}
+
+// Swap swaps the value for a key and returns the previous value if any.
+func (m *SyncMap[K, V]) Swap(key K, value V) (V, bool) {
+	v, loaded := m.m.Swap(key, value)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// CompareAndSwap swaps the old and new values if the value stored for the key equals old.
+func (m *SyncMap[K, V]) CompareAndSwap(key K, old, new V) bool {
+	return m.m.CompareAndSwap(key, old, new)
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+func (m *SyncMap[K, V]) Range(f func(key K, value V) bool) {
+	m.m.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}

--- a/modules/shared/util/syncmap_test.go
+++ b/modules/shared/util/syncmap_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "testing"
+
+func TestSyncMapBasic(t *testing.T) {
+	var m SyncMap[string, int]
+
+	// Store and Load
+	m.Store("a", 1)
+	v, ok := m.Load("a")
+	if !ok || v != 1 {
+		t.Fatalf("expected value 1, got %v ok=%v", v, ok)
+	}
+
+	// LoadOrStore existing
+	actual, loaded := m.LoadOrStore("a", 2)
+	if !loaded || actual != 1 {
+		t.Fatalf("LoadOrStore did not return existing value")
+	}
+
+	// Swap
+	prev, loaded := m.Swap("a", 3)
+	if !loaded || prev != 1 {
+		t.Fatalf("Swap expected 1 got %v", prev)
+	}
+
+	// CompareAndSwap success
+	if !m.CompareAndSwap("a", 3, 4) {
+		t.Fatalf("CompareAndSwap should succeed")
+	}
+	v, _ = m.Load("a")
+	if v != 4 {
+		t.Fatalf("expected 4 got %v", v)
+	}
+
+	// Range and Delete
+	count := 0
+	m.Range(func(k string, v int) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("expected range count 1 got %d", count)
+	}
+
+	m.Delete("a")
+	_, ok = m.Load("a")
+	if ok {
+		t.Fatalf("expected key deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- create a typed `SyncMap` utility
- refactor `HealthMonitor` and authorizers to use the typed map
- update tests
- address feedback on worker goroutines and cache lookup
- add missing license headers

## Related Issues
- Closes #363

## Testing
- `cd modules && test -z $(gofmt -l .)`
- `go vet github.com/kubetail-org/kubetail/modules/...`
- `go test -race github.com/kubetail-org/kubetail/modules/...` *(fails: Codex couldn't run certain commands due to environnment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684052155ae8832397fd7e09d28e2049