### PR TITLE
Allow the new cluster agent to be deployed in the cluster

### DIFF
--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -10,11 +10,7 @@ use logrecords::LogRecords;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let (agent_health_reporter, agent_health_service) = tonic_health::server::health_reporter();
-
-    agent_health_reporter
-        .set_serving::<LogMetadataServiceServer<LogMetadata>>()
-        .await;
+    let (_, agent_health_service) = tonic_health::server::health_reporter();
 
     let reflection_service = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
@@ -25,7 +21,7 @@ async fn main() -> eyre::Result<()> {
         .add_service(reflection_service)
         .add_service(LogMetadataServiceServer::new(LogMetadata {}))
         .add_service(LogRecordsServiceServer::new(LogRecords {}))
-        .serve("[::1]:50051".parse()?)
+        .serve("[::]:50051".parse()?)
         .await
         .unwrap();
 


### PR DESCRIPTION
- 🐋 New feature

## Summary

Enables the deployment of the new cluster agent in the local cluster. This is just to enable running tests on the cluster while developing. There is more cleanup work needed for the deployment scripts, but I left this work to be done as part of #493

## Changes
- Fixes the IP address to be exposed to other containers
- Copies the new cluster agent when using KUBETAIL_DEV_RUST_LOCAL
- I removed the health check for specific services as the k8s scripts check for the basic health service only. We can revise this decision if we ever need to do any per-service health-checking/recovery.


## Submitter checklist

- [x] Add the correct emoji to the PR title
- [ ] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
