### PR TITLE
🎣 Upgrade Rust docker build images to 1.87.0

### DIFF
--- a/build/package/Dockerfile.cluster-agent
+++ b/build/package/Dockerfile.cluster-agent
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.86.0-slim AS rustbuilder
+FROM rust:1.87.0-slim AS rustbuilder
 
 WORKDIR /work
 

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -1,4 +1,4 @@
-FROM rust:1.86.0-slim AS rustbuilder
+FROM rust:1.87.0-slim AS rustbuilder
 
 WORKDIR /work
 


### PR DESCRIPTION
Fixes #377 

## Summary

Upgrade rust images to 1.87.0

## Changes

- Upgrade dev docker rust builder to 1.87.0
- Upgrade production docker rust builder to 1.87.0

------
https://chatgpt.com/codex/tasks/task_e_68409e0c270883239afe25ac59a359d7