### PR TITLE
🐋 Add dual port support to cluster-api server (HTTP + HTTPS)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -212,6 +212,7 @@ k8s_resource(
     'kubetail-cluster-api:clusterrolebinding',
     'kubetail-cluster-api:role',
     'kubetail-cluster-api:rolebinding',
+    'kubetail-cluster-api-tls:secret',
   ],
   resource_deps=['kubetail-shared'],
 )

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -12,11 +12,9 @@ allowed-namespaces: []
 ## dashboard ##
 #
 dashboard:
-
   ## http ##
   #
   http:
-
     ## enabled ##
     #
     # Default value: true
@@ -27,7 +25,7 @@ dashboard:
     #
     # Default value: __empty
     #
-    address: 
+    address:
 
     ## port ##
     #
@@ -38,7 +36,6 @@ dashboard:
   ## https ##
   #
   https:
-
     ## enabled ##
     #
     # Default value: false
@@ -49,7 +46,7 @@ dashboard:
     #
     # Default value: __empty
     #
-    address: 
+    address:
 
     ## port ##
     #
@@ -60,7 +57,6 @@ dashboard:
     ## tls ##
     #
     tls:
-  
       ## cert-file ##
       #
       # Path to tls certificate file
@@ -68,7 +64,7 @@ dashboard:
       # Default value: __empty__
       #
       cert-file:
-  
+
       ## key-file ##
       #
       # Path to tls key file
@@ -82,7 +78,7 @@ dashboard:
   # Sets the authentication method for the app
   #
   # Default value: auto
-  # 
+  #
   # One of:
   # - auto
   # - token
@@ -92,7 +88,7 @@ dashboard:
   ## base-path ##
   #
   # Sets the url path prefix (useful for deploying on a sub-path behind a reverse proxy)
-  # 
+  #
   # Default value: /
   #
   base-path: /
@@ -100,17 +96,17 @@ dashboard:
   ## cluster-api-endpoint (experimental) ##
   #
   # Service url for cluster-api
-  # 
+  #
   # Default value: http://kubetail-cluster-api
   #
   cluster-api-endpoint: http://kubetail-cluster-api
-  
+
   ## environment (experimental) ##
   #
   # Sets the authentication method for the app
   #
   # Default value: auto
-  # 
+  #
   # One of:
   # - desktop
   # - cluster
@@ -132,7 +128,6 @@ dashboard:
   ## csrf ##
   #
   csrf:
-
     ## enabled ##
     #
     # Default value: true
@@ -146,7 +141,7 @@ dashboard:
     # Default value: csrf_token
     #
     field-name: csrf_token
-  
+
     ## secret ##
     #
     # 32-byte long hash key
@@ -154,51 +149,50 @@ dashboard:
     # Default value: __empty__
     #
     secret:
-  
+
     ## cookie ##
     #
     # Set csrf cookie options
     #
     cookie:
-  
       ## name ##
       #
       # Default value: kubetail_dashboard_csrf
       #
       name: kubetail_dashboard_csrf
-  
+
       ## path ##
       #
       # Default value: /
       #
       path: /
-  
+
       ## domain ##
       #
       # Default value: __empty__
       #
-      domain: 
-  
+      domain:
+
       ## max-age ##
       #
       # Cookie max age (in seconds)
-      # 
+      #
       # Default value: 43200
       #
       max-age: 43200
-  
+
       ## secure ##
       #
       # Default value: false
       #
       secure: false
-  
+
       ## http-only ##
       #
       # Default value: true
       #
       http-only: true
-  
+
       ## same-site ##
       #
       # Default value: strict
@@ -209,17 +203,16 @@ dashboard:
       # - none
       #
       same-site: strict
-  
+
   ## logging ##
   #
   logging:
-  
     ## enabled ##
     #
     # Default value: true
     #
     enabled: true
-  
+
     ## level ##
     #
     # Default value: info
@@ -232,7 +225,7 @@ dashboard:
     # - disabled
     #
     level: info
-  
+
     ## format ##
     #
     # Default value: json
@@ -242,11 +235,10 @@ dashboard:
     # - pretty
     #
     format: json
-  
+
     ## access-log ##
     #
-    access-log:  
-  
+    access-log:
       ## enabled ##
       #
       # Enables web access logs for app
@@ -254,7 +246,7 @@ dashboard:
       # Default value: true
       #
       enabled: true
-  
+
       ## hide-health-checks ##
       #
       # Hides health checks from access log
@@ -262,11 +254,10 @@ dashboard:
       # Default: false
       #
       hide-health-checks: false
-  
+
   ## session ##
   #
   session:
-  
     ## secret ##
     #
     # 32-byte long hash key
@@ -274,51 +265,50 @@ dashboard:
     # Default value: __empty__
     #
     secret:
-  
+
     ## cookie ##
     #
     # Set session cookie options
     #
     cookie:
-  
       ## name ##
       #
       # Default value: csrf
       #
       name: session
-  
+
       ## path ##
       #
       # Default value: /
       #
       path: /
-  
+
       ## domain ##
       #
       # Default value: __empty__
       #
-      domain: 
-  
+      domain:
+
       ## max-age ##
       #
       # Cookie max age (in seconds)
-      # 
+      #
       # Default value: 1092000
       #
       max-age: 1092000
-  
+
       ## secure ##
       #
       # Default value: false
       #
       secure: false
-  
+
       ## http-only ##
       #
       # Default value: true
       #
       http-only: true
-  
+
       ## same-site ##
       #
       # Default value: lax
@@ -329,11 +319,10 @@ dashboard:
       # - none
       #
       same-site: lax
-  
+
   ## ui ##
   #
   ui:
-
     ## cluster-api-enabled (experimental) ##
     #
     # Enable features that use cluster-api
@@ -345,19 +334,71 @@ dashboard:
 ## cluster-api ##
 #
 cluster-api:
+  ## http ##
+  #
+  http:
+    ## enabled ##
+    #
+    # Default value: true
+    #
+    enabled: true
 
-  ## addr ##
+    ## address ##
+    #
+    # Default value: __empty
+    #
+    address:
+
+    ## port ##
+    #
+    # Default value: 8080
+    #
+    port: 8080
+
+  ## https ##
   #
-  # Sets the target ip and port to bind the server to
-  #
-  # Default value: ":80"
-  #
-  addr: :80
+  https:
+    ## enabled ##
+    #
+    # Default value: false
+    #
+    enabled: false
+
+    ## address ##
+    #
+    # Default value: __empty
+    #
+    address:
+
+    ## port ##
+    #
+    # Default value: 8443
+    #
+    port: 8443
+
+    ## tls ##
+    #
+    tls:
+      ## cert-file ##
+      #
+      # Path to tls certificate file
+      #
+      # Default value: __empty__
+      #
+      cert-file:
+
+      ## key-file ##
+      #
+      # Path to tls key file
+      #
+      # Default value: __empty__
+      #
+      key-file:
 
   ## base-path ##
   #
   # Sets the url path prefix (useful for deploying on a sub-path behind a reverse proxy)
