### PR TITLE
🎣  Implement safe digest function with fallback when crypto.subtle isn't available

### DIFF
--- a/dashboard-ui/src/pages/console.tsx
+++ b/dashboard-ui/src/pages/console.tsx
@@ -48,7 +48,7 @@ import {
   useViewerMetadata,
   useViewerVisibleCols,
 } from '@/lib/logfeed';
-import { Counter, cn, cssEncode, getBasename, joinPaths, MapSet } from '@/lib/util';
+import { Counter, MapSet, cn, cssEncode, getBasename, joinPaths, safeDigest } from '@/lib/util';
 import { LogSourceFragmentFragment } from '@/lib/graphql/dashboard/__generated__/graphql';
 import { Workload, allWorkloads, iconMap, labelsPMap } from '@/lib/workload';
 
@@ -95,13 +95,8 @@ const ConfigureContainerColors = () => {
     containerKeysRef.current.add(k);
 
     (async () => {
-      // get color
-      const streamUTF8 = new TextEncoder().encode(k);
-      const buffer = await crypto.subtle.digest('SHA-256', streamUTF8);
-      const view = new DataView(buffer);
-      const colorIDX = view.getUint32(0) % 20;
-
       // set css var
+      const colorIDX = (await safeDigest(k)).getUint32(0) % 20;
       document.documentElement.style.setProperty(`--${k}-color`, palette[colorIDX].hex());
     })();
   });


### PR DESCRIPTION
Fixes #517 

## Summary

This PR fixes an issue causing missing container color dots in the logging dashboard for a small number of users. Based on one users' browser console errors it appears that it's an issue where the container hashing function throws an error when the `crypto.subtle` API isn't available. This PR solves the problem by implementing a safe digest method that uses `crypto.subtle` when available and a different hashing function when not.

## Changes

* Add a fallback hashing method when `crypto.subtle` is unavailable (FNV-1a)

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
