### PR TITLE
🎣 Fixes Rpm build issue and deb build issue in release ci

### DIFF
--- a/.github/ci-config/kubetail-rpm.spec
+++ b/.github/ci-config/kubetail-rpm.spec
@@ -1,6 +1,6 @@
-Name:           kubetail 
+Name:           kubetail
 Version:        %{version} 
-Release:        1%{?dist}
+Release:        %{release}%{?dist}
 Summary:        Real-time logging dashboard for Kubernetes 
 
 License:        Apache-2.0

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - "cli/v*"
+      - 'cli/v*'
 
 jobs:
   build:
@@ -46,7 +46,7 @@ jobs:
         uses: olegtarasov/get-tag@v2.1.4
         id: tagName
         with:
-          tagRegex: "cli/v(.*)"
+          tagRegex: 'cli/v(.*)'
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -56,7 +56,7 @@ jobs:
           version: 10
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.4"
+          go-version: '1.24.4'
           cache: false
       - name: Run build script
         run: make build VERSION=${{ steps.tagName.outputs.tag }}
@@ -107,7 +107,7 @@ jobs:
         uses: olegtarasov/get-tag@v2.1.4
         id: tagName
         with:
-          tagRegex: "cli/v(.*)"
+          tagRegex: 'cli/v(.*)'
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -122,14 +122,14 @@ jobs:
           cp -p 'bin/kubetail-${{ matrix.os }}-${{ matrix.arch }}' .debpkg/usr/bin/kubetail
 
       - name: Create a .deb package
-        uses: jiro4989/build-deb-action@975f7f3
+        uses: jiro4989/build-deb-action@975f7f362928fd814e1e607fda0294c86ad07f37
         with:
           package: kubetail
           package_root: .debpkg
           maintainer: Andres Morey
           version: ${{ steps.tagName.outputs.tag }}
           arch: ${{ matrix.arch }}
-          desc: "Real-time logging dashboard for Kubernetes"
+          desc: 'Real-time logging dashboard for Kubernetes'
 
       - name: Calculate sha256 checksum
         run: |