-  # 
+  #
   # Default value: /
   #
   base-path: /
@@ -385,13 +426,12 @@ cluster-api:
   ## csrf ##
   #
   csrf:
-  
     ## enabled ##
     #
     # Default value: true
-    #
+
     enabled: true
-  
+
     ## field-name ##
     #
     # Name to use for token in forms
@@ -399,7 +439,7 @@ cluster-api:
     # Default value: csrf_token
     #
     field-name: csrf_token
-  
+
     ## secret ##
     #
     # 32-byte long hash key
@@ -407,51 +447,50 @@ cluster-api:
     # Default value: __empty__
     #
     secret:
-  
+
     ## cookie ##
     #
     # Set csrf cookie options
     #
     cookie:
-  
       ## name ##
       #
       # Default value: kubetail_api_csrf
       #
       name: kubetail_api_csrf
-  
+
       ## path ##
       #
       # Default value: /
       #
       path: /
-  
+
       ## domain ##
       #
       # Default value: __empty__
       #
-      domain: 
-  
+      domain:
+
       ## max-age ##
       #
       # Cookie max age (in seconds)
-      # 
+      #
       # Default value: 43200
       #
       max-age: 43200
-  
+
       ## secure ##
       #
       # Default value: false
       #
       secure: false
-  
+
       ## http-only ##
       #
       # Default value: true
       #
       http-only: true
-  
+
       ## same-site ##
       #
       # Default value: strict
@@ -466,13 +505,12 @@ cluster-api:
   ## logging ##
   #
   logging:
-  
     ## enabled ##
     #
     # Default value: true
     #
     enabled: true
-  
+
     ## level ##
     #
     # Default value: info
@@ -485,7 +523,7 @@ cluster-api:
     # - disabled
     #
     level: info
-  
+
     ## format ##
     #
     # Default value: json
@@ -495,11 +533,10 @@ cluster-api:
     # - pretty
     #
     format: json
-  
+
     ## access-log ##
     #
-    access-log:  
-  
+    access-log:
       ## enabled ##
       #
       # Enables web access logs for app
@@ -507,7 +544,7 @@ cluster-api:
       # Default value: true
       #
       enabled: true
-  
+
       ## hide-health-checks ##
       #
       # Hides health checks from access log
@@ -516,16 +553,6 @@ cluster-api:
       #
       hide-health-checks: false
 
-  ## tls ##
-  #
-  tls:
-  
-    ## enabled ##
-    #
-    # Default value: false
-    #
-    enabled: false
-  
     ## cert-file ##
     #
     # Path to tls certificate file
@@ -533,7 +560,7 @@ cluster-api:
     # Default value: __empty__
     #
     cert-file:
-  
+
     ## key-file ##
     #
     # Path to tls key file
@@ -545,7 +572,6 @@ cluster-api:
 ## cluster-agent ##
 #
 cluster-agent:
-
   ## addr ##
   #
   # Sets the target ip and port to bind the gRPC server to
@@ -557,13 +583,12 @@ cluster-agent:
   ## logging ##
   #
   logging:
-  
     ## enabled ##
     #
     # Default value: true
     #
     enabled: true
-  
+
     ## level ##
     #
     # Default value: info
@@ -576,7 +601,7 @@ cluster-agent:
     # - disabled
     #
     level: info
-  
+
     ## format ##
     #
     # Default value: json
@@ -590,13 +615,12 @@ cluster-agent:
   ## tls ##
   #
   tls:
-  
     ## enabled ##
     #
     # Default value: false
     #
     enabled: false
-  
+
     ## cert-file ##
     #
     # Path to tls certificate file
@@ -604,7 +628,7 @@ cluster-agent:
     # Default value: __empty__
     #
     cert-file:
-  
+
     ## key-file ##
     #
     # Path to tls key file

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -66,7 +66,17 @@ metadata:
 data:
   config.yaml: |
     cluster-api:
-      addr: :8080
+      http:
+        addr: 0.0.0.0
+        port: 8080
+        enabled: true
+      https:
+        addr: 0.0.0.0
+        port: 8443
+        enabled: true
+        tls:
+          cert-file: /etc/ssl/certs/server.crt
+          key-file: /etc/ssl/private/server.key
       base-path: /
       gin-mode: debug
       agent-dispatch-url: kubernetes://kubetail-cluster-agent:50051
@@ -88,10 +98,6 @@ data:
         access-log:
           enabled: true
           hide-health-checks: true
-      tls:
-        enabled: false
-        cert-file:
-        key-file:
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -131,15 +137,25 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: dashboard
 rules:
-- apiGroups: [""]
-  resources: [namespaces, nodes]
-  verbs: [get, list, watch]
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
-  verbs: [get, list, watch]
-- apiGroups: [authentication.k8s.io]
-  resources: [tokenreviews]
-  verbs: [create]
+  - apiGroups: [""]
+    resources: [namespaces, nodes]
+    verbs: [get, list, watch]
+  - apiGroups: ["", apps, batch]
+    resources:
+      [
+        cronjobs,
+        daemonsets,
+        deployments,
+        jobs,
+        pods,
+        pods/log,
+        replicasets,
+        statefulsets,
+      ]
+    verbs: [get, list, watch]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -153,9 +169,9 @@ roleRef:
   kind: ClusterRole
   name: kubetail-dashboard
 subjects:
