### PR TITLE
🐋 Add SignPath to release workflow

### DIFF
--- a/.github/ci-config/signpath.xml
+++ b/.github/ci-config/signpath.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<artifact-configuration 
+  xmlns="http://signpath.io/artifact-configuration/v1"
+  xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://signpath.io/artifact-configuration/v1 https://app.signpath.io/Web/artifact-configuration/v1.xsd"
+>
+  <parameters>
+    <parameter name="version" required="true" />
+  </parameters>
+  <zip-file>
+    <pe-file path="*" product-name="kubetail" product-version="${version}"> 
+      <authenticode-sign/> 
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -85,11 +85,25 @@ jobs:
           (Get-FileHash -Algorithm SHA256 "${file}.zip").Hash |
             Out-File -FilePath "${file}.zip.sha256" -Encoding ascii
           Remove-Item kubetail.exe
-      - name: Upload artifact
+      - id: upload-artifact
+        name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: bin/*
+      - name: Sign Windows Binary
+        if: matrix.GOOS == 'windows'
+        uses: signpath/github-action-submit-signing-request@v1.1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'kubetail'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'bin'
+          parameters: |
+            version: ${{ steps.tagName.outputs.tag }}
 
   package-deb:
     name: Build deb package


### PR DESCRIPTION
Fixes #455 

## Summary

Add SignPath windows binary signing action to CLI release workflow.

## Changes

* Add SignPath configuration file
* Add SignPath code signing step to release-cli workflow

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
