### PR TITLE
🎣 Remove rust-toolchain.toml

### DIFF
--- a/crates/rust-toolchain.toml
+++ b/crates/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.87.0"


### PR DESCRIPTION
## Summary

Remove rust-toolchain.toml to give more flexibility to developers which Rust toolchain they want to use locally.

## Changes

* Remove crates/rust-toolchain.toml

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
