### PR TITLE
🐋 feat: add Rust crates, Dashboard and Go modules lint/vet CI targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ crates-test:
 	@echo "Testing Rust crates..."
 	@cd $(CRATES_DIR) && cargo test
 
+crates-all: crates-build crates-lint crates-vet crates-test
+	@echo "All Rust crate operations completed successfully."
+
 # Go (modules) targets
 modules-lint:
 	@echo "Linting Go modules..."
@@ -113,6 +116,9 @@ modules-vet:
 	@echo "Vetting Go modules..."
 	@cd $(MODULES_DIR) && go vet github.com/kubetail-org/kubetail/modules/...
 
+modules-all: modules-lint modules-test modules-vet
+	@echo "All Go module operations completed successfully."
+
 # Dashboard UI targets
 dashboard-ui-lint:
 	@echo "Linting dashboard UI..."
@@ -121,6 +127,9 @@ dashboard-ui-lint:
 dashboard-ui-test:
 	@echo "Testing dashboard UI..."
 	@cd $(DASHBOARD_UI_DIR) && pnpm install && pnpm test run
+
+dashboard-ui-all: dashboard-ui-lint dashboard-ui-test
+	@echo "All dashboard UI operations completed successfully."
 
 # Combined targets
 lint-all: crates-lint modules-lint dashboard-ui-lint
@@ -152,11 +161,14 @@ help:
 	@echo "  crates-lint           - Lint Rust crates"
 	@echo "  crates-vet            - Vet Rust crates"
 	@echo "  crates-test           - Test Rust crates"
+	@echo "  crates-all            - Run all Rust crate operations"
 	@echo "  modules-lint          - Lint Go modules"
 	@echo "  modules-test          - Test Go modules"
 	@echo "  modules-vet           - Vet Go modules"
+	@echo "  modules-all           - Run all Go module operations"
 	@echo "  dashboard-ui-lint     - Lint dashboard UI"
 	@echo "  dashboard-ui-test     - Test dashboard UI"
+	@echo "  dashboard-ui-all      - Run all dashboard UI operations"
 	@echo "  lint-all              - Run all lint checks"
 	@echo "  test-all              - Run all tests"
 	@echo "  vet-all               - Run all vetting"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CLI_BINARY := kubetail
 
 DASHBOARD_UI_DIR := ./dashboard-ui
 DASHBOARD_SERVER_DIR := ./modules/dashboard
+CRATES_DIR := ./crates/rgkl
+MODULES_DIR := ./modules
 
 # Detect the operating system
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -25,6 +27,10 @@ else ifeq ($(ARCH),aarch64)
 else
   GOARCH := $(ARCH)
 endif
+
+# Rust toolchain detection
+RUST_VERSION := $(shell rustc --version | cut -d' ' -f2)
+RUST_ARCH := $(shell rustc -vV | grep host | cut -d' ' -f2)
 
 # Allow version override via CLI argument (default to "dev")
 VERSION ?= dev
@@ -75,6 +81,60 @@ build: build-dashboard-ui build-cli
 # Build the CLI
 build-all: build-dashboard-ui build-cli-all
 
+# Rust (crates) targets
+crates-build:
+	@echo "Building Rust crates..."
+	@cd $(CRATES_DIR) && cargo build --release
+
+crates-lint:
+	@echo "Linting Rust crates with architecture $(RUST_ARCH)..."
+	@rustup component add rustfmt
+	@cd $(CRATES_DIR) && cargo fmt --all -- --check
+
+crates-vet:
+	@echo "Vetting Rust crates with architecture $(RUST_ARCH)..."
+	@rustup component add clippy
+	@cd $(CRATES_DIR) && cargo clippy --all -- -D warnings
+
+crates-test:
+	@echo "Testing Rust crates..."
+	@cd $(CRATES_DIR) && cargo test
+
+# Go (modules) targets
+modules-lint:
+	@echo "Linting Go modules..."
+	@cd $(MODULES_DIR) && test -z $$(gofmt -l .)
+
+modules-test:
+	@echo "Testing Go modules..."
+	@cd $(MODULES_DIR) && go test -race github.com/kubetail-org/kubetail/modules/...
+
+modules-vet:
+	@echo "Vetting Go modules..."
+	@cd $(MODULES_DIR) && go vet github.com/kubetail-org/kubetail/modules/...
+
+# Dashboard UI targets
+dashboard-ui-lint:
+	@echo "Linting dashboard UI..."
+	@cd $(DASHBOARD_UI_DIR) && pnpm install && pnpm lint
+
+dashboard-ui-test:
+	@echo "Testing dashboard UI..."
+	@cd $(DASHBOARD_UI_DIR) && pnpm install && pnpm test run
+
+# Combined targets
+lint-all: crates-lint modules-lint dashboard-ui-lint
+	@echo "All linting completed successfully."
+
+test-all: crates-test modules-test dashboard-ui-test
+	@echo "All tests completed successfully."
+
+vet-all: crates-vet modules-vet
+	@echo "All vetting completed successfully."
+
+ci-checks: lint-all test-all vet-all
+	@echo "All CI checks completed successfully."
+
 ## Clean the build output
 clean:
 	@echo "Cleaning up..."
@@ -86,5 +146,19 @@ help:
 	@echo "Makefile targets:"
 	@echo "  all                   - Build the kubetail CLI"
 	@echo "  build                 - Compile the kubetail CLI for the current OS"
