### PR TITLE
🎣 Add upload signed artifacts step to release-cli workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -93,6 +93,14 @@ jobs:
             os: ${{ toJSON(matrix.GOOS) }}
             arch: ${{ toJSON(matrix.GOARCH) }}
             version: ${{ toJSON(steps.tagName.outputs.tag) }}
+      - id: upload-signed-artifact
+        if: matrix.GOOS == 'windows'
+        name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+          path: bin/*
+          overwrite: true
 
   package-deb:
     name: Build deb package


### PR DESCRIPTION
## Summary

Adds upload signed artifacts step to release-cli workflow. Previously signed artifacts were being downloaded but not re-uploaded so final GitHub release contained unsigned binaries.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
