### PR TITLE
🐋 Implement Watch of LogMetadataService

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "prost-wkt-types",
  "regex",
  "rgkl",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -683,6 +684,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2579,6 +2581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2609,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -2715,6 +2732,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -371,6 +371,8 @@ dependencies = [
  "eyre",
  "k8s-openapi",
  "kube",
+ "notify",
+ "notify-debouncer-full",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-resource-detectors",
@@ -625,15 +627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
+name = "file-id"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
 dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1582,17 +1581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,13 +1704,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
  "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1731,7 +1718,20 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]
@@ -1935,7 +1935,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3648,7 +3648,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3657,7 +3657,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3666,14 +3675,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3683,10 +3708,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3695,10 +3732,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3707,10 +3756,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3719,10 +3780,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -42,3 +42,6 @@ tempfile = "3.20.0"
 notify = "8.1.0"
 notify-debouncer-full = "0.5.0"
 
+[dev-dependencies]
+serial_test = "3.2.0"
+

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -39,4 +39,6 @@ kube = { version = "1.1.0" }
 k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 regex = "1.11.1"
 tempfile = "3.20.0"
+notify = "8.1.0"
+notify-debouncer-full = "0.5.0"
 

--- a/crates/cluster_agent/src/logmetadata.rs
+++ b/crates/cluster_agent/src/logmetadata.rs
@@ -47,7 +47,7 @@ impl LogMetadataImpl {
     fn get_log_metadata(
         filepath: PathBuf,
         logs_dir: PathBuf,
-        namespaces: Option<&Vec<String>>,
+        namespaces: &Vec<String>,
         file_exists: bool,
     ) -> Result<Option<LogMetadata>, Box<Status>> {
         let filename = filepath.to_string_lossy();
@@ -66,7 +66,7 @@ impl LogMetadataImpl {
         let mut absolute_file_path = logs_dir;
         absolute_file_path.push(filepath);
 
-        if namespaces.is_some_and(|namespaces| !namespaces.contains(&namespace)) {
+        if !namespaces.contains(&namespace) {
             return Ok(None);
         }
 
@@ -133,7 +133,7 @@ impl LogMetadataService for LogMetadataImpl {
             let metadata = Self::get_log_metadata(
                 file.file_name().into(),
                 logs_dir_path.to_path_buf(),
-                Some(&request.namespaces),
+                &request.namespaces,
                 true,
             )
             .map_err(|status| *status)?;

--- a/crates/cluster_agent/src/logmetadata.rs
+++ b/crates/cluster_agent/src/logmetadata.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
+use tracing::debug;
 
 use tokio::fs::read_dir;
 use tokio::sync::broadcast::Sender;
@@ -48,7 +49,7 @@ impl LogMetadataImpl {
         let captures = LOG_FILE_REGEX.captures(filename.as_ref());
 
         if captures.is_none() {
-            println!("Filename could not be parsed: {}", filename.as_ref());
+            debug!("Filename could not be parsed: {}", filename.as_ref());
             return None;
         }
 
@@ -143,6 +144,7 @@ impl LogMetadataService for LogMetadataImpl {
         }));
     }
 
+    #[tracing::instrument]
     async fn watch(
         &self,
         request: Request<LogMetadataWatchRequest>,

--- a/crates/cluster_agent/src/logmetadata/logmetadata_watcher.rs
+++ b/crates/cluster_agent/src/logmetadata/logmetadata_watcher.rs
@@ -1,0 +1,328 @@
+use core::fmt;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use notify::{
+    Event, EventKind, RecommendedWatcher, RecursiveMode,
+    event::{ModifyKind, RenameMode},
+};
+use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer};
+use tokio::{
+    fs::read_dir,
+    runtime::Handle,
+    select,
+    sync::{
+        broadcast::Sender as BcSender,
+        mpsc::{Receiver, Sender, channel},
+    },
+};
+use tokio_stream::{StreamExt, wrappers::ReadDirStream};
+use tonic::Status;
+use types::cluster_agent::LogMetadataWatchEvent;
+
+use crate::logmetadata::{LOG_FILE_REGEX, LogMetadataImpl};
+
+#[derive(Debug)]
+pub struct LogMetadataWatcher {
+    log_metadata_tx: Sender<Result<LogMetadataWatchEvent, Status>>,
+    term_tx: BcSender<()>,
+    namespaces: Vec<String>,
+    directory: PathBuf,
+}
+
+impl LogMetadataWatcher {
+    pub fn new(
+        directory: PathBuf,
+        namespaces: Vec<String>,
+        term_tx: BcSender<()>,
+    ) -> (Self, Receiver<Result<LogMetadataWatchEvent, Status>>) {
+        let (log_metadata_tx, log_metadata_rx) = channel(100);
+
+        (
+            Self {
+                log_metadata_tx,
+                term_tx,
+                namespaces,
+                directory,
+            },
+            log_metadata_rx,
+        )
+    }
+
+    pub async fn watch(&self) -> Result<(), Box<Status>> {
+        let (internal_tx, mut intenral_rx) = channel(10);
+        let runtime_handle = Handle::current();
+
+        let mut debouncer = new_debouncer(
+            Duration::from_secs(2),
+            None,
+            move |result: DebounceEventResult| {
+                runtime_handle.block_on(async {
+                    let _ = internal_tx.send(handle_debounced_events(result)).await;
+                });
+            },
+        )
+        .map_err(|error| Box::new(Status::new(tonic::Code::Unknown, format!("{error:?}"))))?;
+
+        let paths_to_add = find_log_files(&self.directory, &self.namespaces).await?;
+
+        for path in paths_to_add {
+            let _ = debouncer.watch(&path, notify::RecursiveMode::NonRecursive);
+        }
+        debouncer
+            .watch(&self.directory, notify::RecursiveMode::NonRecursive)
+            .map_err(|error| {
+                Box::new(Status::new(
+                    tonic::Code::NotFound,
+                    format!(
+                        "Could not watch directory: {:?} {:?}",
+                        error.kind, error.paths
+                    ),
+                ))
+            })?;
+
+        let mut term_rx = self.term_tx.subscribe();
+
+        'outer: loop {
+            select! {
+                metadata_events = intenral_rx.recv() => {
+                    if let Some(metadata_events) = metadata_events {
+                        for metadata_event in metadata_events {
+                            if self.log_metadata_tx.send(metadata_event.clone().map_err(|error| *error)).await.is_err() {
+                                    println!("Channel closed from client.");
+                                    break 'outer;
+                            }
+
+                            if let Ok(metadata_event) = metadata_event {
+                                self.update_watcher(metadata_event, &mut debouncer);
+                            }
+                        }
+                    } else {
+                        println!("Internal channel closed!");
+                        break;
+                    }
+                }
+                _ = term_rx.recv() => {
+                        println!("Finished");
+                        break;
+                    }
+            }
+        }
+
+        println!("Stopping watcher");
+        debouncer.stop();
+
+        Ok(())
+    }
+
+    fn update_watcher(
+        &self,
+        watch_event: LogMetadataWatchEvent,
+        watcher: &mut Debouncer<RecommendedWatcher, RecommendedCache>,
+    ) {
+        match LogMetadataWatchEventType::from_str(&watch_event.r#type) {
+            Some(LogMetadataWatchEventType::Added) => {
+                let _ = watcher.watch(self.get_file_path(watch_event), RecursiveMode::NonRecursive);
+            }
+            Some(LogMetadataWatchEventType::Deleted) => {
+                let _ = watcher.unwatch(self.get_file_path(watch_event));
+            }
+            _ => (),
+        }
+    }
+
+    fn get_file_path(&self, watch_event: LogMetadataWatchEvent) -> PathBuf {
+        let file_metadata = watch_event.object.unwrap().spec.unwrap();
+        let mut file_path = self.directory.clone();
+        file_path.set_file_name(format!(
+            "{}_{}_{}-{}.log",
+            file_metadata.pod_name,
+            file_metadata.namespace,
+            file_metadata.container_name,
+            file_metadata.container_id
+        ));
+        file_path
+    }
+}
+
+async fn find_log_files(directory: &Path, namespaces: &[String]) -> Result<Vec<PathBuf>, Status> {
+    if !directory.is_dir() {
+        return Err(Status::new(
+            tonic::Code::NotFound,
+            format!("log directory not found: {}", directory.to_string_lossy()),
+        ));
+    }
+
+    let result = ReadDirStream::new(read_dir(directory).await?)
+        .collect::<Result<Vec<_>, _>>()
+        .await?
+        .into_iter()
+        .filter_map(|file| {
+            let filename = file.file_name();
+            let filename = filename.to_string_lossy();
+            let captures = LOG_FILE_REGEX.captures(&filename);
+
+            if captures.is_some()
+                && namespaces.contains(
+                    &captures
+                        .unwrap()
+                        .name("namespace")
+                        .unwrap()
+                        .as_str()
+                        .to_owned(),
+                )
+            {
+                let mut absolute_path = directory.to_path_buf();
+                absolute_path.push(file.file_name());
+
+                Some(absolute_path)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(result)
+}
+
+fn handle_debounced_events(
+    debounced_event_result: DebounceEventResult,
+) -> Vec<Result<LogMetadataWatchEvent, Box<Status>>> {
+    if let Err(errors) = debounced_event_result {
+        return errors
+            .into_iter()
+            .map(|error| {
+                Err(Box::new(Status::new(
+                    tonic::Code::Unknown,
+                    format!("{error:?}"),
+                )))
+            })
+            .collect();
+    }
+
+    debounced_event_result
+        .unwrap()
+        .into_iter()
+        .filter(|debounced_event| {
+            matches!(
+                debounced_event.kind,
+                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+            )
+        })
+        .flat_map(|debounced_event| transform_notify_event(&debounced_event.event))
+        .collect()
+}
+
+fn transform_notify_event(event: &Event) -> Vec<Result<LogMetadataWatchEvent, Box<Status>>> {
+    let mut result = Vec::new();
+
+    if let EventKind::Modify(ModifyKind::Name(rename_mode)) = event.kind {
+        match rename_mode {
+            RenameMode::Both => {
+                push_watch_event(
+                    &mut result,
+                    &LogMetadataWatchEventType::Deleted,
+                    event.paths.first(),
+                );
+                push_watch_event(
+                    &mut result,
+                    &LogMetadataWatchEventType::Added,
+                    event.paths.get(1),
+                );
+            }
+            RenameMode::From => push_watch_event(
+                &mut result,
+                &LogMetadataWatchEventType::Deleted,
+                event.paths.first(),
+            ),
+            RenameMode::To => push_watch_event(
+                &mut result,
+                &LogMetadataWatchEventType::Added,
+                event.paths.first(),
+            ),
+            _ => {
+                return result;
+            }
+        }
+    } else {
+        let event_type = match event.kind {
+            EventKind::Modify(_) => LogMetadataWatchEventType::Modified,
+            EventKind::Create(_) => LogMetadataWatchEventType::Added,
+            EventKind::Remove(_) => LogMetadataWatchEventType::Deleted,
+            _ => return result,
+        };
+
+        push_watch_event(&mut result, &event_type, event.paths.first());
+    }
+
+    result
+}
+
+#[derive(Debug)]
+enum LogMetadataWatchEventType {
+    Added,
+    Modified,
+    Deleted,
+}
+
+impl fmt::Display for LogMetadataWatchEventType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl LogMetadataWatchEventType {
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "ADDED" => Some(Self::Added),
+            "MODIFIED" => Some(Self::Modified),
+            "DELETED" => Some(Self::Deleted),
+            _ => None,
+        }
+    }
+
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Added => "ADDED",
+            Self::Modified => "MODIFIED",
+            Self::Deleted => "DELETED",
+        }
+    }
+}
+
+fn push_watch_event(
+    events: &mut Vec<Result<LogMetadataWatchEvent, Box<Status>>>,
+    event_type: &LogMetadataWatchEventType,
+    path: Option<&PathBuf>,
+) {
+    let Some(Some(filename)) = path.map(|path| path.file_name()) else {
+        return;
+    };
+
+    let path = path.unwrap();
+    let logs_dir = path.parent().unwrap();
+
+    let file_exists = matches!(
+        event_type,
+        LogMetadataWatchEventType::Added | LogMetadataWatchEventType::Modified
+    );
+    let log_metadata =
+        LogMetadataImpl::get_log_metadata(filename.into(), logs_dir.into(), None, file_exists);
+    let event_metadata = match log_metadata {
+        Err(err) => {
+            events.push(Err(err));
+            return;
+        }
+        Ok(None) => return,
+        Ok(Some(log_metadata)) => Some(log_metadata),
+    };
+
+    let watch_event = LogMetadataWatchEvent {
+        r#type: event_type.as_str().to_owned(),
+        object: event_metadata,
+    };
+
+    events.push(Ok(watch_event));
+}

--- a/crates/cluster_agent/src/logmetadata/logmetadata_watcher.rs
+++ b/crates/cluster_agent/src/logmetadata/logmetadata_watcher.rs
@@ -1,4 +1,3 @@
-use core::fmt;
 use std::{
     path::{Path, PathBuf},
     time::Duration,

--- a/crates/cluster_agent/src/logrecords.rs
+++ b/crates/cluster_agent/src/logrecords.rs
@@ -57,6 +57,7 @@ impl LogRecordsService for LogRecordsImpl {
     type StreamForwardStream = ReceiverStream<Result<LogRecord, Status>>;
     type StreamBackwardStream = ReceiverStream<Result<LogRecord, Status>>;
 
+    #[tracing::instrument]
     async fn stream_backward(
         &self,
         request: Request<LogRecordsStreamRequest>,
@@ -86,6 +87,7 @@ impl LogRecordsService for LogRecordsImpl {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
+    #[tracing::instrument]
     async fn stream_forward(
         &self,
         request: Request<LogRecordsStreamRequest>,

--- a/crates/cluster_agent/src/logrecords.rs
+++ b/crates/cluster_agent/src/logrecords.rs
@@ -67,6 +67,7 @@ impl LogRecordsService for LogRecordsImpl {
         let term_tx = self.term_tx.clone();
 
         self.task_tracker.spawn(async move {
+            // TODO: Add error handling
             let _ = stream_backward::stream_backward(
                 &file_path,
                 request.start_time.parse::<DateTime<Utc>>().ok(),
@@ -96,6 +97,7 @@ impl LogRecordsService for LogRecordsImpl {
         let term_tx = self.term_tx.clone();
 
         self.task_tracker.spawn(async move {
+            // TODO: Add error handling
             let _ = stream_forward::stream_forward(
                 &file_path,
                 request.start_time.parse::<DateTime<Utc>>().ok(),

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -1,4 +1,5 @@
-use tokio::signal::{ctrl_c, unix::*};
+use tokio::signal::ctrl_c;
+use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::broadcast::{self, Sender};
 use tokio_util::task::TaskTracker;
 use tonic::transport::Server;

--- a/proto/cluster_agent.proto
+++ b/proto/cluster_agent.proto
@@ -20,29 +20,42 @@ option go_package = "shared/clusteragentpb";
 
 import "google/protobuf/timestamp.proto";
 
-// Define LogMetadata service
-
+// LogMetadataService provides metadata for the log files in a directory.
 service LogMetadataService {
+  // List the log files and their metadata.
   rpc List (LogMetadataListRequest) returns (LogMetadataList);
+
+  // Subscribe for changes on a directory and its files (non-recursive).
   rpc Watch (LogMetadataWatchRequest) returns (stream LogMetadataWatchEvent);
 }
 
+// Metadata for a log file.
 message LogMetadata {
+  // Container id.
   string id = 1;
+
   LogMetadataSpec spec = 2;
+
   LogMetadataFileInfo fileInfo = 3;
 }
 
 message LogMetadataFileInfo {
+  // Size of the file in bytes.
   int64 size = 1;
+
   google.protobuf.Timestamp last_modified_at = 2;
 }
 
+// K8s metadata information.
 message LogMetadataSpec {
   string node_name = 1;
+
   string namespace = 2;
+
   string pod_name = 3;
+
   string container_name = 4;
+
   string container_id = 5;
 }
 
@@ -58,8 +71,14 @@ message LogMetadataWatchRequest {
   repeated string namespaces = 1;
 }
 
+// Represents an update of the metadata of the log file.
 message LogMetadataWatchEvent {
+  // Possible values:
+  // ADDED -> A new file was created.
+  // MODIFIED -> File has been modified.
+  // DELETED -> File was deleted.
   string type = 1;
+
   LogMetadata object = 2;
 }
 


### PR DESCRIPTION
Fixes #491

## Summary

Implements the watch service for LogMetadata. 

There are some limitations to this service that stem from how the filesystem works. From investigating online it seems that we should consider events coming from notify more like an event of "something has changed" as the events are generally not consistent. Some of these inconsistencies can be found in [notify's documentation](https://docs.rs/notify/latest/notify/).

Events are debounced by using notify's debouncer every 2 seconds for each file. As we are mapping many event types, to only three types, there is still some possibility of duplicate events currently.

There are some improvements that I will implement as part of a subsequent PR:
- Improve error handling
- Deduplicate events using an IndexSet.

## Testing instructions
- Ensure that the tests are passing (`cargo test`)

### Testing the service
- Install [grpcurl](https://github.com/fullstorydev/grpcurl)
- Start the dev environment `tilt up`
- Get the loggen pod name, container id, and the cluster agent pod name with:
```
kubectl get pods --all-namespaces \
  --field-selector spec.nodeName=minikube-m03 \
  -o json | jq -r '
    .items[] | 
    . as $pod |
    $pod.status.containerStatuses[]? | 
    "\($pod.metadata.namespace)/\($pod.metadata.name) \(.containerID)"
'
```
- Map the cluster agent port to localhost with `kubectl -n kubetail-system port-forward <cluster agent pod name> 50051:50051`
- Finally, run a gRPC request with
```
grpcurl -plaintext -d '{
  "namespaces":  ["default"]
}
' localhost:50051 cluster_agent.LogMetadataService/Watch
```


## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
