### PR TITLE
🎣 Switch to using `SyncMap` in desktop connection manager to fix slow startup times

### DIFF
--- a/modules/shared/k8shelpers/connection-manager_test.go
+++ b/modules/shared/k8shelpers/connection-manager_test.go
@@ -54,13 +54,11 @@ func TestDesktopConnectionManager_NewInformer_AuthorizationFailure(t *testing.T)
 	).Return(expectedError)
 
 	// Create DesktopConnectionManager with the mock authorizer
-	csCache := make(map[string]*kubernetes.Clientset)
-	csCache["test-context"] = &kubernetes.Clientset{}
-
 	cm := &DesktopConnectionManager{
 		authorizer: mockAuthorizer,
-		csCache:    csCache,
 	}
+
+	cm.csCache.Store("test-context", &kubernetes.Clientset{})
 
 	// Set up test parameters
 	ctx := context.Background()

--- a/modules/shared/util/syncmap.go
+++ b/modules/shared/util/syncmap.go
@@ -14,12 +14,16 @@
 
 package util
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // SyncMap is a typed wrapper around sync.Map.
 // The zero value is ready for use.
 type SyncMap[K comparable, V any] struct {
-	m sync.Map
+	m  sync.Map
+	mu sync.Mutex
 }
 
 // Load returns the value stored in the map for a key, or zero value if none.