-- kind: ServiceAccount
-  name: kubetail-dashboard
-  namespace: kubetail-system
+  - kind: ServiceAccount
+    name: kubetail-dashboard
+    namespace: kubetail-system
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -166,9 +182,9 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: dashboard
 rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [list, watch]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -183,14 +199,24 @@ roleRef:
   name: kubetail-dashboard
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: ServiceAccount
-  name: kubetail-dashboard
-  namespace: kubetail-system
+  - kind: ServiceAccount
+    name: kubetail-dashboard
+    namespace: kubetail-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: kubetail-dashboard-tls
+  namespace: kubetail-system
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVwRENDQW93Q0NRRE50V3ZJZk1LYWREQU5CZ2txaGtpRzl3MEJBUXNGQURBVU1SSXdFQVlEVlFRRERBbHMKYjJOaGJHaHZjM1F3SGhjTk1qVXdOakV6TWpFeE1EVXdXaGNOTWpZd05qRXpNakV4TURVd1dqQVVNUkl3RUFZRApWUVFEREFsc2IyTmhiR2h2YzNRd2dnSWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUNEd0F3Z2dJS0FvSUNBUUMwCmRIMkxsMFdIRkp3S2JudnhxaDRWVTMxTDFhcVAxRXJLbnpldGhPclVoSS9yVUJVWU9yYjhZUlF2QWphTmh3cm0KTGlRbWtMb01VYzBvRHJDaFF5N3lWbC9PakxHN1RoajNtZExNRmJTWi9PbUtLUGRUNUk3SXpFbWNXV0d5SUN5Mgp0MzRlbS9hM1lwQ1ZJaC9EekZPVFNwSDJydjQ4cHpTN0p4d3hiOEhpd3NiUERqdlA5S0REQ0dnTmRFZXI2K0M0ClV2Rm93azdhazVXOVZjdUlWUjhEM1Y3R2JNQUQxTlErRllvNnUreVN6cXRVaFFwWFJVZUNJREUybmlzU0QvZ3AKeGQ5RlMveU1raFl6WFdZQkFKZUgyQVM5UWFyYkhZS29yMEhYcmh2WFJOaU4xRWMwbjJ5YVA3bGwrQlhwZURBaQpUY3J4Nlp2WjNXNElKcjZqUE1menZ0UEFnaytGYVBJQ3h5TVN6UlVkWUpSazdwK2V2Q2pHeHhRK2RqbmVQeUgzCm5xdGlKTSt2TTJjMXpwZWFTV3lpVUVzTWlDTkNlQWpKSjBQU2lGYmlWOWIwcm15a1k2SGJtc1JLVWRVYjhyQkYKVnFTWEt2TEYvOG1PcUtCVHZITFA2enA5QnFQQ0FBSEhhNU1RVE0yRFRTUDRMMFkyQk9qWktRN3g4YUFCTXRydgpLSGpiOHVidlRidFZxMEY5VU1BNXNqZjRkT1pQMi9Uc25SM1M1aUNDMWhIWmMrYXQrb2M0U052eDNiRHB5KzQ1CkJhMTN2UGdVaGJidGJxdVJvbzYzazdhV09kTHF2NmZmejU4K1JFVmIxRXJ6UlhwcUtzM1ZJZnY4WWsrblZZb08KNk1JZWoySGx3MVp2dlU1VW9HYWxpNWZpa3NEUHc1aDlzYVZhZXFOWVl3SURBUUFCTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQ0FRQ3VMeU9rRVB1WE53dEtaUVhyWCs2S3htMWxKeEFWUXpHaVlDNERjMUdVcjA4VzRHZ09XcU9ICnYzekxNcTZ2MngxOGgwREJTU2VYazhCdzlnZVQ2ZW85aWhmOTF5bFlKRk9iTjltdHpZTnhDZ3E2eFhmb3EzMEMKeFNIV01zM0N0TkY2Q0QxYUpMMWM3NjlvSkJUZXpiVmFxWDVMbkpBdEJZV2gxRHc2S1EzS0tmWDJyaVd4TU02egpWNFVONkRpYkZmb093OWNnblg2T0RqTVBrakUrcmo4UW5XcUlzOGZHUmtWZlhvc0s4eG1XYWN5WFBFVmlTTXhTCnB0SlJkaHZxUEhwdXA0N0NBZnVWUFJ4L0NENHBhYzJkZ21NdGNkY1ErYVd6a0NBaXBzdThvWnVobnNJdWVRSDgKRmNDVUR2cVNKR0g3aVZGTkR2UmFjNjEvYWhTVHRUY1hqWFZSeUo0WGgwQXc5eHMwaFRMQjZsZmhRU2NadWhGdwo2bG9kRGpkczl1bi9MUlNaelRJQmUvSjFJcUxENWNKK2hoZHVIdWVXa29GUzY1RGkxWkNSWGNuNVFGTDAxVDFSCnJheEtVckp6TU1OUk93RWhuNWpGWnNJQUVzcWtQd2ppVUlobGZ5ays2dHVDYUk4SERwM0lmRmt0SnJud0YwVXcKRDErYWRjWjYrU0ZKVHYxSnZNS1JKelM0Q2dMbjd3YUMxNlh6THE5UjJWZER5S3Q4UDgrVVN5Z3JWeTIvK21NRQpIUjFoWFlPNW9tMjRBRGI2aUhmN0c0VjdHdXF5K0QxTnVvcDlFOTBrRWJmalRZbE1yS05NNXY2TmN5L1o2Y1NBCk1kM2docTJFL3NOcVVGWFdUYlJ0cFlhSXczbi8wVDF1UU56ejFUYm9QcTNuZE1NU1NSRDBadz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUpRZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQ1N3d2dna29BZ0VBQW9JQ0FRQzBkSDJMbDBXSEZKd0sKYm52eHFoNFZVMzFMMWFxUDFFcktuemV0aE9yVWhJL3JVQlVZT3JiOFlSUXZBamFOaHdybUxpUW1rTG9NVWMwbwpEckNoUXk3eVZsL09qTEc3VGhqM21kTE1GYlNaL09tS0tQZFQ1STdJekVtY1dXR3lJQ3kydDM0ZW0vYTNZcENWCkloL0R6Rk9UU3BIMnJ2NDhwelM3Snh3eGI4SGl3c2JQRGp2UDlLRERDR2dOZEVlcjYrQzRVdkZvd2s3YWs1VzkKVmN1SVZSOEQzVjdHYk1BRDFOUStGWW82dSt5U3pxdFVoUXBYUlVlQ0lERTJuaXNTRC9ncHhkOUZTL3lNa2hZegpYV1lCQUplSDJBUzlRYXJiSFlLb3IwSFhyaHZYUk5pTjFFYzBuMnlhUDdsbCtCWHBlREFpVGNyeDZadlozVzRJCkpyNmpQTWZ6dnRQQWdrK0ZhUElDeHlNU3pSVWRZSlJrN3ArZXZDakd4eFErZGpuZVB5SDNucXRpSk0rdk0yYzEKenBlYVNXeWlVRXNNaUNOQ2VBakpKMFBTaUZiaVY5YjBybXlrWTZIYm1zUktVZFViOHJCRlZxU1hLdkxGLzhtTwpxS0JUdkhMUDZ6cDlCcVBDQUFISGE1TVFUTTJEVFNQNEwwWTJCT2paS1E3eDhhQUJNdHJ2S0hqYjh1YnZUYnRWCnEwRjlVTUE1c2pmNGRPWlAyL1RzblIzUzVpQ0MxaEhaYythdCtvYzRTTnZ4M2JEcHkrNDVCYTEzdlBnVWhiYnQKYnF1Um9vNjNrN2FXT2RMcXY2ZmZ6NTgrUkVWYjFFcnpSWHBxS3MzVklmdjhZaytuVllvTzZNSWVqMkhsdzFadgp2VTVVb0dhbGk1Zmlrc0RQdzVoOXNhVmFlcU5ZWXdJREFRQUJBb0lDQUFoRmZxdXpWMkNGdFZGVkZ5RlFwdWhiClYxYnVpRTduY0RZeGJoL3FBOG1SK2ZiVFNPUS9iTHZNeDF3UVFlZmkxTUVRUkYvd0tsYitPT1VwSnpkOUdOM0sKejhGcitZbVlYdFNhbkdyMlk3emJOdWs2VDN2czhnNktMcVdZQXo1aTh5bTg1MjhIdnh0UXpVZkl0S1FJN1p2Rwp3MElIYTJma1VpcHg5SHpmbm9lQ1hoS0htSDVEdkVxMFMvQ3g3OGNWbk10V0lmS25WVzMzYmRtcjRSUnlzbVUrCjlHVXIvdkV1QkR5RVNEM0E5MnNUUmc4dHVmZWVHVlVCbkwvZ0tDRS8waVE0Q2EvbmQ4QUp3akxBaVRocWlvZVQKZzBRWmluZFl0dkI4ZUF3bTB1ZmZJLzM4U1BkRWgzbmFpZWorb2lKOWU5ZFdzWUs5TG9PaC9yVW84WHdTQVNnNwpQOHFRUEovTTQ1WS9ZVlNQVDhUTlBFYTllQW10aExUeHMxU2Fwam83Y2tBbFZIT2ppRENaUDRBWlhwSmZpOFR4CmdJRTNvcDZJbVNCRHB4enkxSTE2RXhqSy9RMWNneDdHWU1uV2dDTWxxT3NNVXVvU1BxUEMyazhySlFISm1UU3oKdWc5Ym41Ni9XdzJwU0VSQTlyVi9Sdld6Z3FUb3hFZW9KUlBETW0zSG04WjE2TTY1MnFCRjl4SVFCcWUwcnlldQpNVy82bHRJaFZickVTOE01cUpBZzZsT1dRVkp0clJ2NUtkaW1raFQyRE1aZm5Kd1dKTGJlNDNLSm44ak9BeVNHClRXMTl5d0phdGkwaTNXVUZ1R0pRZFlaOWFBdGFsZXpqWk9nVFgxMmJ5MGkyU3FBR2tLaG1HbzQyZGVzWjl2ZXUKRVN3MVlOS3I2M3dYaFluM2N3RmhBb0lCQVFEc2RRcWNjUVRybFpseU9WcFdFNHlRUFk5cXovSzI0eSszL1lPagpsd2pMZ2pzZkRIVEtmcFYvTS9ESzFJNmhpeTlPNjRuTjQwUE5lWXBxM2xsbHdycWVVTkU5b0x4d3ZoeDNUaEVzClRSRW04MmpPcTNRM0M1OGwzYzYxWWNrZnNzQmVGeE84bURjRGxVbjRScVdNSmZ6cHo4K21NdjRZNktRcWtXa2QKZVY3dHF2NGpEY3hNOHptOXlsQW55V2xqSXA2OTN5WkMzUERJa3dNcUJudldUQnNTQU03a3pDb2JVU0RLR1lRMQpaWDM1cHNSTkR3d0pwTmlOYWtvMkYvMmZXVXVnU2Y0c2ptNkd6UUxJNHFWMThxSm9FSjhiSDVQOHpLQ2t0VFhNClMyNjRRUFBZZW5mZHJvU25CTlVGUTQ0T1YrVGJnRVI1TlNyb2lLMksvWG1haWV1dkFvSUJBUUREWG81YWhOajkKUGlXVnQwYU9mNjVpZS8zdVJRSEtHTG1mbVJjSVFPMHJxRXNGaVFkQ3o0NHBkRU04ZGdkaWYrcUxwWC85RTM3bgpROVpjVWxVdFcrSk5hcCt2QlNUVk1TL1hlNmlzc1NYcHVzRis4VzdldFRabmpOQXdQeVRPOGZsUWtVQ1V5TjZXCnNEeis1UC96Mythdi9NOWJCdWs2cEhsNWZDM0thMmg4OVhtUjdETTJ0ZFF3NUdnYXdoSkh0R25BeDJ2dDlvL08KNExYTjQraCsrV2lwbkJPMmtXeHZ5SWR6V3Z6S2ZaSDlGUGhFZHo3UGpNR2cxanNwWVVNU05qcG1lWkNlY0hJdwpvTzFNdmZoVDArb1l1ZWd5cVN5Sjd0ZW9ha1cxeEExazl1a3BPSFI3eUpva2xzYWJEbVJvUzBuNVR2eWxqd3hyCmFSOVJ6dlBoWVVlTkFvSUJBUUMwcU5mcW53ODdUNWxsaEJ4WkY2YVZyZk1ka0xQSXQ5dUZuOVFyOFFGdk81a2cKSjh3enluTStOTmtNbjBvNmNyVTZmd3RTbXdqNnZKbmMvUFVnb3A4aXhteVh3Vzg0VklnN1B4SXYzdEgwQ0pWVApFZnhBOGtndURrSVlveFdmZWxzdmlFSTBIYmdxcksxUFcrcXdJWFlTemd2QTE4VDhFd01hNHU2RTdtNXc5K3dqCnJDOGp1OUdxQ0NFbHhPVVlNU05Idm03bE54bGdwYklOTWRiNzdEbmlqMnVEczltWDlXd3YvVDdkN1NWSzBQZTYKU0h6U0FYalMweHJRS1pSRlkxdzhvMHZuandzelF2K1ZyRlR1d09zRXgyNUlzdC9HampGT3BvVHNDZFlXUU1vTgo0OFFoUTIxbWpuS1RDd0pHUXpFLzQ4aHRNd29Oa0IvSHlkSlhHSGxSQW9JQkFDdVBKWVloSUpBMkR3TTJmZEMvCnZ3M09QMnVranlXVUphN2ozekxENXgxWXhJRlRiLzhCYjl6bVF5ZHoyV21vdzQ2bk04WWxWcUlSaWZYRGxhSXIKWG1XTVpGWU5lNHpkRHFHb3ZJN2tZR09nZEF2dG9KNmZJS1l0eXkwMnB1cE5JUjFKaFhDbTZKb0lhVkVibGNXMgpJaVVTNU5pU3plVjVUbXc3dDZudUVMbnJzVk5McW8rRU11OUR2Y0paaXVIWjQ4cExyRkMrTElvZnArbGo2eTZFClJVV3J1dWwxdXd1aFZqSHVFM2JDVUk1dzRubkJiSXV5QW1udDJmcjc2SXhpOHRwdU9FUmJKZHFaeHM3WmZFaVUKY3hsWU9lRXh2dkJ5QkR0VWxuNVVXL2dxNVFsL3dOam9mUld6V0V5eUJNa01JRTRwd2tMWGhobGNzdEwycFlHVwp3dkVDZ2dFQWN1bDZ5SGJUSzBLN2pSc1dOWDZTTGM5ZVJwTmxQWkxDUCtva2Z5eWFIekFWTTczYWRpUk92OWpOCitnYWJubTJEQmlIdW1VWDVrdnhqS0hOWHhZdExBSk10MTd6ck5kaVNVTkFEdXZEWVA0RXlMdllTQ0VvYm1STEkKZldXVFVYTk8xRjJpNDJpRTJldHRqaGw4Y1dadXloeER2dTBjcmF3ZW8zUHIwaTNWOHdmVzgvdVAvRDJyc0Q1bgozK2lPMFRKa1VOWTREeFBIQStIN0l4aE0zSTd0NS80NC9TS05QNFI0TlEyeFpnZ2JMbFRORFFsdlc1dHdCWEp5ClBnOTZMYUd0dW1ENjR1Tzl2KytSVzhtNmJ4bXFFUm1SbThOV2hiNHNqbzFGRnVreC9kMCszTCtONkNsTGtnc3EKWmxVdHdSVk5ScUpjYUw1N3EvT3k4dmRWTE1UYTR3PT0KLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubetail-cluster-api-tls
   namespace: kubetail-system
 type: kubernetes.io/tls
 data:
