### PR TITLE
🎣 Deduplicate Metadata events

### DIFF
--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -44,7 +44,6 @@ kube = { version = "1.1.0" }
 k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 regex = "1.11.1"
 
-
 [dev-dependencies]
 serial_test = "3.2.0"
 


### PR DESCRIPTION
Fixes #590 

## Summary

Another step was added after the transformation that removes the duplicate events.

## Changes
- This also includes the changes from https://github.com/kubetail-org/kubetail/pull/589 as I based this work on that branch
- Switched the Vec<LogMetadataWatchEvent> to a VecDeque to better support building the list of events from end to start
- The reverse construction happens to ensure that the most recent event is sent from gRPC service

## Testing instructions
- Follow the testing instructions in #572 and observe that no duplicate events are created
- Observe in tests that no duplicate events are now created.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
Signed-off-by: Giannis K <ikaragi23@yahoo.gr>