### PR TITLE
✨ Migrate from Recoil to Jotai  

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Kubetail is a real-time logging dashboard for Kubernetes that provides both brow
 - **Log Search Engine** (`crates/rgkl/`) - High-performance Rust binary for log searching and streaming
 
 ### Technology Stack
-- **TypeScript/React**: Frontend with Vite, Tailwind CSS, Apollo Client, and Recoil state management
+- **TypeScript/React**: Frontend with Vite, Tailwind CSS, Apollo Client, and Jotai state management
 - **Go 1.24+**: Backend services using Go workspaces (`modules/go.work`)
 - **Rust**: High-performance log processing in `crates/rgkl/`
 - **GraphQL**: User-facing API layer uses gqlgen for Go backends with code generation

--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -24,6 +24,7 @@
     "fancy-ansi": "^0.1.3",
     "graphql": "^16.11.0",
     "graphql-ws": "^6.0.5",
+    "jotai": "^2.12.5",
     "lucide-react": "^0.516.0",
     "numeral": "^2.0.6",
     "react": "^18.3.1",
@@ -35,7 +36,6 @@
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "react-window-infinite-loader": "^1.0.10",
-    "recoil": "^0.7.7",
     "tailwind-merge": "^3.3.1",
     "usehooks-ts": "^3.1.1"
   },

--- a/dashboard-ui/pnpm-lock.yaml
+++ b/dashboard-ui/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       graphql-ws:
         specifier: ^6.0.5
         version: 6.0.5(graphql@16.11.0)(ws@8.18.2)
+      jotai:
+        specifier: ^2.12.5
+        version: 2.12.5(@types/react@18.3.23)(react@18.3.1)
       lucide-react:
         specifier: ^0.516.0
         version: 0.516.0(react@18.3.1)
@@ -77,9 +80,6 @@ importers:
       react-window-infinite-loader:
         specifier: ^1.0.10
         version: 1.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      recoil:
-        specifier: ^0.7.7
-        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2804,9 +2804,6 @@ packages:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  hamt_plus@1.0.2:
-    resolution: {integrity: sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==}
-
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3083,6 +3080,18 @@ packages:
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jotai@2.12.5:
+    resolution: {integrity: sha512-G8m32HW3lSmcz/4mbqx0hgJIQ0ekndKWiYP7kWVKi0p6saLXdSoye+FZiOFyonnd7Q482LCzm8sMDl7Ar1NWDw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3688,18 +3697,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  recoil@0.7.7:
-    resolution: {integrity: sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==}
-    peerDependencies:
-      react: '>=16.13.1'
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7381,8 +7378,6 @@ snapshots:
 
   graphql@16.11.0: {}
 
-  hamt_plus@1.0.2: {}
-
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -7669,6 +7664,11 @@ snapshots:
   jiti@2.4.2: {}
 
   jose@5.10.0: {}
+
+  jotai@2.12.5(@types/react@18.3.23)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.23
+      react: 18.3.1
 
   js-tokens@4.0.0: {}
 
@@ -8241,13 +8241,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  recoil@0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      hamt_plus: 1.0.2
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   redent@3.0.0:
     dependencies:

--- a/dashboard-ui/src/components/widgets/ServerStatus.tsx
+++ b/dashboard-ui/src/components/widgets/ServerStatus.tsx
@@ -14,7 +14,7 @@
 
 import { useSubscription } from '@apollo/client';
 import { Fragment, useEffect, useState } from 'react';
-import { RecoilRoot, atom, useRecoilValue, useSetRecoilState, type SetterOrUpdater } from 'recoil';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 
 import DataTable from '@kubetail/ui/elements/DataTable';
 
@@ -31,15 +31,9 @@ import {
 } from '@/lib/server-status';
 import { cn } from '@/lib/util';
 
-const kubernetesAPIServerStatusMapState = atom({
-  key: 'kubernetesAPIServerStatusMap',
-  default: new Map<string, ServerStatus>(),
-});
+const kubernetesAPIServerStatusMapState = atom(new Map<string, ServerStatus>());
 
-const clusterAPIServerStatusMapState = atom({
-  key: 'clusterAPIServerStatusMap',
-  default: new Map<string, ServerStatus>(),
-});
+const clusterAPIServerStatusMapState = atom(new Map<string, ServerStatus>());
 
 const HealthDot = ({ status }: { status: Status }) => {
   let color;
@@ -97,7 +91,7 @@ const statusMessage = (s: ServerStatus, unknownDefault: string): string => {
 
 function useEffectServerStatus(
   kubeContext: string,
-  setServerStatusMap: SetterOrUpdater<Map<string, ServerStatus>>,
+  setServerStatusMap: (update: (prev: Map<string, ServerStatus>) => Map<string, ServerStatus>) => void,
   serverStatus: ServerStatus,
 ) {
   useEffect(() => {
@@ -122,7 +116,7 @@ const KubernetesAPIServerStatusFetcher = ({ kubeContext }: { kubeContext: string
   const serverStatus = useKubernetesAPIServerStatus(kubeContext);
 
   // Update map
-  const setServerStatusMap = useSetRecoilState(kubernetesAPIServerStatusMapState);
+  const setServerStatusMap = useSetAtom(kubernetesAPIServerStatusMapState);
   useEffectServerStatus(kubeContext, setServerStatusMap, serverStatus);
 
   return null;
@@ -132,7 +126,7 @@ const ClusterAPIServerStatusFetcher = ({ kubeContext }: { kubeContext: string })
   const serverStatus = useClusterAPIServerStatus(kubeContext);
 
   // Update map
-  const setServerStatusMap = useSetRecoilState(clusterAPIServerStatusMapState);
+  const setServerStatusMap = useSetAtom(clusterAPIServerStatusMapState);
   useEffectServerStatus(kubeContext, setServerStatusMap, serverStatus);
 
   return null;
@@ -160,7 +154,7 @@ type ServerStatusRowProps = {
 };
 
 const KubernetesAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: ServerStatusRowProps) => {
-  const serverStatusMap = useRecoilValue(kubernetesAPIServerStatusMapState);
+  const serverStatusMap = useAtomValue(kubernetesAPIServerStatusMapState);
   const serverStatus = serverStatusMap.get(kubeContext) || new ServerStatus();
 
   return (
@@ -176,7 +170,7 @@ const KubernetesAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: Se
 };
 
 const ClusterAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: ServerStatusRowProps) => {
-  const serverStatusMap = useRecoilValue(clusterAPIServerStatusMapState);
+  const serverStatusMap = useAtomValue(clusterAPIServerStatusMapState);
   const serverStatus = serverStatusMap.get(kubeContext) || new ServerStatus();
 
   return (
@@ -216,8 +210,8 @@ const ServerStatusWidget = ({ className }: ServerStatusWidgetProps) => {
   }
 
   const dashboardServerStatus = useDashboardServerStatus();
-  const kubernetesAPIServertatusMap = useRecoilValue(kubernetesAPIServerStatusMapState);
-  const clusterAPIServerStatusMap = useRecoilValue(clusterAPIServerStatusMapState);
+  const kubernetesAPIServertatusMap = useAtomValue(kubernetesAPIServerStatusMapState);
+  const clusterAPIServerStatusMap = useAtomValue(clusterAPIServerStatusMapState);
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
@@ -273,10 +267,6 @@ const ServerStatusWidget = ({ className }: ServerStatusWidgetProps) => {
   );
 };
 
-const ServerStatusWidgetWrapper = (props: ServerStatusWidgetProps) => (
-  <RecoilRoot>
-    <ServerStatusWidget {...props} />
-  </RecoilRoot>
-);
+const ServerStatusWidgetWrapper = (props: ServerStatusWidgetProps) => <ServerStatusWidget {...props} />;
 
 export default ServerStatusWidgetWrapper;

--- a/dashboard-ui/src/pages/home.tsx
+++ b/dashboard-ui/src/pages/home.tsx
@@ -18,7 +18,7 @@ import numeral from 'numeral';
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import TimeAgo from 'react-timeago';
 import type { Formatter, Suffix, Unit } from 'react-timeago';
-import { RecoilRoot, atom, useRecoilValue, useSetRecoilState } from 'recoil';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 
 import { Boxes, Layers3, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react';
 import { useDebounceCallback } from 'usehooks-ts';
@@ -50,10 +50,7 @@ const basename = getBasename();
 
 const defaultKubeContext = appConfig.environment === 'cluster' ? '' : undefined;
 
-const logMetadataMapState = atom({
-  key: 'homeLogMetadataMap',
-  default: new Map<string, FileInfo>(),
-});
+const logMetadataMapState = atom(new Map<string, FileInfo>());
 
 type ContextType = {
   kubeContext?: string;
@@ -150,7 +147,7 @@ function useStatefulSets(kubeContext?: string) {
 }
 
 function useLogFileInfo(uids: string[], ownershipMap: Map<string, string[]>) {
-  const logMetadataMap = useRecoilValue(logMetadataMapState);
+  const logMetadataMap = useAtomValue(logMetadataMapState);
 
   const logFileInfo = new Map<string, { size: number; lastModifiedAt: Date; containerIDs: string[] }>();
   uids.forEach((uid) => {
@@ -240,7 +237,7 @@ function useFilteredWorkloads() {
 
 const LogMetadataMapProvider = () => {
   const { kubeContext } = useContext(Context);
-  const setLogMetadataMap = useSetRecoilState(logMetadataMapState);
+  const setLogMetadataMap = useSetAtom(logMetadataMapState);
 
   const logMetadata = useLogMetadata({
     enabled: appConfig.clusterAPIEnabled && kubeContext !== undefined,
@@ -1061,12 +1058,10 @@ export default function Page() {
   return (
     <AuthRequired>
       <Context.Provider value={context}>
-        <RecoilRoot>
-          <LogMetadataMapProvider />
-          <AppLayout>
-            <InnerLayout header={<Header />} sidebar={<Sidebar />} content={<Content />} />
-          </AppLayout>
-        </RecoilRoot>
+        <LogMetadataMapProvider />
+        <AppLayout>
+          <InnerLayout header={<Header />} sidebar={<Sidebar />} content={<Content />} />
+        </AppLayout>
       </Context.Provider>
     </AuthRequired>
   );


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #505

## Summary

This pull request migrates the application's state management from the archived Recoil library to Jotai. This is a necessary refactor to enable a future upgrade to React 19, as Recoil is no longer maintained.

## Changes

- Replaced the `recoil` dependency with `jotai` for React 19 compatibility.
- Migrated state management logic in key components like `logfeed`, `ServerStatus`, and the `home` page.
- Updated the `CLAUDE.md` documentation to reflect the new state management library.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)