@@ -222,52 +248,52 @@ spec:
     spec:
       serviceAccountName: kubetail-dashboard
       containers:
-      - name: kubetail-dashboard
-        image: kubetail-dashboard
-        ports:
-        - name: http
-          protocol: TCP
-          containerPort: 8080
-        args:
-        - --config=/etc/kubetail/config.yaml
-        volumeMounts:
-        - name: config
-          mountPath: /etc/kubetail
-          readOnly: true
-        - name: tls
-          mountPath: /etc/ssl/certs/server.crt
-          subPath: tls.crt
-          readOnly: true
-        - name: tls
-          mountPath: /etc/ssl/private/server.key
-          subPath: tls.key
-          readOnly: true
-        readinessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /healthz
-            port: http
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /healthz
-            port: http
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        resources: {}
+        - name: kubetail-dashboard
+          image: kubetail-dashboard
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+          args:
+            - --config=/etc/kubetail/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubetail
+              readOnly: true
+            - name: tls
+              mountPath: /etc/ssl/certs/server.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: tls
+              mountPath: /etc/ssl/private/server.key
+              subPath: tls.key
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          resources: {}
       volumes:
-      - name: config
-        configMap:
-          name: kubetail-dashboard
-      - name: tls
-        secret:
-          secretName: kubetail-dashboard-tls
+        - name: config
+          configMap:
+            name: kubetail-dashboard
+        - name: tls
+          secret:
+            secretName: kubetail-dashboard-tls
 ---
 kind: Service
 apiVersion: v1