+	@echo "  build-all             - Compile the kubetail CLI for all platforms"
 	@echo "  clean                 - Remove the built binaries"
+	@echo "  crates-build          - Build Rust crates"
+	@echo "  crates-lint           - Lint Rust crates"
+	@echo "  crates-vet            - Vet Rust crates"
+	@echo "  crates-test           - Test Rust crates"
+	@echo "  modules-lint          - Lint Go modules"
+	@echo "  modules-test          - Test Go modules"
+	@echo "  modules-vet           - Vet Go modules"
+	@echo "  dashboard-ui-lint     - Lint dashboard UI"
+	@echo "  dashboard-ui-test     - Test dashboard UI"
+	@echo "  lint-all              - Run all lint checks"
+	@echo "  test-all              - Run all tests"
+	@echo "  vet-all               - Run all vetting"
+	@echo "  ci-checks             - Run all CI checks (lint, test, vet)"
 	@echo "  help                  - Show this help message"

--- a/crates/rgkl/README.md
+++ b/crates/rgkl/README.md
@@ -80,10 +80,29 @@ cargo run -- stream-forward ./pod.log --grep "panic" --follow-from end
 
 ### Run Tests
 
-Run all unit and integration tests:
+Run all unit and integration tests directly with Cargo:
 
 ```bash
 cargo test
+```
+
+Using the Makefile from the project root:
+
+```bash
+# Run all Rust crate tests
+make crates-test
+
+# Run linting for Rust code
+make crates-lint
+
+# Run code vetting with Clippy
+make crates-vet
+```
+
+You can also run all Rust checks at once with:
+
+```bash
+make crates-all
 ```
 
 Test coverage includes:

--- a/dashboard-ui/README.md
+++ b/dashboard-ui/README.md
@@ -22,12 +22,34 @@ This project uses [vitest](https://vitest.dev/) for testing. To run the test sui
 pnpm test
 ```
 
+Using the Makefile from the project root:
+
+```console
+# Run dashboard UI tests
+make dashboard-ui-test
+```
+
 ## Lint
 
 This project uses TypeScript and enforces the [Airbnb JavaScript styleguide](https://github.com/airbnb/javascript) using eslint. To run the linter:
 
 ```sh
 pnpm lint
+```
+
+Using the Makefile from the project root:
+
+```console
+# Run dashboard UI linting
+make dashboard-ui-lint
+```
+
+## Combined Operations
+
+To run all dashboard UI tests and linting in one command, use:
+
+```console
+make dashboard-ui-all
 ```
 
 ## Build
@@ -39,3 +61,10 @@ pnpm build
 ```
 
 This will place the static assets in the `dist` directory.
+
+Using the Makefile from the project root:
+
+```console
+# Build the dashboard UI
+make build-dashboard-ui
+```

--- a/modules/README.md
+++ b/modules/README.md
@@ -14,7 +14,9 @@ This workspace contains the following modules:
 
 Please view the README in each directory for more details. 
 
-## Run code generators
+## Development Commands
+
+### Run code generators
 
 First install the dependencies:
 
@@ -28,10 +30,26 @@ Next, run the code generators:
 go generate github.com/kubetail-org/kubetail/modules/...
 ```
 
-## Run tests
+### Run tests
 
-To run the tests in all the modules:
-
+Using the Go toolchain directly:
 ```console
 go test github.com/kubetail-org/kubetail/modules/...
+```
+
+Using the Makefile:
+```console
+# Run tests for all Go modules
+make modules-test
+
+# Run linter for all Go modules
+make modules-lint
+
+# Run code vetting for all Go modules
+make modules-vet
+```
+
+You can also run all Go module checks at once with:
+```console
+make modules-all
 ```

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -72,8 +72,25 @@ go generate ./...
 
 ## Test
 
-To run the test suite execute this command:
+To run the test suite directly:
 
 ```console
 go test ./...
+```
+
+Using the Makefile from the project root:
+
+```console
+# Run tests for all modules including dashboard
+make dashboard-ui-test
+
+# Run linter
+make dashboard-ui-lint
+
+
+```
+
+You can also run all Dashboard checks at once with:
+```console
+make dashboard-ui-all
 ```

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -82,15 +82,17 @@ Using the Makefile from the project root:
 
 ```console
 # Run tests for all modules including dashboard
-make dashboard-ui-test
+make modules-test
 
 # Run linter
-make dashboard-ui-lint
+make modules-lint
+
+# Run code vetting
+make modules-vet
 
 
 ```
-
 You can also run all Dashboard checks at once with:
 ```console
-make dashboard-ui-all
+make modules-all
 ```


### PR DESCRIPTION
- 🐋 New feature

Fixes https://github.com/kubetail-org/kubetail/issues/401

## Summary

Add targets for linting, vetting, and testing for all components (Rust crates, Go modules, and dashboard UI) based on the CI workflow to Makefile.

## Changes

### Makefile build system enhancements

* Added new Rust-related targets (`crates-build`, `crates-lint`, `crates-vet`, `crates-test`) and Go-related targets (`modules-lint`, `modules-test`, `modules-vet`) to the `Makefile`, enabling streamlined builds, linting, testing, and vetting for both ecosystems. Also introduced combined targets like `lint-all`, `test-all`, and `ci-checks` for comprehensive CI checks.
* Introduced Rust toolchain detection (`RUST_VERSION` and `RUST_ARCH`) and added directory variables (`CRATES_DIR` and `MODULES_DIR`) for better modularity in the `Makefile`.


## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]
