### PR TITLE
🎣 Fix concurrent memoization issue in syncmap

### DIFF
--- a/modules/shared/k8shelpers/connection-manager_test.go
+++ b/modules/shared/k8shelpers/connection-manager_test.go
@@ -58,7 +58,9 @@ func TestDesktopConnectionManager_NewInformer_AuthorizationFailure(t *testing.T)
 		authorizer: mockAuthorizer,
 	}
 
-	cm.csCache.Store("test-context", &kubernetes.Clientset{})
+	cm.csCache.LoadOrCompute("test-context", func() (*kubernetes.Clientset, error) {
+		return &kubernetes.Clientset{}, nil
+	})
 
 	// Set up test parameters
 	ctx := context.Background()

--- a/modules/shared/util/syncgroup.go
+++ b/modules/shared/util/syncgroup.go
@@ -1,0 +1,88 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"sync"
+)
+
+// SyncGroup is a generic memoization library that uses our implementation
+// of SyncMap under the hood
+
+type SyncGroup[K comparable, V any] struct {
+	m     SyncMap[K, V]
+	muMap SyncMap[K, *sync.Mutex]
+}
+
+// Expose SyncMap Range function
+func (g *SyncGroup[K, V]) Range(f func(key K, value V) bool) {
+	g.m.Range(f)
+}
+
+// LoadOrCompute returns the existing value for the key if present. Otherwise, it calls the
+// compute function and stores the result. Subsequent callers will wait until the result is
+// ready. The compute function is only called once per key, even under concurrent access.
+func (g *SyncGroup[K, V]) LoadOrCompute(key K, compute func() (V, error)) (V, bool, error) {
+	mu, _ := g.muMap.LoadOrStore(key, &sync.Mutex{})
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Fast path: check if value already exists
+	if v, loaded := g.m.Load(key); loaded {
+		return v, true, nil
+	}
+
+	// Create and store the value
+	value, err := compute()
+	if err != nil {
+		return value, false, err
+	}
+
+	g.m.Store(key, value)
+	return value, false, nil
+}
+
+// LoadOrComputeWithContext is a context-aware version of LoadOrComputer. If the context is
+// cancelled during computation, it returns the context error.
+func (g *SyncGroup[K, V]) LoadOrComputeWithContext(ctx context.Context, key K, compute func() (V, error)) (V, bool, error) {
+	// Exit early if context already canceled
+	if err := ctx.Err(); err != nil {
+		var zero V
+		return zero, false, err
+	}
+
+	type result struct {
+		value  V
+		loaded bool
+		err    error
+	}
+
+	resultCh := make(chan result, 1)
+
+	// Execute inner LoadOrCompute() inside goroutine
+	go func() {
+		v, loaded, err := g.LoadOrCompute(key, compute)
+		resultCh <- result{v, loaded, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		var zero V
+		return zero, false, ctx.Err()
+	case res := <-resultCh:
+		return res.value, res.loaded, res.err
+	}
+}

--- a/modules/shared/util/syncgroup_test.go
+++ b/modules/shared/util/syncgroup_test.go
@@ -1,0 +1,203 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncGroupLoadOrCompute(t *testing.T) {
+	var g SyncGroup[string, int]
+
+	// Test creating new value
+	result, loaded, err := g.LoadOrCompute("key1", func() (int, error) {
+		return 42, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, result)
+
+	// Test loading existing value (compute function should not be called)
+	computeCalled := false
+	result, loaded, err = g.LoadOrCompute("key1", func() (int, error) {
+		computeCalled = true
+		return 99, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, loaded)
+	assert.Equal(t, 42, result)
+	assert.False(t, computeCalled)
+
+	// Test error handling
+	computeErr := errors.New("compute error")
+	_, _, err = g.LoadOrCompute("key2", func() (int, error) {
+		return 0, computeErr
+	})
+	require.ErrorIs(t, err, computeErr)
+
+	// Verify error case didn't store anything
+	_, ok := g.m.Load("key2")
+	assert.False(t, ok)
+}
+
+func TestSyncGroupLoadOrComputeConcurrency(t *testing.T) {
+	var g SyncGroup[string, int]
+	var computeCount int32
+
+	// Run multiple goroutines trying to create the same key
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	results := make([]int, numGoroutines)
+	errors := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			result, _, err := g.LoadOrCompute("shared_key", func() (int, error) {
+				atomic.AddInt32(&computeCount, 1)
+				return 123, nil
+			})
+			results[index] = result
+			errors[index] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify compute function was called exactly once
+	require.Equal(t, int32(1), computeCount)
+
+	// Verify all goroutines got the same result
+	for i := range numGoroutines {
+		require.NoError(t, errors[i], "%d", i)
+		require.Equal(t, 123, results[i], "%d", i)
+	}
+
+	// Verify the value is stored correctly
+	value, ok := g.m.Load("shared_key")
+	assert.True(t, ok)
+	assert.Equal(t, 123, value)
+}
+
+func TestSyncGroupLoadOrComputeWithContext(t *testing.T) {
+	var g SyncGroup[string, int]
+
+	t.Run("successful computation", func(t *testing.T) {
+		ctx := context.Background()
+		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
+			return 42, nil
+		})
+		require.NoError(t, err)
+		assert.False(t, loaded)
+		assert.Equal(t, 42, result)
+	})
+
+	t.Run("load existing value", func(t *testing.T) {
+		ctx := context.Background()
+		computeCalled := false
+		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
+			computeCalled = true
+			return 99, nil
+		})
+		require.NoError(t, err)
+		assert.True(t, loaded)
+		assert.Equal(t, 42, result)
+		assert.False(t, computeCalled)
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancel context immediately
+		cancel()
+
+		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key2", func() (int, error) {
+			time.Sleep(100 * time.Millisecond)
+			return 99, nil
+		})
+
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, loaded)
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("context timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key3", func() (int, error) {
+			time.Sleep(50 * time.Millisecond)
+			return 99, nil
+		})
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.False(t, loaded)
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("compute error", func(t *testing.T) {
+		ctx := context.Background()
+		_, loaded, err := g.LoadOrComputeWithContext(ctx, "key4", func() (int, error) {
+			return 0, errors.New("compute error")
+		})
+		require.Error(t, err)
+		assert.False(t, loaded)
+		assert.Equal(t, "compute error", err.Error())
+	})
+
+	t.Run("concurrent access", func(t *testing.T) {
+		var m2 SyncGroup[string, int]
+		var computeCount int32
+		const numGoroutines = 50
+
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		results := make([]int, numGoroutines)
+		errors := make([]error, numGoroutines)
+
+		for i := range numGoroutines {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				result, _, err := m2.LoadOrComputeWithContext(ctx, "shared_key", func() (int, error) {
+					atomic.AddInt32(&computeCount, 1)
+					return 123, nil
+				})
+				results[index] = result
+				errors[index] = err
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Verify compute function was called exactly once
+		require.Equal(t, int32(1), computeCount)
+
+		// Verify all goroutines got the same result
+		for i := range numGoroutines {
+			require.NoError(t, errors[i], "goroutine %d", i)
+			require.Equal(t, 123, results[i], "goroutine %d", i)
+		}
+	})
+}

