### PR TITLE
✨ Revert to single-port http endpoints in Dashboard and Cluster Agent

### DIFF
--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -12,66 +12,14 @@ allowed-namespaces: []
 ## dashboard ##
 #
 dashboard:
-  ## http ##
+
+  ## addr ##
   #
-  http:
-    ## enabled ##
-    #
-    # Default value: true
-    #
-    enabled: true
-
-    ## address ##
-    #
-    # Default value: __empty
-    #
-    address:
-
-    ## port ##
-    #
-    # Default value: 8080
-    #
-    port: 8080
-
-  ## https ##
+  # Sets the target ip and port to bind the server to
   #
-  https:
-    ## enabled ##
-    #
-    # Default value: false
-    #
-    enabled: false
-
-    ## address ##
-    #
-    # Default value: __empty
-    #
-    address:
-
-    ## port ##
-    #
-    # Default value: 8443
-    #
-    port: 8443
-
-    ## tls ##
-    #
-    tls:
-      ## cert-file ##
-      #
-      # Path to tls certificate file
-      #
-      # Default value: __empty__
-      #
-      cert-file:
-
-      ## key-file ##
-      #
-      # Path to tls key file
-      #
-      # Default value: __empty__
-      #
-      key-file:
+  # Default value: ":80"
+  #
+  addr: :80
 
   ## auth-mode (experimental) ##
   #
@@ -128,6 +76,7 @@ dashboard:
   ## csrf ##
   #
   csrf:
+
     ## enabled ##
     #
     # Default value: true
@@ -155,6 +104,7 @@ dashboard:
     # Set csrf cookie options
     #
     cookie:
+
       ## name ##
       #
       # Default value: kubetail_dashboard_csrf
@@ -207,6 +157,7 @@ dashboard:
   ## logging ##
   #
   logging:
+
     ## enabled ##
     #
     # Default value: true
@@ -239,6 +190,7 @@ dashboard:
     ## access-log ##
     #
     access-log:
+
       ## enabled ##
       #
       # Enables web access logs for app
@@ -258,6 +210,7 @@ dashboard:
   ## session ##
   #
   session:
+
     ## secret ##
     #
     # 32-byte long hash key
@@ -271,6 +224,7 @@ dashboard:
     # Set session cookie options
     #
     cookie:
+
       ## name ##
       #
       # Default value: csrf
@@ -320,9 +274,36 @@ dashboard:
       #
       same-site: lax
 
+  ## tls ##
+  #
+  tls:
+  
+    ## enabled ##
+    #
+    # Default value: false
+    #
+    enabled: false
+  
+    ## cert-file ##
+    #
+    # Path to tls certificate file
+    #
+    # Default value: __empty__
+    #
+    cert-file:
+  
+    ## key-file ##
+    #
+    # Path to tls key file
+    #
+    # Default value: __empty__
+    #
+    key-file:
+
   ## ui ##
   #
   ui:
+
     ## cluster-api-enabled (experimental) ##
     #
     # Enable features that use cluster-api
@@ -334,66 +315,14 @@ dashboard:
 ## cluster-api ##
 #
 cluster-api:
-  ## http ##
+
+  ## addr ##
   #
-  http:
-    ## enabled ##
-    #
-    # Default value: true
-    #
-    enabled: true
-
-    ## address ##
-    #
-    # Default value: __empty
-    #
-    address:
-
-    ## port ##
-    #
-    # Default value: 8080
-    #
-    port: 8080
-
-  ## https ##
+  # Sets the target ip and port to bind the server to
   #
-  https:
-    ## enabled ##
-    #
-    # Default value: false
-    #
-    enabled: false
-
-    ## address ##
-    #
-    # Default value: __empty
-    #
-    address:
-
-    ## port ##
-    #
-    # Default value: 8443
-    #
-    port: 8443
-
-    ## tls ##
-    #
-    tls:
-      ## cert-file ##
-      #
-      # Path to tls certificate file
-      #
-      # Default value: __empty__
-      #
-      cert-file:
-
-      ## key-file ##
-      #
-      # Path to tls key file
-      #
-      # Default value: __empty__
-      #
-      key-file:
+  # Default value: ":8080"
+  #
+  addr: :8080
 
   ## base-path ##
   #
