### PR TITLE
🎣 Set Rust version in CI workflow to 1.87.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Enable rustfmt
+        run: rustup component add --toolchain 1.87.0-x86_64-unknown-linux-gnu rustfmt
       - name: Run linter
         working-directory: ./crates/rgkl
         run: |
@@ -39,11 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Enable rustfmt
+        run: rustup component add --toolchain 1.87.0-x86_64-unknown-linux-gnu clippy
       - name: Run code vetter
         working-directory: ./crates/rgkl
         run: |

--- a/crates/rust-toolchain.toml
+++ b/crates/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.87.0"


### PR DESCRIPTION
## Summary

This PR removes the use of `action-rs/toolchain` action which is has been archived and sets the Rust toolchain version to 1.87.0 using a `rust-toolchain.toml` file.

## Changes

- Replace use of `action-rs/toolchain` with explict command to install Rust toolchain components using `rustup`
- Add `rust-toolchain.toml` file to `crates`/ directory

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
