### PR TITLE
🎣 Fix scroll timing issue in logfeed viewer

### DIFF
--- a/dashboard-ui/src/lib/logfeed.tsx
+++ b/dashboard-ui/src/lib/logfeed.tsx
@@ -411,6 +411,8 @@ const ContentImpl: React.ForwardRefRenderFunction<ContentHandle, ContentProps> =
 
   const [msgColWidth, setMsgColWidth] = useState(0);
 
+  const nextTick = useNextTick();
+
   let itemCount = items.length + 1; // always add extra row before
   if (hasMoreAfter) itemCount += 1; // only add extra row if more are hidden
 
@@ -459,7 +461,7 @@ const ContentImpl: React.ForwardRefRenderFunction<ContentHandle, ContentProps> =
     if (startIndex === 0) await loadMoreBefore();
     else await loadMoreAfter();
 
-    setTimeout(() => {
+    nextTick(() => {
       // maintain scroll position
       if (startIndex === 0 && listOuterRef.current) {
         // Scroll
@@ -472,7 +474,7 @@ const ContentImpl: React.ForwardRefRenderFunction<ContentHandle, ContentProps> =
 
       // stop loading
       setIsLoading(false);
-    }, 0);
+    });
   };
 
   // -------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes an issue with scroll lock timing when scrolling up in the log feed viewer that was introduced with the Jotai migration. The desired behavior is that the apparent scroll position should be maintained when the user scrolls up and new data is fetched and prepended to the cache. This behavior was working properly with Recoil but broke with Jotai because apparently the libraries have different DOM update timings. This PR fixes the issue by wrapping the scroll lock logic in a `nextTick()` instead of a `setTimeout()`.

## Changes

- Replaced use of `setTimeout()` for timing with `nextTick()`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
