### PR TITLE
🎣 ci: Run Go module tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,16 @@ jobs:
         run: go vet ./...
 
   modules-test:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-24.04, windows-latest]
         module: [cli, cluster-agent, cluster-api, dashboard, shared]
+        exclude:
+          - os: windows-latest
+            module: cluster-agent
+          - os: windows-latest
+            module: cluster-api
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment


### PR DESCRIPTION
Fixes #587

## Summary
The goal of this PR is to extend the existing CI workflow to run Go module tests on `windows-latest`. This will improve test coverage and ensure compatibility with the Windows operating system.

## Changes
- The `.github/workflows/ci.yml` file has been modified.
- `windows-latest` has been added to the operating system array for the `modules-test` job.
- The `cluster-agent` and `cluster-api` modules have been excluded from running on Windows, as they are Linux-specific.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
