### PR TITLE
🎣 Fixed regression bug from previous fsnotify upgrade

### DIFF
--- a/modules/cli/go.mod
+++ b/modules/cli/go.mod
@@ -8,6 +8,8 @@ replace github.com/kubetail-org/kubetail/modules/dashboard => ../dashboard
 
 replace github.com/kubetail-org/kubetail/modules/shared => ../shared
 
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
+
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-logr/logr v1.4.3

--- a/modules/cli/go.sum
+++ b/modules/cli/go.sum
@@ -105,8 +105,8 @@ github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7Dlme
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=

--- a/modules/cluster-agent/go.mod
+++ b/modules/cluster-agent/go.mod
@@ -6,6 +6,8 @@ toolchain go1.24.4
 
 replace github.com/kubetail-org/kubetail/modules/shared => ../shared
 
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
+
 require (
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/fsnotify/fsnotify v1.9.0

--- a/modules/cluster-agent/go.sum
+++ b/modules/cluster-agent/go.sum
@@ -10,8 +10,8 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=

--- a/modules/cluster-agent/internal/services/logmetadata/helpers.go
+++ b/modules/cluster-agent/internal/services/logmetadata/helpers.go
@@ -90,21 +90,21 @@ func newLogMetadataWatchEvent(event fsnotify.Event, nodeName string) (*clusterag
 	}
 
 	switch {
-	case event.Op&fsnotify.Create == fsnotify.Create:
+	case event.Has(fsnotify.Create):
 		watchEv.Type = "ADDED"
 		if fileInfo, err := newLogMetadataFileInfo(event.Name); err != nil {
 			return nil, err
 		} else {
 			watchEv.Object.FileInfo = fileInfo
 		}
-	case event.Op&fsnotify.Write == fsnotify.Write:
+	case event.Has(fsnotify.Write):
 		watchEv.Type = "MODIFIED"
 		if fileInfo, err := newLogMetadataFileInfo(event.Name); err != nil {
 			return nil, err
 		} else {
 			watchEv.Object.FileInfo = fileInfo
 		}
-	case event.Op&fsnotify.Remove == fsnotify.Remove:
+	case event.Has(fsnotify.Remove):
 		watchEv.Type = "DELETED"
 		watchEv.Object.FileInfo = &clusteragentpb.LogMetadataFileInfo{}
 	default:
@@ -245,7 +245,7 @@ func newContainerLogsWatcher(ctx context.Context, containerLogsDir string, names
 				}
 
 				// handle new files
-				if inEv.Op&fsnotify.Create == fsnotify.Create {
+				if inEv.Has(fsnotify.Create) {
 					if isInNamespace(inEv.Name, namespaces) {
 						addTarget(inEv.Name)
 					} else {

--- a/modules/cluster-agent/internal/services/logmetadata/helpers_test.go
+++ b/modules/cluster-agent/internal/services/logmetadata/helpers_test.go
@@ -192,7 +192,7 @@ func (suite *ContainerLogsWatcherTestSuite) TestCreate() {
 				defer wg.Done()
 				ev, ok := <-watcher.Events
 				suite.Require().True(ok)
-				suite.Equal(fsnotify.Create, ev.Op&fsnotify.Create)
+				suite.True(ev.Op.Has(fsnotify.Create))
 			}()
 
 			// create file
@@ -273,7 +273,7 @@ func (suite *ContainerLogsWatcherTestSuite) TestModify() {
 				defer wg.Done()
 				ev, ok := <-watcher.Events
 				suite.Require().True(ok)
-				suite.Equal(fsnotify.Write, ev.Op&fsnotify.Write)
+				suite.True(ev.Op.Has(fsnotify.Write))
 			}()
 
 			// modify file
@@ -363,7 +363,7 @@ func (suite *ContainerLogsWatcherTestSuite) TestDelete() {
 					lastEv = ev
 				}
 
-				suite.Equal(fsnotify.Remove, lastEv.Op&fsnotify.Remove)
+				suite.True(lastEv.Op.Has(fsnotify.Remove))
 			}()
 
 			// delete file

--- a/modules/cluster-api/go.mod
+++ b/modules/cluster-api/go.mod
@@ -8,6 +8,8 @@ replace github.com/kubetail-org/kubetail/modules/shared => ../shared
 
 replace github.com/gorilla/csrf => github.com/gorilla/csrf v1.7.2
 
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
+
 require (
 	github.com/99designs/gqlgen v0.17.74
 	github.com/gin-contrib/gzip v1.2.3

--- a/modules/cluster-api/go.sum
+++ b/modules/cluster-api/go.sum
@@ -32,8 +32,8 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=

--- a/modules/dashboard/go.mod
+++ b/modules/dashboard/go.mod
@@ -8,6 +8,8 @@ replace github.com/kubetail-org/kubetail/modules/shared => ../shared
 
 replace github.com/gorilla/csrf => github.com/gorilla/csrf v1.7.2
 
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
+
 require (
 	github.com/99designs/gqlgen v0.17.74
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef

--- a/modules/dashboard/go.sum
+++ b/modules/dashboard/go.sum
@@ -105,8 +105,8 @@ github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7Dlme
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=

--- a/modules/go.work.sum
+++ b/modules/go.work.sum
@@ -175,6 +175,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
@@ -224,8 +226,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
-github.com/gorilla/csrf v1.7.2 h1:oTUjx0vyf2T+wkrx09Trsev1TE+/EbDAeHtSTbtC2eI=
-github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=

--- a/modules/shared/go.mod
+++ b/modules/shared/go.mod
@@ -6,6 +6,8 @@ toolchain go1.24.4
 
 replace github.com/gorilla/csrf => github.com/gorilla/csrf v1.7.2
 
+replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
+
 require (
 	github.com/99designs/gqlgen v0.17.74
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/modules/shared/go.sum
+++ b/modules/shared/go.sum
@@ -97,8 +97,8 @@ github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7Dlme
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=


### PR DESCRIPTION
## Summary

This PR fixes fsnotify to to v1.8.0 to fix a regression bug causing test failures on macos. It also makes a small improvement to how we're checking fsnotify events.

## Changes

- Fix fsnotify to v1.8.0 in each go module
- Use fsnotify event `.Has()` method to check for events in cluster agent logmetadata helper.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