--- a/modules/shared/util/syncmap_test.go
+++ b/modules/shared/util/syncmap_test.go
@@ -15,12 +15,10 @@
 package util
 
 import (
-	"context"
-	"errors"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncMapBasic(t *testing.T) {
@@ -29,30 +27,23 @@ func TestSyncMapBasic(t *testing.T) {
 	// Store and Load
 	m.Store("a", 1)
 	v, ok := m.Load("a")
-	if !ok || v != 1 {
-		t.Fatalf("expected value 1, got %v ok=%v", v, ok)
-	}
+	require.True(t, ok)
+	assert.Equal(t, 1, v)
 
 	// LoadOrStore existing
 	actual, loaded := m.LoadOrStore("a", 2)
-	if !loaded || actual != 1 {
-		t.Fatalf("LoadOrStore did not return existing value")
-	}
+	require.True(t, loaded)
+	assert.Equal(t, 1, actual)
 
 	// Swap
 	prev, loaded := m.Swap("a", 3)
-	if !loaded || prev != 1 {
-		t.Fatalf("Swap expected 1 got %v", prev)
-	}
+	require.True(t, loaded)
+	assert.Equal(t, 1, prev)
 
 	// CompareAndSwap success
-	if !m.CompareAndSwap("a", 3, 4) {
-		t.Fatalf("CompareAndSwap should succeed")
-	}
+	require.True(t, m.CompareAndSwap("a", 3, 4))
 	v, _ = m.Load("a")
-	if v != 4 {
-		t.Fatalf("expected 4 got %v", v)
-	}
+	assert.Equal(t, 4, v)
 
 	// Range and Delete
 	count := 0
@@ -60,236 +51,9 @@ func TestSyncMapBasic(t *testing.T) {
 		count++
 		return true
 	})
-	if count != 1 {
-		t.Fatalf("expected range count 1 got %d", count)
-	}
+	assert.Equal(t, 1, count)
 
 	m.Delete("a")
 	_, ok = m.Load("a")
-	if ok {
-		t.Fatalf("expected key deleted")
-	}
-}
-
-func TestSyncMapLoadOrCompute(t *testing.T) {
-	var m SyncMap[string, int]
-
-	// Test creating new value
-	result, err := m.LoadOrCompute("key1", func() (int, error) {
-		return 42, nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != 42 {
-		t.Fatalf("expected 42, got %d", result)
-	}
-
-	// Test loading existing value (compute function should not be called)
-	computeCalled := false
-	result, err = m.LoadOrCompute("key1", func() (int, error) {
-		computeCalled = true
-		return 99, nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != 42 {
-		t.Fatalf("expected 42, got %d", result)
-	}
-	if computeCalled {
-		t.Fatalf("compute function should not be called for existing key")
-	}
-
-	// Test error handling
-	_, err = m.LoadOrCompute("key2", func() (int, error) {
-		return 0, errors.New("compute error")
-	})
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	if err.Error() != "compute error" {
-		t.Fatalf("expected 'compute error', got '%s'", err.Error())
-	}
-
-	// Verify error case didn't store anything
-	_, ok := m.Load("key2")
-	if ok {
-		t.Fatalf("expected key2 to not exist after error")
-	}
-}
-
-func TestSyncMapLoadOrComputeConcurrency(t *testing.T) {
-	var m SyncMap[string, int]
-	var computeCount int32
-
-	// Run multiple goroutines trying to create the same key
-	const numGoroutines = 100
-	var wg sync.WaitGroup
-	results := make([]int, numGoroutines)
-	errors := make([]error, numGoroutines)
-
-	for i := range numGoroutines {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			result, err := m.LoadOrCompute("shared_key", func() (int, error) {
-				atomic.AddInt32(&computeCount, 1)
-				return 123, nil
-			})
-			results[index] = result
-			errors[index] = err
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify compute function was called exactly once
-	if computeCount != 1 {
-		t.Fatalf("expected compute function to be called once, got %d", computeCount)
-	}
-
-	// Verify all goroutines got the same result
-	for i := range numGoroutines {
-		if errors[i] != nil {
-			t.Fatalf("goroutine %d got error: %v", i, errors[i])
-		}
-		if results[i] != 123 {
-			t.Fatalf("goroutine %d got result %d, expected 123", i, results[i])
-		}
-	}
-
-	// Verify the value is stored correctly
-	value, ok := m.Load("shared_key")
-	if !ok {
-		t.Fatalf("expected shared_key to exist")
-	}
-	if value != 123 {
-		t.Fatalf("expected 123, got %d", value)
-	}
-}
-
-func TestSyncMapLoadOrComputeWithContext(t *testing.T) {
-	var m SyncMap[string, int]
-
-	t.Run("successful computation", func(t *testing.T) {
-		ctx := context.Background()
-		result, err := m.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
-			return 42, nil
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if result != 42 {
-			t.Fatalf("expected 42, got %d", result)
-		}
-	})
-
-	t.Run("load existing value", func(t *testing.T) {
-		ctx := context.Background()
-		computeCalled := false
-		result, err := m.LoadOrComputeWithContext(ctx, "key1", func() (int, error) {
-			computeCalled = true
-			return 99, nil
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if result != 42 {
-			t.Fatalf("expected 42, got %d", result)
-		}
-		if computeCalled {
-			t.Fatalf("compute function should not be called for existing key")
-		}
-	})
-
-	t.Run("context cancellation", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-
-		// Cancel context immediately
-		cancel()
-
-		result, err := m.LoadOrComputeWithContext(ctx, "key2", func() (int, error) {
-			time.Sleep(100 * time.Millisecond)
-			return 99, nil
-		})
-
-		if err != context.Canceled {
-			t.Fatalf("expected context.Canceled, got %v", err)
-		}
-		if result != 0 {
-			t.Fatalf("expected zero value, got %d", result)
-		}
-	})
-
-	t.Run("context timeout", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-		defer cancel()
-
-		result, err := m.LoadOrComputeWithContext(ctx, "key3", func() (int, error) {
-			time.Sleep(50 * time.Millisecond)
-			return 99, nil
-		})
-
-		if err != context.DeadlineExceeded {
-			t.Fatalf("expected context.DeadlineExceeded, got %v", err)
-		}
-		if result != 0 {
-			t.Fatalf("expected zero value, got %d", result)
-		}
-	})
-
-	t.Run("compute error", func(t *testing.T) {
-		ctx := context.Background()
-		_, err := m.LoadOrComputeWithContext(ctx, "key4", func() (int, error) {
-			return 0, errors.New("compute error")
-		})
-		if err == nil {
-			t.Fatalf("expected error")
-		}
-		if err.Error() != "compute error" {
-			t.Fatalf("expected 'compute error', got '%s'", err.Error())
-		}
-	})
-
-	t.Run("concurrent access", func(t *testing.T) {
-		var m2 SyncMap[string, int]
-		var computeCount int32
-		const numGoroutines = 50
-
-		ctx := context.Background()
-		var wg sync.WaitGroup
-		results := make([]int, numGoroutines)
-		errors := make([]error, numGoroutines)
-
-		for i := range numGoroutines {
-			wg.Add(1)
-			go func(index int) {
-				defer wg.Done()
-				result, err := m2.LoadOrComputeWithContext(ctx, "shared_key", func() (int, error) {
-					atomic.AddInt32(&computeCount, 1)
-					return 123, nil
-				})
-				results[index] = result
-				errors[index] = err
-			}(i)
-		}
-
-		wg.Wait()
-
-		// Verify compute function was called exactly once
-		if computeCount != 1 {
-			t.Fatalf("expected compute function to be called once, got %d", computeCount)
-		}
-
-		// Verify all goroutines got the same result
-		for i := range numGoroutines {
-			if errors[i] != nil {
-				t.Fatalf("goroutine %d got error: %v", i, errors[i])
-			}
-			if results[i] != 123 {
-				t.Fatalf("goroutine %d got result %d, expected 123", i, results[i])
-			}
-		}
-	})
+	assert.False(t, ok)
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue preventing `LoadOrCompute()` and `LoadOrComputeWithContext()` callback functions in the `SyncMap` implementation from running concurrently even for different map keys. Previously the `SyncMap` implementation used a per-instance mutex to implement wait-until-ready behavior which was preventing callbacks for different map keys from running concurrently. The solution is to implement per-key mutex locks but rather than adding this to `SyncMap` itself we decided to simplify the struct and return it to its original intension which is a type-aware implementation of `sync.Map`. Instead, we moved `LoadOrCompute()` and `LoadOrComputeWithContext()` into a new per-key thread-safe sister struct called `SyncGroup` that properly implements the desired memoization behavior.

This PR also does some light refactoring.

## Changes

* Remove `LoadOrCompute()` and `LoadOrComputeWithContext()` from `SyncMap`
* Create new struct `SyncGroup` with new methods that uses `SyncMap` under-the-hood to implement per-key mutex locks
* Removes unnecessary loop var copy statements from `shared/k8shelpers/connection-manager.go`
* Removes unnecessary logging statement from DesktopConnectionManager cache warmer

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