@@ -76,6 +80,62 @@ func (m *SyncMap[K, V]) Swap(key K, value V) (V, bool) {
 // CompareAndSwap swaps the old and new values if the value stored for the key equals old.
 func (m *SyncMap[K, V]) CompareAndSwap(key K, old, new V) bool {
 	return m.m.CompareAndSwap(key, old, new)
+}
+
+// LoadOrCompute returns the existing value for the key if present.
+// Otherwise, it calls the compute function and stores the result.
+// The compute function is only called once per key, even under concurrent access.
+func (m *SyncMap[K, V]) LoadOrCompute(key K, compute func() (V, error)) (V, error) {
+	// Use mutex to ensure only one goroutine creates the value
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Fast path: check if value already exists
+	if v, ok := m.Load(key); ok {
+		return v, nil
+	}
+
+	// Create and store the value
+	value, err := compute()
+	if err != nil {
+		return value, err
+	}
+
+	m.Store(key, value)
+	return value, nil
+}
+
+// LoadOrComputeWithContext returns the existing value for the key if present.
+// Otherwise, it calls the compute function and stores the result.
+// The compute function is only called once per key, even under concurrent access.
+// If the context is cancelled during computation, returns the context error.
+func (m *SyncMap[K, V]) LoadOrComputeWithContext(ctx context.Context, key K, compute func() (V, error)) (V, error) {
+	// Exit early if context already canceled
+	if err := ctx.Err(); err != nil {
+		var zero V
+		return zero, err
+	}
+
+	type result struct {
+		value V
+		err   error
+	}
+
+	resultCh := make(chan result, 1)
+
+	// Execute inner LoadOrCompute() inside goroutine
+	go func() {
+		v, err := m.LoadOrCompute(key, compute)
+		resultCh <- result{v, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		var zero V
+		return zero, ctx.Err()
+	case res := <-resultCh:
+		return res.value, res.err
+	}
 }
 
 // Range calls f sequentially for each key and value present in the map.

--- a/modules/shared/util/syncmap_test.go
+++ b/modules/shared/util/syncmap_test.go
@@ -14,7 +14,14 @@
 
 package util
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 func TestSyncMapBasic(t *testing.T) {
 	var m SyncMap[string, int]
@@ -62,4 +69,227 @@ func TestSyncMapBasic(t *testing.T) {
 	if ok {
 		t.Fatalf("expected key deleted")
 	}
+}
+
+func TestSyncMapLoadOrCompute(t *testing.T) {
+	var m SyncMap[string, int]
+
+	// Test creating new value
+	result, err := m.LoadOrCompute("key1", func() (int, error) {
+		return 42, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != 42 {
+		t.Fatalf("expected 42, got %d", result)
+	}
+
+	// Test loading existing value (compute function should not be called)
+	computeCalled := false
+	result, err = m.LoadOrCompute("key1", func() (int, error) {
+		computeCalled = true
+		return 99, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != 42 {
+		t.Fatalf("expected 42, got %d", result)
+	}
+	if computeCalled {
+		t.Fatalf("compute function should not be called for existing key")
+	}
+
+	// Test error handling
+	_, err = m.LoadOrCompute("key2", func() (int, error) {
+		return 0, errors.New("compute error")
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "compute error" {
+		t.Fatalf("expected 'compute error', got '%s'", err.Error())
+	}
+
+	// Verify error case didn't store anything
+	_, ok := m.Load("key2")
+	if ok {
+		t.Fatalf("expected key2 to not exist after error")
+	}
+}
+
+func TestSyncMapLoadOrComputeConcurrency(t *testing.T) {
+	var m SyncMap[string, int]
+	var computeCount int32
+
+	// Run multiple goroutines trying to create the same key
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	results := make([]int, numGoroutines)
+	errors := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			result, err := m.LoadOrCompute("shared_key", func() (int, error) {
+				atomic.AddInt32(&computeCount, 1)
+				return 123, nil
+			})
+			results[index] = result
+			errors[index] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify compute function was called exactly once
+	if computeCount != 1 {
+		t.Fatalf("expected compute function to be called once, got %d", computeCount)
+	}
+
+	// Verify all goroutines got the same result
+	for i := range numGoroutines {
+		if errors[i] != nil {
+			t.Fatalf("goroutine %d got error: %v", i, errors[i])
+		}
+		if results[i] != 123 {
+			t.Fatalf("goroutine %d got result %d, expected 123", i, results[i])
+		}
+	}
+
+	// Verify the value is stored correctly
+	value, ok := m.Load("shared_key")
+	if !ok {
+		t.Fatalf("expected shared_key to exist")
+	}
+	if value != 123 {
+		t.Fatalf("expected 123, got %d", value)
+	}
+}
+
+func TestSyncMapLoadOrComputeWithContext(t *testing.T) {
+	var m SyncMap[string, int]
+
+	t.Run("successful computation", func(t *testing.T) {
+		ctx := context.Background()
+		result, err := m.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
+			return 42, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != 42 {
+			t.Fatalf("expected 42, got %d", result)
+		}
+	})
+
+	t.Run("load existing value", func(t *testing.T) {
+		ctx := context.Background()
+		computeCalled := false
+		result, err := m.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
+			computeCalled = true
+			return 99, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != 42 {
+			t.Fatalf("expected 42, got %d", result)
+		}
+		if computeCalled {
+			t.Fatalf("compute function should not be called for existing key")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancel context immediately
+		cancel()
+
+		result, err := m.LoadOrComputeWithContext(ctx, "key2", func() (int, error) {
+			time.Sleep(100 * time.Millisecond)
+			return 99, nil
+		})
+
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+		if result != 0 {
+			t.Fatalf("expected zero value, got %d", result)
+		}
+	})
+
+	t.Run("context timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		result, err := m.LoadOrComputeWithContext(ctx, "key3", func() (int, error) {
+			time.Sleep(50 * time.Millisecond)
+			return 99, nil
+		})
+
+		if err != context.DeadlineExceeded {
+			t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+		}
+		if result != 0 {
+			t.Fatalf("expected zero value, got %d", result)
+		}
+	})
+
+	t.Run("compute error", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := m.LoadOrComputeWithContext(ctx, "key4", func() (int, error) {
+			return 0, errors.New("compute error")
+		})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if err.Error() != "compute error" {
+			t.Fatalf("expected 'compute error', got '%s'", err.Error())
+		}
+	})
+
+	t.Run("concurrent access", func(t *testing.T) {
+		var m2 SyncMap[string, int]
+		var computeCount int32
+		const numGoroutines = 50
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		results := make([]int, numGoroutines)
+		errors := make([]error, numGoroutines)
+
+		for i := range numGoroutines {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				result, err := m2.LoadOrComputeWithContext(ctx, "shared_key", func() (int, error) {
+					atomic.AddInt32(&computeCount, 1)
+					return 123, nil
+				})
+				results[index] = result
+				errors[index] = err
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Verify compute function was called exactly once
+		if computeCount != 1 {
+			t.Fatalf("expected compute function to be called once, got %d", computeCount)
+		}
+
+		// Verify all goroutines got the same result
+		for i := range numGoroutines {
+			if errors[i] != nil {
+				t.Fatalf("goroutine %d got error: %v", i, errors[i])
+			}
+			if results[i] != 123 {
+				t.Fatalf("goroutine %d got result %d, expected 123", i, results[i])
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

The goal of this PR is to fix intermittent slow startup times in the Kubetail Dashboard when running in a desktop environment. The cause is lock contention in `DesktopConnectionManager` across clusters due to the the singleton `sync.Mutex` used by instances of the struct. To fix this issue, this PR adds threadsafe `LoadOrCompute()` and `LoadOrComputeWithContext()` methods to the `SyncMap` implementation and uses them to replace the global `sync.Mutex` in `DesktopConnectionManager`.

Note: `LoadOrCompute()` is essentially a thread-safe memoization method so it seems like there should already be something in the standard library or a third-party implementation we can use instead. When I looked around I found the [singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight) library but it doesn't support generics and isn't context-aware so it's not ideal. There are other versions with those features (e.g. [janos/singleflight](https://github.com/janos/singleflight)) but none are popular and the implementation isn't difficult so I decided to implement it here. We should definitely revisit this if the upstream singleflight library gets updated or there's a better way to do this that I missed.

## Changes

* Adds new `LoadOrCompute()` and `LoadOrComputeWithContext()` methods to `SyncMap`
* Refactors `DesktopConnectionManager` and replace use of global `sync.Mutex` with `SyncMap` instances
* Fixes previous mistake where `DesktopConnectionManager.WaitUntilReady()` was ignoring the context argument

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
