### PR TITLE
Implement List of LogMetadata 🐋

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -369,6 +369,8 @@ dependencies = [
  "colored",
  "either",
  "eyre",
+ "k8s-openapi",
+ "kube",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-resource-detectors",
@@ -377,6 +379,7 @@ dependencies = [
  "prost-types",
  "prost-wkt",
  "prost-wkt-types",
+ "regex",
  "rgkl",
  "thiserror 2.0.12",
  "tokio",
@@ -408,6 +411,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -464,6 +487,26 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "digest"
@@ -632,6 +675,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +769,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -924,8 +982,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "headers-core",
+ "headers-core 0.2.0",
  "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -941,6 +1014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1033,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1063,6 +1154,44 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers 0.4.1",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1320,6 +1449,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1491,71 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kube"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778f98664beaf4c3c11372721e14310d1ae00f5e2d9aabcf8906c881aa4e9f51"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb276b85b6e94ded00ac8ea2c68fcf4697ea0553cb25fddc35d4a0ab718db8d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-http-proxy",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c56ff45deb0031f2a476017eed60c06872251f271b8387ad8020b8fef60960"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "form_urlencoded",
+ "http 1.3.1",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1554,6 +1773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "opentelemetry"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,10 +1937,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -2126,6 +2414,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2486,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2595,51 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2229,6 +2654,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -2267,10 +2702,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2344,6 +2803,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2498,6 +2963,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,16 +3122,19 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2826,6 +3304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +3320,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2906,7 +3402,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "headers",
+ "headers 0.3.9",
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
@@ -3292,6 +3788,12 @@ dependencies = [
  "syn 2.0.103",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "prost-wkt-types",
  "regex",
  "rgkl",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -37,4 +37,5 @@ tokio-util = { version = "0.7.15", features = ["rt"] }
 kube = { version = "1.1.0" }
 k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 regex = "1.11.1"
+tempfile = "3.20.0"
 

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -34,4 +34,7 @@ eyre = "0.6.12"
 tokio-stream = { version = "0.1.17", features = ["full"] }
 tokio-util = { version = "0.7.15", features = ["rt"] }
 
+kube = { version = "1.1.0" }
+k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
+regex = "1.11.1"
 

--- a/crates/cluster_agent/src/logmetadata.rs
+++ b/crates/cluster_agent/src/logmetadata.rs
@@ -1,10 +1,21 @@
+use prost_wkt_types::Timestamp;
+use regex::Regex;
+use std::fs::File;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
-use tokio_stream::Stream;
+use tokio::fs::read_dir;
+use tokio::sync::broadcast::Sender;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReadDirStream;
+use tokio_stream::{Stream, StreamExt};
+use tokio_util::task::TaskTracker;
 use tonic::{Request, Response, Status};
 use types::cluster_agent::log_metadata_service_server::LogMetadataService;
 use types::cluster_agent::{
-    LogMetadataList, LogMetadataListRequest, LogMetadataWatchEvent, LogMetadataWatchRequest,
+    LogMetadata, LogMetadataFileInfo, LogMetadataList, LogMetadataListRequest, LogMetadataSpec,
+    LogMetadataWatchEvent, LogMetadataWatchRequest,
 };
 
 type AgentResult<T> = Result<Response<T>, Status>;
@@ -12,17 +23,105 @@ type WatchResponseStream =
     Pin<Box<dyn Stream<Item = Result<LogMetadataWatchEvent, Status>> + Send>>;
 
 #[derive(Debug)]
-pub struct LogMetadata;
+pub struct LogMetadataImpl {
+    logs_dir: &'static str,
+    term_tx: Sender<()>,
+    task_tracker: TaskTracker,
+}
+
+impl LogMetadataImpl {
+    pub const fn new(term_tx: Sender<()>, task_tracker: TaskTracker) -> Self {
+        Self {
+            logs_dir: "/var/log/containers",
+            term_tx,
+            task_tracker,
+        }
+    }
+
+    fn get_file_info(filepath: PathBuf) -> Result<LogMetadataFileInfo, Status> {
+        let metadata = File::open(filepath)?.metadata()?;
+
+        Ok(LogMetadataFileInfo {
+            size: metadata.size().try_into().unwrap(),
+            last_modified_at: metadata.modified().ok().map(Timestamp::from),
+        })
+    }
+}
 
 #[tonic::async_trait]
-impl LogMetadataService for LogMetadata {
+impl LogMetadataService for LogMetadataImpl {
     type WatchStream = WatchResponseStream;
+
     async fn list(
         &self,
-        _request: Request<LogMetadataListRequest>,
+        request: Request<LogMetadataListRequest>,
     ) -> Result<Response<LogMetadataList>, Status> {
-        todo!()
+        let request = request.into_inner();
+        let logs_dir_path = Path::new(self.logs_dir);
+
+        if !logs_dir_path.is_dir() {
+            return Err(Status::new(
+                tonic::Code::NotFound,
+                format!(
+                    "log directory not found: {}",
+                    logs_dir_path.to_string_lossy()
+                ),
+            ));
+        }
+
+        let mut files = ReadDirStream::new(read_dir(logs_dir_path).await?);
+
+        let filename_regex = Regex::new(
+            r"^(?P<pod_name>[^_]+)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[^-]+)\.log$",
+        ).unwrap();
+
+        let mut metadata_items = Vec::new();
+
+        while let Some(file) = files.next().await {
+            let file = match file {
+                Ok(file) => file,
+                Err(error) => return Err(Status::new(tonic::Code::Unknown, error.to_string())),
+            };
+
+            let filepath: PathBuf = file.file_name().into();
+            let filename = filepath.to_string_lossy();
+            let captures = filename_regex.captures(filename.as_ref());
+
+            if captures.is_none() {
+                println!("Filename could not be parsed: {}", filename.as_ref());
+                continue;
+            }
+
+            let captures = captures.unwrap();
+            let container_id = captures["container_id"].to_string();
+            let container_name = captures["container_name"].to_string();
+            let pod_name = captures["pod_name"].to_string();
+            let namespace = captures["namespace"].to_string();
+            let mut absolute_file_path = logs_dir_path.to_path_buf();
+            absolute_file_path.push(filepath);
+
+            if !request.namespaces.contains(&namespace) {
+                continue;
+            }
+
+            metadata_items.push(LogMetadata {
+                id: container_id.clone(),
+                spec: Some(LogMetadataSpec {
+                    container_id,
+                    container_name,
+                    pod_name,
+                    node_name: "The node name".to_string(),
+                    namespace,
+                }),
+                file_info: Some(Self::get_file_info(absolute_file_path)?),
+            });
+        }
+
+        return Ok(Response::new(LogMetadataList {
+            items: metadata_items,
+        }));
     }
+
     async fn watch(
         &self,
         _request: Request<LogMetadataWatchRequest>,

--- a/crates/cluster_agent/src/logrecords.rs
+++ b/crates/cluster_agent/src/logrecords.rs
@@ -14,13 +14,13 @@ use rgkl::{stream_backward, stream_forward};
 use tonic::{Request, Response, Status};
 
 #[derive(Debug)]
-pub struct LogRecords {
+pub struct LogRecordsImpl {
     logs_dir: &'static str,
     term_tx: Sender<()>,
     task_tracker: TaskTracker,
 }
 
-impl LogRecords {
+impl LogRecordsImpl {
     pub const fn new(term_tx: Sender<()>, task_tracker: TaskTracker) -> Self {
         Self {
             logs_dir: "/var/log/containers",
@@ -53,7 +53,7 @@ impl LogRecords {
 }
 
 #[tonic::async_trait]
-impl LogRecordsService for LogRecords {
+impl LogRecordsService for LogRecordsImpl {
     type StreamForwardStream = ReceiverStream<Result<LogRecord, Status>>;
     type StreamBackwardStream = ReceiverStream<Result<LogRecord, Status>>;
 

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -8,8 +8,8 @@ use types::cluster_agent::log_records_service_server::LogRecordsServiceServer;
 mod logmetadata;
 mod logrecords;
 
-use logmetadata::LogMetadata;
-use logrecords::LogRecords;
+use logmetadata::LogMetadataImpl;
+use logrecords::LogRecordsImpl;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -30,8 +30,11 @@ async fn main() -> eyre::Result<()> {
     Server::builder()
         .add_service(agent_health_service)
         .add_service(reflection_service)
-        .add_service(LogMetadataServiceServer::new(LogMetadata {}))
-        .add_service(LogRecordsServiceServer::new(LogRecords::new(
+        .add_service(LogMetadataServiceServer::new(LogMetadataImpl::new(
+            term_tx.clone(),
+            task_tracker.clone(),
+        )))
+        .add_service(LogRecordsServiceServer::new(LogRecordsImpl::new(
             term_tx.clone(),
             task_tracker.clone(),
         )))


### PR DESCRIPTION
## Summary

Implements List of LogMetadata service

## Changes

- Adds the implementation for List of the metadata service
- I added kube and k8s-openapi dependencies when I was trying things but didn't remove them since we are going to need them eventually.

## Testing
- Ensure that the tests are passing (`cargo test`)

### Testing the service
As the integration with the UI does not work yet, follow the steps below to test the gRPC services (although there might be a better way to do it):
- Install [grpcurl](https://github.com/fullstorydev/grpcurl)
- Start the dev environment `tilt up`
- Get the loggen pod name, container id, and the cluster agent pod name with:
```
kubectl get pods --all-namespaces \
  --field-selector spec.nodeName=minikube-m03 \
  -o json | jq -r '
    .items[] | 
    . as $pod |
    $pod.status.containerStatuses[]? | 
    "\($pod.metadata.namespace)/\($pod.metadata.name) \(.containerID)"
'
```
- Map the cluster agent port to localhost with `kubectl -n kubetail-system port-forward <cluster agent pod name> 50051:50051`
- Finally, run a gRPC request with
```
grpcurl -plaintext -d '{
  "namespaces":  ["default","kubetail-system"]
}
' localhost:50051 cluster_agent.LogMetadataService/List
```

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [ ] Link the issue number, if any, to *Fixes #*
- [ ] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
Signed-off-by: Giannis K <ikaragi23@yahoo.gr>