@@ -478,6 +407,7 @@ cluster-api:
   ## csrf ##
   #
   csrf:
+
     ## enabled ##
     #
     # Default value: true
@@ -505,6 +435,7 @@ cluster-api:
     # Set csrf cookie options
     #
     cookie:
+
       ## name ##
       #
       # Default value: kubetail_api_csrf
@@ -557,6 +488,7 @@ cluster-api:
   ## logging ##
   #
   logging:
+
     ## enabled ##
     #
     # Default value: true
@@ -589,6 +521,7 @@ cluster-api:
     ## access-log ##
     #
     access-log:
+
       ## enabled ##
       #
       # Enables web access logs for app
@@ -604,6 +537,16 @@ cluster-api:
       # Default: false
       #
       hide-health-checks: false
+
+  ## tls ##
+  #
+  tls:
+
+    ## enabled ##
+    #
+    # Default value: false
+    #
+    enabled: false
 
     ## cert-file ##
     #
@@ -624,6 +567,7 @@ cluster-api:
 ## cluster-agent ##
 #
 cluster-agent:
+
   ## addr ##
   #
   # Sets the target ip and port to bind the gRPC server to
@@ -635,6 +579,7 @@ cluster-agent:
   ## logging ##
   #
   logging:
+
     ## enabled ##
     #
     # Default value: true
@@ -667,6 +612,7 @@ cluster-agent:
   ## tls ##
   #
   tls:
+
     ## enabled ##
     #
     # Default value: false

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -9,17 +9,7 @@ metadata:
 data:
   config.yaml: |
     dashboard:
-      http:
-        addr: 0.0.0.0
-        port: 8080
-        enabled: true
-      https:
-        addr: 0.0.0.0
-        port: 8443
-        enabled: true
-        tls:
-          cert-file: /etc/tls/tls.crt
-          key-file: /etc/tls/tls.key
+      addr: :8080
       auth-mode: auto
       base-path: /
       cluster-api-endpoint: http://kubetail-cluster-api.kubetail-system.svc:8080
@@ -54,6 +44,10 @@ data:
         access-log:
           enabled: true
           hide-health-checks: true
+      tls: 
+        enabled: false
+        cert-file:
+        key-file:
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -66,17 +60,7 @@ metadata:
 data:
   config.yaml: |
     cluster-api:
-      http:
-        addr: 0.0.0.0
-        port: 8080
-        enabled: true
-      https:
-        addr: 0.0.0.0
-        port: 8443
-        enabled: true
-        tls:
-          cert-file: /etc/kubetail/tls.crt
-          key-file: /etc/kubetail/tls.key
+      addr: :8080
       base-path: /
       gin-mode: debug
       cluster-agent:
@@ -105,6 +89,10 @@ data:
         access-log:
           enabled: true
           hide-health-checks: true
