### PR TITLE
🎣 Issue warning on browser open error instead of fatal exit

### DIFF
--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -170,7 +170,7 @@ var serveCmd = &cobra.Command{
 		if !skipOpen {
 			err = browser.OpenURL(fmt.Sprintf("http://%s:%d/", host, port))
 			if err != nil {
-				zlog.Fatal().Err(err).Send()
+				zlog.Warn().Err(err).Msg("Unable to open browser automatically. Please open the dashboard URL manually.")
 			}
 		}
 


### PR DESCRIPTION
## Summary

Previously, the Kubetail CLI `serve` sub-command would issue a fatal exit if it was unable to open a new browser tab. This PR modifies the behavior and issues a warning instead of exiting the command loop.

## Changes

* Replaced `zlog.Fatal()` with `zlog.Warn()` in `modules/cli/cmd/serve.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
