### PR TITLE
✨ Add Ubuntu-Arm to Rust build and test jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   crates-build:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment
@@ -46,7 +49,10 @@ jobs:
         run: cargo clippy --all -- -D warnings
 
   crates-test:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment


### PR DESCRIPTION
## Summary

This PR extends the existing CI workflow and adds Ubuntu-Arm to the Rust build and test jobs.

## Changes

* The `.github/workflows/ci.yml` file has been modified
* Implements matrix strategy for Rust build and test jobs and adds `ubuntu-24.04-arm` to the os array

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