@@ -282,11 +308,11 @@ spec:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: dashboard
   ports:
-  - name: http
-    protocol: TCP
-    port: 8080
-    targetPort: http
-    appProtocol: http
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+      appProtocol: http
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -305,12 +331,13 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: cli
 rules:
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [get, list, watch]
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
-  verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
+  - apiGroups: ["", apps, batch]
+    resources:
+      [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
+    verbs: [get, list, watch]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -324,9 +351,9 @@ roleRef:
   kind: ClusterRole
   name: kubetail-cluster-api
 subjects:
-- kind: ServiceAccount
-  name: kubetail-cluster-api
-  namespace: kubetail-system
+  - kind: ServiceAccount
+    name: kubetail-cluster-api
+    namespace: kubetail-system
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -337,9 +364,9 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: cluster-api
 rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [list, watch]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -354,9 +381,9 @@ roleRef:
   name: kubetail-cluster-api
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: ServiceAccount
-  name: kubetail-cluster-api
-  namespace: kubetail-system
+  - kind: ServiceAccount
+    name: kubetail-cluster-api
+    namespace: kubetail-system
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -383,41 +410,52 @@ spec:
     spec:
       serviceAccountName: kubetail-cluster-api
       containers:
-      - name: kubetail-cluster-api
-        image: kubetail-cluster-api
-        ports:
-        - name: http
-          protocol: TCP
-          containerPort: 8080
-        args:
-        - --config=/etc/kubetail/config.yaml
-        volumeMounts:
-        - name: config
-          mountPath: /etc/kubetail
-          readOnly: true
-        readinessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /healthz
-            port: http
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /healthz
-            port: http
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        resources: {}
+        - name: kubetail-cluster-api
+          image: kubetail-cluster-api
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+          args:
+            - --config=/etc/kubetail/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubetail
+              readOnly: true
+            - name: tls
+              mountPath: /etc/ssl/certs/server.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: tls
+              mountPath: /etc/ssl/private/server.key
+              subPath: tls.key
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          resources: {}
       volumes:
-      - name: config
-        configMap:
-          name: kubetail-cluster-api
+        - name: config
+          configMap:
+            name: kubetail-cluster-api
+        - name: tls
+          secret:
+            secretName: kubetail-cluster-api-tls
 ---
 kind: Service
 apiVersion: v1
@@ -432,11 +470,11 @@ spec:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: cluster-api
   ports:
-  - name: http
-    protocol: TCP
-    port: 8080
-    targetPort: http
-    appProtocol: http
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+      appProtocol: http
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -468,53 +506,53 @@ spec:
     spec:
       serviceAccountName: kubetail-cluster-agent
       containers:
-      - name: kubetail-cluster-agent
-        image: kubetail-cluster-agent
-        ports:
-        - name: grpc
-          protocol: TCP
-          containerPort: 50051
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        args:
-        - --config=/etc/kubetail/config.yaml
-        volumeMounts:
-        - name: config
-          mountPath: /etc/kubetail
-          readOnly: true
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        readinessProbe:
-          grpc:
-            port: 50051
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        livenessProbe:
-          grpc:
-            port: 50051
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          periodSeconds: 5
-          failureThreshold: 3
-        resources: {}
+        - name: kubetail-cluster-agent
+          image: kubetail-cluster-agent
+          ports:
+            - name: grpc
+              protocol: TCP
+              containerPort: 50051
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          args:
+            - --config=/etc/kubetail/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubetail
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          readinessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+          resources: {}
       volumes:
-      - name: config
-        configMap:
-          name: kubetail-cluster-agent
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
+        - name: config
+          configMap:
+            name: kubetail-cluster-agent
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 kind: Service
 apiVersion: v1
@@ -544,11 +582,11 @@ spec:
       app.kubernetes.io/name: kubetail
       app.kubernetes.io/component: cluster-agent
   ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: kubetail
-          app.kubernetes.io/component: cluster-api
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kubetail
+              app.kubernetes.io/component: cluster-api
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -567,15 +605,16 @@ metadata:
     app.kubernetes.io/name: kubetail
     app.kubernetes.io/component: cli
 rules:
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [get, list, watch]
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
-  verbs: [get, list, watch]
-- apiGroups: [""]
-  resources: [pods/log]
-  verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
+  - apiGroups: ["", apps, batch]
+    resources:
+      [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [pods/log]
+    verbs: [list, watch]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -589,9 +628,9 @@ roleRef:
   kind: ClusterRole
   name: kubetail-cli
 subjects:
-- kind: ServiceAccount
-  name: kubetail-cli
-  namespace: kubetail-system
+  - kind: ServiceAccount
+    name: kubetail-cli
+    namespace: kubetail-system
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -604,9 +643,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubetail-testuser
 rules:
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, namespaces, nodes, pods, pods/log, replicasets, statefulsets]
-  verbs: [get, list, watch]
+  - apiGroups: ["", apps, batch]
+    resources:
+      [
+        cronjobs,
+        daemonsets,
+        deployments,
+        jobs,
+        namespaces,
+        nodes,
+        pods,
+        pods/log,
+        replicasets,
+        statefulsets,
+      ]
+    verbs: [get, list, watch]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -617,9 +668,9 @@ roleRef:
   kind: ClusterRole
   name: kubetail-testuser
 subjects:
-- kind: ServiceAccount
-  name: kubetail-testuser
-  namespace: default
+  - kind: ServiceAccount
+    name: kubetail-testuser
+    namespace: default
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -627,9 +678,9 @@ metadata:
   name: kubetail-testuser
   namespace: kubetail-system
 rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [list, watch]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -641,6 +692,6 @@ roleRef:
   name: kubetail-testuser
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: ServiceAccount
-  name: kubetail-testuser
-  namespace: default
+  - kind: ServiceAccount
+    name: kubetail-testuser
+    namespace: default

--- a/modules/cluster-api/README.md
+++ b/modules/cluster-api/README.md
@@ -8,42 +8,45 @@ Go-based HTTP server that handles Kubetail Cluster API requests
 
 The Kubetail Cluster API executable supports the following command line configuration options:
 
-| Flag         | Datatype | Description                      | Default   |
-| ------------ | -------- | -------------------------------- | --------- |
-| -c, --config | string   | Path to Kubetail config file     | ""        |
-| -a, --addr   | string   | Host address to bind to          | ":8080"   |
-| --gin-mode   | string   | Gin mode (release, debug)        | "release" |
-| -p, --param  | []string | Config params ("key:val" format) | []        |
+| Flag         | Datatype   | Description                      | Default                   |
+| ------------ | ---------- | -------------------------------- | ------------------------- | --------- | --- |
+| -c, --config | string     | Path to Kubetail config file     | ""                        |
+| <!--         | --gin-mode | string                           | Gin mode (release, debug) | "release" | --> |
+| -p, --param  | []string   | Config params ("key:val" format) | []                        |
 
 ### Config file
 
 The Kubetail Cluster API executable can be configured using a configuration file written in YAML, JSON, TOML, HCL or envfile format. The application will automatically replace ENV variables written in the format `${NAME}` with their corresponding values. The config file supports the following options (also see [hack/config.yaml](../../hack/config.yaml)):
 
-| Name                                              | Datatype | Description                                          | Default                                     |
-| ------------------------------------------------- | -------- | ---------------------------------------------------- | ------------------------------------------- |
-| allowed-namespaces                                | []string | If populated, restricts namespace access             | []                                          |
-| cluster-api.addr                                  | string   | Host address to bind to                              | ":8080"                                     |
-| cluster-api.base-path                             | string   | URL path prefix                                      | "/"                                         |
-| cluster-api.cluster-agent-dispatch-url            | string   | URL for sending dispatch requests to cluster-agent   | "kubernetes://kubetail-cluster-agent:50051" |
-| cluster-api.gin-mode                              | string   | Gin mode (release, debug)                            | "release"                                   |
-| cluster-api.csrf.enabled                          | bool     | Enable CSRF protection                               | true                                        |
-| cluster-api.csrf.field-name                       | string   | CSRF token name in forms                             | "csrf_token"                                |
-| cluster-api.csrf.secret                           | string   | CSRF hash key                                        | ""                                          |
-| cluster-api.csrf.cookie.name                      | string   | CSRF cookie name                                     | "csrf"                                      |
-| cluster-api.csrf.cookie.path                      | string   | CSRF cookie path                                     | "/"                                         |
-| cluster-api.csrf.cookie.domain                    | string   | CSRF cookie domain                                   | ""                                          |
-| cluster-api.csrf.cookie.max-age                   | int      | CSRF cookie max age (in seconds)                     | 43200                                       |
-| cluster-api.csrf.cookie.secure                    | bool     | CSRF cookie secure property                          | false                                       |
-| cluster-api.csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                        | true                                        |
-| cluster-api.csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)    | "strict"                                    |
-| cluster-api.logging.enabled                       | bool     | Enable logging                                       | true                                        |
-| cluster-api.logging.level                         | string   | Log level                                            | "info"                                      |
-| cluster-api.logging.format                        | string   | Log format (json, pretty)                            | "json"                                      |
-| cluster-api.logging.access-log.enabled            | bool     | Enable access log                                    | true                                        |
-| cluster-api.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log            | false                                       |
-| cluster-api.tls.enabled                           | bool     | Enable TLS endpoint termination                      | false                                       |
-| cluster-api.tls.cert-file                         | string   | Path to cert file                                    | ""                                          |
-| cluster-api.tls.key-file                          | string   | Path to key file                                     | ""                                          |
+| Name                                              | Datatype | Description                                        | Default                                     | Status |
+| ------------------------------------------------- | -------- | -------------------------------------------------- | ------------------------------------------- | ------ |
+| allowed-namespaces                                | []string | If populated, restricts namespace access           | []                                          | stable |
+| cluster-api.base-path                             | string   | URL path prefix                                    | "/"                                         | stable |
+| cluster-api.cluster-agent-dispatch-url            | string   | URL for sending dispatch requests to cluster-agent | "kubernetes://kubetail-cluster-agent:50051" | stable |
+| cluster-api.gin-mode                              | string   | Gin mode (release, debug)                          | "release"                                   | stable |
+| cluster-api.csrf.enabled                          | bool     | Enable CSRF protection                             | true                                        | stable |
+| cluster-api.csrf.field-name                       | string   | CSRF token name in forms                           | "csrf_token"                                | stable |
+| cluster-api.csrf.secret                           | string   | CSRF hash key                                      | ""                                          | stable |
+| cluster-api.csrf.cookie.name                      | string   | CSRF cookie name                                   | "csrf"                                      | stable |
+| cluster-api.csrf.cookie.path                      | string   | CSRF cookie path                                   | "/"                                         | stable |
+| cluster-api.csrf.cookie.domain                    | string   | CSRF cookie domain                                 | ""                                          | stable |
+| cluster-api.csrf.cookie.max-age                   | int      | CSRF cookie max age (in seconds)                   | 43200                                       | stable |
+| cluster-api.csrf.cookie.secure                    | bool     | CSRF cookie secure property                        | false                                       | stable |
+| cluster-api.csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                      | true                                        | stable |
+| cluster-api.csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)  | "strict"                                    | stable |
+| cluster-api.http.enabled                          | bool     | Enables http server                                | true                                        | stable |
+| cluster-api.http.address                          | string   | URL of the http server                             | ""                                          | stable |
+| cluster-api.http.port                             | int      | Port of the http server                            | 8080                                        | stable |
+| cluster-api.https.enabled                         | bool     | Enables https server                               | false                                       | stable |
+| cluster-api.https.address                         | string   | URL of the https server                            | ""                                          | stable |
+| cluster-api.https.port                            | int      | Port of the https server                           | 8443                                        | stable |
+| cluster-api.https.tls.cert-file                   | string   | Path to tls certificate file                       | ""                                          | stable |
+| cluster-api.https.tls.key-file                    | string   | Path to tls key file                               | ""                                          | stable |
+| cluster-api.logging.enabled                       | bool     | Enable logging                                     | true                                        | stable |
+| cluster-api.logging.level                         | string   | Log level                                          | "info"                                      | stable |
+| cluster-api.logging.format                        | string   | Log format (json, pretty)                          | "json"                                      | stable |
+| cluster-api.logging.access-log.enabled            | bool     | Enable access log                                  | true                                        | stable |
+| cluster-api.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log          | false                                       | stable |
 
 ## GraphQL
 

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -17,7 +17,6 @@ The Kubetail backend server executable supports the following command line confi
 | Flag         | Datatype | Description                      | Default   |
 | ------------ | -------- | -------------------------------- | --------- |
 | -c, --config | string   | Path to Kubetail config file     | ""        |