+      tls: 
+        enabled: false
+        cert-file:
+        key-file:
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -130,7 +130,7 @@ var serveCmd = &cobra.Command{
 
 		// create server
 		server := http.Server{
-			Addr:         fmt.Sprintf("%s:%d", cfg.Dashboard.HTTP.Address, cfg.Dashboard.HTTP.Port),
+			Addr:         cfg.Dashboard.Addr,
 			Handler:      app,
 			IdleTimeout:  1 * time.Minute,
 			ReadTimeout:  5 * time.Second,

--- a/modules/cluster-api/README.md
+++ b/modules/cluster-api/README.md
@@ -8,11 +8,12 @@ Go-based HTTP server that handles Kubetail Cluster API requests
 
 The Kubetail Cluster API executable supports the following command line configuration options:
 
-| Flag         | Datatype   | Description                      | Default                   |
-| ------------ | ---------- | -------------------------------- | ------------------------- | --------- | --- |
-| -c, --config | string     | Path to Kubetail config file     | ""                        |
-| <!--         | --gin-mode | string                           | Gin mode (release, debug) | "release" | --> |
-| -p, --param  | []string   | Config params ("key:val" format) | []                        |
+| Flag         | Datatype   | Description                      | Default   |
+| ------------ | ---------- | -------------------------------- | --------- |
+| -c, --config | string     | Path to Kubetail config file     | ""        |
+| -a, --addr   | string     | Host address to bind to          | ":8080"   |
+| --gin-mode   | string     | Gin mode (release, debug)        | "release" |
+| -p, --param  | []string   | Config params ("key:val" format) | []        |
 
 ### Config file
 
@@ -21,6 +22,7 @@ The Kubetail Cluster API executable can be configured using a configuration file
 | Name                                              | Datatype | Description                                        | Default                                     | Status |
 | ------------------------------------------------- | -------- | -------------------------------------------------- | ------------------------------------------- | ------ |
 | allowed-namespaces                                | []string | If populated, restricts namespace access           | []                                          | stable |
+| cluster-api.addr                                  | string   | Host address to bind to                            | ":8080"                                     | stable |
 | cluster-api.base-path                             | string   | URL path prefix                                    | "/"                                         | stable |
 | cluster-api.gin-mode                              | string   | Gin mode (release, debug)                          | "release"                                   | stable |
 | cluster-api.cluster-agent.dispatch-url            | string   | URL for sending dispatch requests to cluster-agent | "kubernetes://kubetail-cluster-agent:50051" | alpha  |
@@ -39,19 +41,14 @@ The Kubetail Cluster API executable can be configured using a configuration file
 | cluster-api.csrf.cookie.secure                    | bool     | CSRF cookie secure property                        | false                                       | stable |
 | cluster-api.csrf.cookie.http-only                 | bool     | CSRF cookie HttpOnly property                      | true                                        | stable |
 | cluster-api.csrf.cookie.same-site                 | string   | CSRF cookie SameSite property (strict, lax, none)  | "strict"                                    | stable |
-| cluster-api.http.enabled                          | bool     | Enables http server                                | true                                        | stable |
-| cluster-api.http.address                          | string   | URL of the http server                             | ""                                          | stable |
-| cluster-api.http.port                             | int      | Port of the http server                            | 8080                                        | stable |
-| cluster-api.https.enabled                         | bool     | Enables https server                               | false                                       | stable |
-| cluster-api.https.address                         | string   | URL of the https server                            | ""                                          | stable |
-| cluster-api.https.port                            | int      | Port of the https server                           | 8443                                        | stable |
-| cluster-api.https.tls.cert-file                   | string   | Path to tls certificate file                       | ""                                          | stable |
-| cluster-api.https.tls.key-file                    | string   | Path to tls key file                               | ""                                          | stable |
 | cluster-api.logging.enabled                       | bool     | Enable logging                                     | true                                        | stable |
 | cluster-api.logging.level                         | string   | Log level                                          | "info"                                      | stable |
 | cluster-api.logging.format                        | string   | Log format (json, pretty)                          | "json"                                      | stable |
 | cluster-api.logging.access-log.enabled            | bool     | Enable access log                                  | true                                        | stable |
 | cluster-api.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log          | false                                       | stable |
+| cluster-api.tls.enabled                           | bool     | Enable tls                                         | false                                       | stable |
+| cluster-api.tls.cert-file                         | string   | Path to tls certificate file                       | ""                                          | stable |
+| cluster-api.tls.key-file                          | string   | Path to tls key file                               | ""                                          | stable |  
 
 ## GraphQL
 

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -17,6 +17,7 @@ The Kubetail backend server executable supports the following command line confi
 | Flag         | Datatype | Description                      | Default   |
 | ------------ | -------- | -------------------------------- | --------- |
 | -c, --config | string   | Path to Kubetail config file     | ""        |
+| -a, --addr   | string   | Host address to bind to          | ":8080"   |
 | --gin-mode   | string   | Gin mode (release, debug)        | "release" |
 | -p, --param  | []string | Config params ("key:val" format) | []        |
 
@@ -27,18 +28,11 @@ The Kubetail Dashboard server can be configured using a configuration file writt
 | Name                                            | Datatype | Description                                          | Default      | Status       |
 | ----------------------------------------------- | -------- | ---------------------------------------------------- | ------------ | ------------ |
 | allowed-namespaces                              | []string | If populated, restricts namespace access             | []           | stable       |
+| dashboard.addr                                  | string   | Host address to bind to                              | ":8080"      | stable       |
 | dashboard.auth-mode                             | string   | Auth mode (auto, token)                              | "auto"       | experimental |
 | dashboard.base-path                             | string   | URL path prefix                                      | "/"          | stable       |
 | dashboard.cluster-api-endpoint                  | string   | Service url for Cluster API                          | ""           | experimental |
 | dashboard.environment                           | string   | Environment (desktop, cluster)                       | "desktop"    | experimental |
-| dashboard.http.enabled                          | bool     | Enables http server                                  | true         | stable       |
-| dashboard.http.address                          | string   | URL of the http server                               | ""           | stable       |
-| dashboard.http.port                             | int      | Port of the http server                              | 8080         | stable       |
-| dashboard.https.enabled                         | bool     | Enables https server                                 | false        | stable       |
-| dashboard.https.address                         | string   | URL of the https server                              | ""           | stable       |
-| dashboard.https.port                            | int      | Port of the https server                             | 8443         | stable       |
-| dashboard.https.tls.cert-file                   | string   | Path to tls certificate file                         | ""           | stable       |
-| dashboard.https.tls.key-file                    | string   | Path to tls key file                                 | ""           | stable       |
 | dashboard.gin-mode                              | string   | Gin mode (release, debug)                            | "release"    | stable       |
 | dashboard.csrf.enabled                          | bool     | Enable CSRF protection                               | true         | stable       |
 | dashboard.csrf.field-name                       | string   | CSRF token name in forms                             | "csrf_token" | stable       |
@@ -64,6 +58,9 @@ The Kubetail Dashboard server can be configured using a configuration file writt
 | dashboard.session.cookie.http-only              | bool     | Session cookie HttpOnly property                     | true         | stable       |
 | dashboard.session.cookie.same-site              | string   | Session cookie SameSite property (strict, lax, none) | "strict"     | stable       |
 | dashboard.ui.cluster-api-enabled                | bool     | Enable Cluster API features                          | true         | experimental |
+| dashboard.tls.enabled                           | bool     | Enable tls                                           | false        | stable       |
+| dashboard.tls.cert-file                         | string   | Path to tls certificate file                         | ""           | stable       |
+| dashboard.tls.key-file                          | string   | Path to tls key file                                 | ""           | stable       |  
 
 ## GraphQL
 

--- a/modules/dashboard/cmd/main.go
+++ b/modules/dashboard/cmd/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -65,6 +64,7 @@ func main() {
 
 			// Init viper
 			v := viper.New()
+			v.BindPFlag("dashboard.addr", cmd.Flags().Lookup("addr"))
 			v.BindPFlag("dashboard.gin-mode", cmd.Flags().Lookup("gin-mode"))
 
 			// Init config
@@ -108,59 +108,31 @@ func main() {
 				zlog.Fatal().Caller().Err(err).Send()
 			}
 
-			// Create servers
-			var servers []*http.Server
-			var serverWg sync.WaitGroup
+			// Create server
+			server := &http.Server{
+				Addr:         cfg.Dashboard.Addr,
+				Handler:      app,
+				IdleTimeout:  1 * time.Minute,
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			}
 
-			// HTTP Server
-			if cfg.Dashboard.HTTP.Enabled {
-				httpAddr := fmt.Sprintf("%s:%d", cfg.Dashboard.HTTP.Address, cfg.Dashboard.HTTP.Port)
-				httpServer := &http.Server{
-					Addr:         httpAddr,
-					Handler:      app,
-					IdleTimeout:  1 * time.Minute,
-					ReadTimeout:  5 * time.Second,
-					WriteTimeout: 10 * time.Second,
+			// Run server in goroutine
+			go func() {
+				var serverErr error
+				zlog.Info().Msg("Starting server on " + cfg.Dashboard.Addr)
+
+				if cfg.Dashboard.TLS.Enabled {
+					serverErr = server.ListenAndServeTLS(cfg.Dashboard.TLS.CertFile, cfg.Dashboard.TLS.KeyFile)
+				} else {
+					serverErr = server.ListenAndServe()
 				}
-				servers = append(servers, httpServer)
 
-				serverWg.Add(1)
-				go func() {
-					defer serverWg.Done()
-					zlog.Info().Msg("Starting HTTP server on " + httpAddr)
-					if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-						zlog.Fatal().Caller().Err(err).Send()
-					}
-				}()
-			}
-
-			// HTTPS Server
-			if cfg.Dashboard.HTTPS.Enabled {
-				httpsAddr := fmt.Sprintf("%s:%d", cfg.Dashboard.HTTPS.Address, cfg.Dashboard.HTTPS.Port)
-
-				httpsServer := &http.Server{
-					Addr:         httpsAddr,
-					Handler:      app,
-					IdleTimeout:  1 * time.Minute,
-					ReadTimeout:  5 * time.Second,
-					WriteTimeout: 10 * time.Second,
+				// log non-normal errors
+				if serverErr != nil && serverErr != http.ErrServerClosed {
+					zlog.Fatal().Caller().Err(err).Send()
 				}
-				servers = append(servers, httpsServer)
-
-				serverWg.Add(1)
-				go func() {
-					defer serverWg.Done()
-					zlog.Info().Msg("Starting HTTPS server on " + httpsAddr)
-					if err := httpsServer.ListenAndServeTLS(cfg.Dashboard.HTTPS.TLS.CertFile, cfg.Dashboard.HTTPS.TLS.KeyFile); err != nil && err != http.ErrServerClosed {
-						zlog.Fatal().Caller().Err(err).Send()
-					}
-				}()
-			}
-
-			// Ensure at least one server is enabled
-			if len(servers) == 0 {
-				zlog.Fatal().Msg("No servers enabled. Please enable at least HTTP or HTTPS")
-			}
+			}()
 
 			// wait for termination signal
 			<-quit
@@ -175,15 +147,13 @@ func main() {
 			var wg sync.WaitGroup
 
 			// attempt graceful shutdown
-			for _, server := range servers {
-				wg.Add(1)
-				go func(s *http.Server) {
-					defer wg.Done()
-					if err := s.Shutdown(ctx); err != nil {
-						zlog.Error().Err(err).Send()
-					}
-				}(server)
-			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := server.Shutdown(ctx); err != nil {
+					zlog.Error().Err(err).Send()
+				}
+			}()
 
 			// shutdown app
 			// TODO: handle long-lived requests shutdown (e.g. websockets)
@@ -207,6 +177,7 @@ func main() {
 	flagset := cmd.Flags()
 	flagset.SortFlags = false
 	flagset.StringVarP(&cli.Config, "config", "c", "", "Path to configuration file (e.g. \"/etc/kubetail/dashboard.yaml\")")
+	flagset.StringP("addr", "a", ":8080", "Host address to bind to")
 	flagset.String("gin-mode", "release", "Gin mode (release, debug)")
 	flagset.StringArrayVarP(&params, "param", "p", []string{}, "Config params")
 

--- a/modules/dashboard/hack/config.yaml
+++ b/modules/dashboard/hack/config.yaml
@@ -1,9 +1,8 @@
 allowed-namespaces: []
 dashboard:
+  addr: :4000
   base-path: /
   gin-mode: debug
-  http:
-    port: 4000
   csrf:
     secret: replaceme
   logging:


### PR DESCRIPTION
## Summary

This PR reverts to single-port http endpoints in the Kubetail Dashboard and the Kubetail Cluster Agent servers. In a recent commit we added support for dual-port http/https endpoints but upon further reflection it's better to keep the original behavior (single-port has less operational complexity, less security risk and is inline with Kubernetes' own API server behavior). Since we haven't issued a release since the dual-port commit, this PR represents a non-breaking change from the point of view of users. We may want to make breaking changes in the future but the only goal of this PR was to revert to the previous behavior.

## Changes

* Modify `hack/config.yaml` and revert to old single-port config schema
* Modify `modules/shared/config/config.go` and implement old single-port schema
* Modify `modules/dashboard/cmd/main.go` and revert to old single-port behavior
* Modify `modules/cluster-api/cmd/main.go` and revert to old single-port behavior
* Update docs

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