@@ -145,73 +145,95 @@ jobs:
           name: artifacts-${{ matrix.arch }}-deb
           path: deb-output/*
 
-  #package-rpm:
-  #  name: Build rpm package
-  #  needs: build
-  #  strategy:
-  #    matrix:
-  #      include:
-  #        - os: linux
-  #          arch: amd64
-  #          pkgArch: x86_64
-  #        - os: linux
-  #          arch: arm64
-  #          pkgArch: aarch64
-  #  runs-on: ubuntu-24.04
-  #  steps:
-  #    - name: Get tag name
-  #      uses: olegtarasov/get-tag@2.1.3
-  #      id: tagName
-  #      with:
-  #        tagRegex: "cli/v(.*)"
-  #    - uses: actions/checkout@v4
-  #    - name: Install the rpm and rpm build
-  #      run: |
-  #        sudo apt-get update
-  #        sudo apt-get install -y rpm build-essential
-  #    - name: Download artifacts
-  #      uses: actions/download-artifact@v4
-  #      with:
-  #        path: bin
-  #        pattern: artifacts-${{ matrix.os }}-${{ matrix.arch }}
-  #        merge-multiple: true
-  #    - name: Rename the build binary to kubetail
-  #      run: |
-  #        mv 'bin/kubetail-${{ matrix.os }}-${{ matrix.arch }}' bin/kubetail
-  #    - name: Copy spec file to SPEC dir
-  #      run: |
-  #        mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-  #        cp .github/ci-config/kubetail-rpm.spec ~/rpmbuild/SPECS/kubetail.spec
-  #    - name: Create tarball for the binary
-  #      run: |
-  #        CLI_VER='${{ steps.tagName.outputs.tag }}'
-  #        mkdir -p ~/rpmbuild/SOURCES/kubetail-${CLI_VER}
-  #        mv bin/kubetail ~/rpmbuild/SOURCES/kubetail-${CLI_VER}
-  #        cd ~/rpmbuild/SOURCES
-  #        tar czf "kubetail-${CLI_VER}.tar.gz" "kubetail-${CLI_VER}/"
-  #    - name: Build RPM package
-  #      run: |
-  #        CLI_VER='${{ steps.tagName.outputs.tag }}'
-  #        ARCH='${{ matrix.pkgArch }}'
-  #        rpmbuild -ba --target "${ARCH}" ~/rpmbuild/SPECS/kubetail.spec --define "version ${CLI_VER}"
-  #    - name: Calculate sha256 checksum
-  #      run: |
-  #        mkdir -p rpm-output
-  #        FILE_NAME=kubetail-${{ steps.tagName.outputs.tag }}-1.${{ matrix.pkgArch }}.rpm
-  #        FILE_NEW_NAME=kubetail-${{ steps.tagName.outputs.tag }}-1.${{ matrix.arch }}.rpm # renaming arch to arm64 and amd64
-  #        mv ~/rpmbuild/RPMS/'${{ matrix.pkgArch }}'/"${FILE_NAME}" ./rpm-output/"${FILE_NEW_NAME}"
-  #        FILE=./rpm-output/"${FILE_NEW_NAME}"
-  #        OUTPUT_FILE="${FILE}".sha256
-  #        sha256sum "$FILE" | cut -d " " -f 1 > "$OUTPUT_FILE"
-  #    - name: Upload rpm artifacts
-  #      uses: actions/upload-artifact@v4
-  #      with:
-  #        name: artifacts-${{ matrix.arch }}-rpm
-  #        path: rpm-output/*
+  package-rpm:
+    name: Build rpm package
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            pkgArch: x86_64
+          - os: linux
+            arch: arm64
+            pkgArch: aarch64
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get tag name
+        uses: olegtarasov/get-tag@2.1.3
+        id: tagName
+        with:
+          tagRegex: 'cli/v(.*)'
+      - uses: actions/checkout@v4
+      - name: Install the rpm and rpm build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm build-essential
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bin
+          pattern: artifacts-${{ matrix.os }}-${{ matrix.arch }}
+          merge-multiple: true
+      - name: Rename the build binary to kubetail
+        run: |
+          mv 'bin/kubetail-${{ matrix.os }}-${{ matrix.arch }}' bin/kubetail
+      - name: Copy spec file to SPEC dir
+        run: |
+          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          cp .github/ci-config/kubetail-rpm.spec ~/rpmbuild/SPECS/kubetail.spec
+      - name: Extract the release and version for rpm
+        id: rpmBuildInfo
+        run: |
+          CLI_VER='${{ steps.tagName.outputs.tag }}'
+          if [[ "$CLI_VER" == *"-"* ]]; then
+            # Handle pre-release versions like "0.7.1-rc1"
+            IFS='-' read -ra parts <<< "${CLI_VER}"
+            VERSION="${parts[0]}" 
+            RELEASE="0.${parts[1]}.1"
+          else
+            # Handle stable versions like "0.7.1" - always set release to "1"
+            VERSION="${CLI_VER}"
+            RELEASE="1"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release=$RELEASE" >> $GITHUB_OUTPUT
+
+      - name: Create tarball for the binary
+        run: |
+          CLI_VER='${{steps.rpmBuildInfo.outputs.version}}' 
+          mkdir -p ~/rpmbuild/SOURCES/kubetail-${CLI_VER}
+          mv bin/kubetail ~/rpmbuild/SOURCES/kubetail-${CLI_VER}
+          cd ~/rpmbuild/SOURCES
+          tar czf "kubetail-${CLI_VER}.tar.gz" "kubetail-${CLI_VER}/"
+      - name: Build RPM package
+        run: |
+          VERSION='${{ steps.rpmBuildInfo.outputs.version }}' 
+          RELEASE='${{ steps.rpmBuildInfo.outputs.release }}'
+          ARCH='${{ matrix.pkgArch }}'
+          rpmbuild -ba --target "${ARCH}" ~/rpmbuild/SPECS/kubetail.spec --define "version ${VERSION}" --define "release ${RELEASE}"
+      - name: Calculate sha256 checksum
+        run: |
+          VERSION='${{ steps.rpmBuildInfo.outputs.version }}' 
+          RELEASE='${{ steps.rpmBuildInfo.outputs.release }}'
+
+          mkdir -p rpm-output
+          FILE_NAME="kubetail-$VERSION-$RELEASE.${{ matrix.pkgArch }}.rpm"
+          FILE_NEW_NAME="kubetail-$VERSION-$RELEASE.${{ matrix.arch }}.rpm" # renaming arch to arm64 and amd64
+
+          mv ~/rpmbuild/RPMS/'${{ matrix.pkgArch }}'/"${FILE_NAME}" ./rpm-output/"${FILE_NEW_NAME}"
+          FILE=./rpm-output/"${FILE_NEW_NAME}"
+          OUTPUT_FILE="${FILE}".sha256
+          sha256sum "$FILE" | cut -d " " -f 1 > "$OUTPUT_FILE"
+      - name: Upload rpm artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.arch }}-rpm
+          path: rpm-output/*
 
   release:
     name: Create GitHub release
-    needs: [build, package-deb]
+    needs: [build, package-deb, package-rpm]
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts


### PR DESCRIPTION


<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #454  

## Summary
This Pr fixes the rpm build issue that occurs when we have "-" in the release name. if there is a "-" in the cli version, we split it into version number and release and use it the rpm build. 
This also fixes rpm build issue which was occuring due to using a shorter form of the commit sha for the jiro/deb action.

## Changes
- Adds a step in package-deb job to split the cli version into Version number and release.
- modify the kubetail rpm spec to take release as an input dynamically.
- if the cli version is a pre-release like "0.8.3-rc1", then we split it as version = 0.8.3 and release = "0.rc1.1", we are using "0.rc1.1" instead of "rc1", because this shows the pre-release comes before the release.
- if the cli version is proper release like "0.8.3", then the version is equal to "0.8.3" and release is equal to "1". 

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

