### PR TITLE
🎣 Bug/windows tests portability

### DIFF
--- a/modules/cluster-agent/internal/server/server_test.go
+++ b/modules/cluster-agent/internal/server/server_test.go
@@ -101,7 +101,7 @@ func TestNewServerTLSConfiguration(t *testing.T) {
 			certFile:    "/nonexistent/cert.pem",
 			keyFile:     keyFile,
 			wantErr:     true,
-			errContains: "no such file or directory",
+			errContains: "",
 		},
 		{
 			name:        "TLS enabled with missing key file",
@@ -109,7 +109,7 @@ func TestNewServerTLSConfiguration(t *testing.T) {
 			certFile:    certFile,
 			keyFile:     "/nonexistent/key.pem",
 			wantErr:     true,
-			errContains: "no such file or directory",
+			errContains: "",
 		},
 		{
 			name:        "TLS enabled with missing CA file",
@@ -118,7 +118,7 @@ func TestNewServerTLSConfiguration(t *testing.T) {
 			keyFile:     keyFile,
 			caFile:      "/nonexistent/ca.pem",
 			wantErr:     true,
-			errContains: "no such file or directory",
+			errContains: "",
 		},
 		{
 			name:        "TLS enabled with invalid CA file",
@@ -146,6 +146,8 @@ func TestNewServerTLSConfiguration(t *testing.T) {
 				assert.Error(t, err)
 				if tt.errContains != "" {
 					assert.Contains(t, err.Error(), tt.errContains)
+				} else {
+					assert.ErrorIs(t, err, os.ErrNotExist)
 				}
 				assert.Nil(t, server)
 			} else {

--- a/modules/cluster-agent/internal/services/logmetadata/helpers_test.go
+++ b/modules/cluster-agent/internal/services/logmetadata/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -78,6 +79,9 @@ type ContainerLogsWatcherTestSuite struct {
 }
 
 func (suite *ContainerLogsWatcherTestSuite) SetupTest() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("symlink-based tests are skipped on Windows")
+	}
 	// temporary directory for pod logs
 	podLogsDir, err := os.MkdirTemp("", "podlogsdir-")
 	suite.Require().Nil(err)

--- a/modules/cluster-agent/internal/services/logmetadata/logmetadata_test.go
+++ b/modules/cluster-agent/internal/services/logmetadata/logmetadata_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -41,6 +42,9 @@ var ctxWithToken = context.WithValue(context.Background(), grpchelpers.K8STokenC
 
 // Setup suite
 func (suite *LogMetadataTestSuite) SetupSuite() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("logmetadata symlink-based tests are skipped on Windows")
+	}
 	// disable logging
 	config.ConfigureLogger(config.LoggerOptions{Enabled: false})
 
@@ -421,5 +425,8 @@ func (suite *LogMetadataTestSuite) TestWatch_Deleted() {
 
 // test runner
 func TestLogMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("logmetadata symlink-based tests are skipped on Windows")
+	}
 	suite.Run(t, new(LogMetadataTestSuite))
 }

--- a/modules/shared/k8shelpers/kube-config-watcher_test.go
+++ b/modules/shared/k8shelpers/kube-config-watcher_test.go
@@ -121,7 +121,8 @@ func TestKubeConfigWatcherGet(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set environment
-		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, fmt.Sprintf("%s:%s", p1, p2))
+		sep := string(os.PathListSeparator)
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, fmt.Sprintf("%s%s%s", p1, sep, p2))
 
 		// Init watcher
 		watcher, err := NewKubeConfigWatcher("")
@@ -165,7 +166,8 @@ func TestKubeConfigWatcherSubscribeModified(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set environment
-	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, fmt.Sprintf("%s:%s", p1, p2))
+	sep := string(os.PathListSeparator)
+	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, fmt.Sprintf("%s%s%s", p1, sep, p2))
 
 	// Initialize watcher
 	watcher, err := NewKubeConfigWatcher("")


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #583

## Summary
Make unit tests portable on Windows by removing OS-specific assumptions (symlinks, error message strings, and path separators). No production code changes; tests only.

## Changes
- cluster-agent/internal/server/server_test.go
  - Use `assert.ErrorIs(err, os.ErrNotExist)` instead of comparing error strings for missing files.
- cluster-agent/internal/services/logmetadata/helpers_test.go
  - Skip symlink-dependent test suite on Windows (`runtime.GOOS == "windows"`).
- cluster-agent/internal/services/logmetadata/logmetadata_test.go
  - Skip symlink-dependent test suite on Windows (`runtime.GOOS == "windows"`) in `SetupSuite` and in the test runner as a safeguard.
- shared/k8shelpers/kube-config-watcher_test.go
  - Use `os.PathListSeparator` to build `KUBECONFIG` instead of hardcoding `:` (Windows uses `;`).

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
