### PR TITLE
🎣 fix(renovate): remove mergeConfidence

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "mergeConfidence:all-badges",
     ":dependencyDashboard",
     ":semanticCommits",
     ":semanticPrefixChore",
@@ -13,22 +12,13 @@
   "commitMessagePrefix": "chore: ",
   "packageRules": [
     {
-      "groupName": "high confidence: patch dependency updates",
       "description": "Automerge patch",
       "matchUpdateTypes": ["patch"],
-      "matchConfidence": ["very high", "high"],
       "automerge": true
     },
     {
-      "groupName": "high confidence: minor dependency updates",
-      "description": "No automerge for minor updates",
-      "matchUpdateTypes": ["minor"],
-      "matchConfidence": ["very high", "high"],
-      "automerge": false
-    },
-    {
-      "description": "No automerge for major updates",
-      "matchUpdateTypes": ["major"],
+      "description": "No automerge for minor and major updates",
+      "matchUpdateTypes": ["minor", "major"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
-->

Fixes #418 

## Summary

 - Removes mergeConfidence feature since it needs credentials and maybe is not free to use 

## Changes

- Just removes the mergeConfidence from the renovate.json

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