-| -a, --addr   | string   | Host address to bind to          | ":8080"   |
 | --gin-mode   | string   | Gin mode (release, debug)        | "release" |
 | -p, --param  | []string | Config params ("key:val" format) | []        |
 
@@ -25,42 +24,46 @@ The Kubetail backend server executable supports the following command line confi
 
 The Kubetail Dashboard server can be configured using a configuration file written in YAML, JSON, TOML, HCL or envfile format. The application will automatically replace ENV variables written in the format `${NAME}` with their corresponding values. The config file supports the following options (also see [hack/config.yaml](../../hack/config.yaml)):
 
-| Name                                            | Datatype | Description                                          | Default                       | Status       |
-| ----------------------------------------------- | -------- | ---------------------------------------------------- | ----------------------------- | ------------ |
-| allowed-namespaces                              | []string | If populated, restricts namespace access             | []                            |              |
-| dashboard.addr                                  | string   | Host address to bind to                              | ":8080"                       |              |
-| dashboard.auth-mode                             | string   | Auth mode (auto, token)                              | "auto"                        | experimental |
-| dashboard.base-path                             | string   | URL path prefix                                      | "/"                           |              |
-| dashboard.cluster-api-endpoint                  | string   | Service url for Cluster API                          | ""                            | experimental |
-| dashboard.environment                           | string   | Environment (desktop, cluster)                       | "desktop"                     | experimental |
-| dashboard.gin-mode                              | string   | Gin mode (release, debug)                            | "release"                     |              |
-| dashboard.csrf.enabled                          | bool     | Enable CSRF protection                               | true                          |              |
-| dashboard.csrf.field-name                       | string   | CSRF token name in forms                             | "csrf_token"                  |              |
-| dashboard.csrf.secret                           | string   | CSRF hash key                                        | ""                            |              |
-| dashboard.csrf.cookie.name                      | string   | CSRF cookie name                                     | "csrf"                        |              |
-| dashboard.csrf.cookie.path                      | string   | CSRF cookie path                                     | "/"                           |              |
-| dashboard.csrf.cookie.domain                    | string   | CSRF cookie domain                                   | ""                            |              |
-| dashboard.csrf.cookie.max-age                   | int      | CSRF cookie max age (in seconds)                     | 43200                         |              |
-| dashboard.csrf.cookie.secure                    | bool     | CSRF cookie secure property                          | false                         |              |
-| dashboard.csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                        | true                          |              |
-| dashboard.csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)    | "strict"                      |              |
-| dashboard.logging.enabled                       | bool     | Enable logging                                       | true                          |              |
-| dashboard.logging.level                         | string   | Log level                                            | "info"                        |              |
-| dashboard.logging.format                        | string   | Log format (json, pretty)                            | "json"                        |              |
-| dashboard.logging.access-log.enabled            | bool     | Enable access log                                    | true                          |              |
-| dashboard.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log            | false                         |              |
-| dashboard.session.secret                        | string   | Session hash key                                     | ""                            |              |
-| dashboard.session.cookie.name                   | string   | Session cookie name                                  | "session"                     |              |
-| dashboard.session.cookie.path                   | string   | Session cookie path                                  | "/"                           |              |
-| dashboard.session.cookie.domain                 | string   | Session cookie domain                                | ""                            |              |
-| dashboard.session.cookie.max-age                | int      | Session cookie max age (in seconds)                  | 43200                         |              |
-| dashboard.session.cookie.secure                 | bool     | Session cookie secure property                       | false                         |              |
-| dashboard.session.cookie.http-only              | bool     | Session cookie HttpOnly property                     | true                          |              |
-| dashboard.session.cookie.same-site              | string   | Session cookie SameSite property (strict, lax, none) | "strict"                      |              |
-| dashboard.tls.enabled                           | bool     | Enable TLS endpoint termination                      | false                         |              |
-| dashboard.tls.cert-file                         | string   | Path to cert file                                    | ""                            |              |
-| dashboard.tls.key-file                          | string   | Path to key file                                     | ""                            |              |
-| dashboard.ui.cluster-api-enabled                | bool     | Enable Cluster API features                          | true                          | experimental |
+| Name                                            | Datatype | Description                                          | Default      | Status       |
+| ----------------------------------------------- | -------- | ---------------------------------------------------- | ------------ | ------------ |
+| allowed-namespaces                              | []string | If populated, restricts namespace access             | []           | stable       |
+| dashboard.auth-mode                             | string   | Auth mode (auto, token)                              | "auto"       | experimental |
+| dashboard.base-path                             | string   | URL path prefix                                      | "/"          | stable       |
+| dashboard.cluster-api-endpoint                  | string   | Service url for Cluster API                          | ""           | experimental |
+| dashboard.environment                           | string   | Environment (desktop, cluster)                       | "desktop"    | experimental |
+| dashboard.http.enabled                          | bool     | Enables http server                                  | true         | stable       |
+| dashboard.http.address                          | string   | URL of the http server                               | ""           | stable       |
+| dashboard.http.port                             | int      | Port of the http server                              | 8080         | stable       |
+| dashboard.https.enabled                         | bool     | Enables https server                                 | false        | stable       |
+| dashboard.https.address                         | string   | URL of the https server                              | ""           | stable       |
+| dashboard.https.port                            | int      | Port of the https server                             | 8443         | stable       |
+| dashboard.https.tls.cert-file                   | string   | Path to tls certificate file                         | ""           | stable       |
+| dashboard.https.tls.key-file                    | string   | Path to tls key file                                 | ""           | stable       |
+| dashboard.gin-mode                              | string   | Gin mode (release, debug)                            | "release"    | stable       |
+| dashboard.csrf.enabled                          | bool     | Enable CSRF protection                               | true         | stable       |
+| dashboard.csrf.field-name                       | string   | CSRF token name in forms                             | "csrf_token" | stable       |
+| dashboard.csrf.secret                           | string   | CSRF hash key                                        | ""           | stable       |
+| dashboard.csrf.cookie.name                      | string   | CSRF cookie name                                     | "csrf"       | stable       |
+| dashboard.csrf.cookie.path                      | string   | CSRF cookie path                                     | "/"          | stable       |
+| dashboard.csrf.cookie.domain                    | string   | CSRF cookie domain                                   | ""           | stable       |
+| dashboard.csrf.cookie.max-age                   | int      | CSRF cookie max age (in seconds)                     | 43200        | stable       |
+| dashboard.csrf.cookie.secure                    | bool     | CSRF cookie secure property                          | false        | stable       |
+| dashboard.csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                        | true         | stable       |
+| dashboard.csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)    | "strict"     | stable       |
+| dashboard.logging.enabled                       | bool     | Enable logging                                       | true         | stable       |
+| dashboard.logging.level                         | string   | Log level                                            | "info"       | stable       |
+| dashboard.logging.format                        | string   | Log format (json, pretty)                            | "json"       | stable       |
+| dashboard.logging.access-log.enabled            | bool     | Enable access log                                    | true         | stable       |
+| dashboard.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log            | false        | stable       |
+| dashboard.session.secret                        | string   | Session hash key                                     | ""           | stable       |
+| dashboard.session.cookie.name                   | string   | Session cookie name                                  | "session"    | stable       |
+| dashboard.session.cookie.path                   | string   | Session cookie path                                  | "/"          | stable       |
+| dashboard.session.cookie.domain                 | string   | Session cookie domain                                | ""           | stable       |
+| dashboard.session.cookie.max-age                | int      | Session cookie max age (in seconds)                  | 43200        | stable       |
+| dashboard.session.cookie.secure                 | bool     | Session cookie secure property                       | false        | stable       |
+| dashboard.session.cookie.http-only              | bool     | Session cookie HttpOnly property                     | true         | stable       |
+| dashboard.session.cookie.same-site              | string   | Session cookie SameSite property (strict, lax, none) | "strict"     | stable       |
+| dashboard.ui.cluster-api-enabled                | bool     | Enable Cluster API features                          | true         | experimental |
 
 ## GraphQL
 
@@ -92,7 +95,9 @@ make modules-vet
 
 
 ```
+
 You can also run all Dashboard checks at once with:
+
 ```console
 make modules-all
 ```

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -146,7 +146,6 @@ type Config struct {
 
 	// Cluster API options
 	ClusterAPI struct {
-		Addr                    string `validate:"omitempty,hostname_port"`
 		GinMode                 string `mapstructure:"gin-mode" validate:"omitempty,oneof=debug release"`
 		BasePath                string `mapstructure:"base-path"`
 		ClusterAgentDispatchUrl string `mapstructure:"cluster-agent-dispatch-url"`
@@ -169,16 +168,23 @@ type Config struct {
 			}
 		}
 
-		// TLS options
-		TLS struct {
-			// enable tls termination
+		HTTP struct {
 			Enabled bool
+			Address string `validate:"omitempty,hostname"`
+			Port    uint   `validate:"omitempty,port"`
+		}
 
-			// TLS certificate file
-			CertFile string `mapstructure:"cert-file" validate:"omitempty,file"`
+		HTTPS struct {
+			Enabled bool
+			Address string `validate:"omitempty,hostname"`
+			Port    uint   `validate:"omitempty,port"`
+			TLS     struct {
+				// TLS certificate file
+				CertFile string `mapstructure:"cert-file" validate:"omitempty,file"`
 
-			// TLS certificate key file
-			KeyFile string `mapstructure:"key-file" validate:"omitempty,file"`
+				// TLS certificate key file
+				KeyFile string `mapstructure:"key-file" validate:"omitempty,file"`
+			}
 		}
 
 		// logging options
@@ -289,7 +295,14 @@ func DefaultConfig() *Config {
 	cfg.Dashboard.Session.Cookie.SameSite = http.SameSiteLaxMode
 	cfg.Dashboard.UI.ClusterAPIEnabled = true
 
-	cfg.ClusterAPI.Addr = ":8080"
+	cfg.ClusterAPI.HTTP.Enabled = true
+	cfg.ClusterAPI.HTTP.Address = ""
+	cfg.ClusterAPI.HTTP.Port = 8080
+	cfg.ClusterAPI.HTTPS.Enabled = false
+	cfg.ClusterAPI.HTTPS.Address = ""
+	cfg.ClusterAPI.HTTPS.Port = 8443
+	cfg.ClusterAPI.HTTPS.TLS.CertFile = ""
+	cfg.ClusterAPI.HTTPS.TLS.KeyFile = ""
 	cfg.ClusterAPI.BasePath = "/"
 	cfg.ClusterAPI.ClusterAgentDispatchUrl = "kubernetes://kubetail-cluster-agent:50051"
 	cfg.ClusterAPI.GinMode = "release"


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #389 

## Summary

Add http and https support for cluster-api-server.

## Changes

- adding the ability to use http and/or https port for cluster api server
- both ports are enabled by default
- update README.md of dashboard and cluster-api go module

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
