### PR TITLE
Add TLS, integrate with cluster-api

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["rt"] }
 
-tonic = { workspace = true, features = ["gzip"] }
+tonic = { workspace = true, features = ["gzip", "tls-ring"] }
 tonic-health = { workspace = true}
 tonic-reflection = { workspace = true}
 

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -238,17 +238,10 @@ async fn find_log_files(
         .filter_map(|file| {
             let filename = file.file_name();
             let filename = filename.to_string_lossy();
-            let captures = LOG_FILE_REGEX.captures(&filename);
+            let captures = LOG_FILE_REGEX.captures(&filename)?;
 
-            if captures.is_some()
-                && namespaces.contains(
-                    &captures
-                        .unwrap()
-                        .name("namespace")
-                        .unwrap()
-                        .as_str()
-                        .to_owned(),
-                )
+            if namespaces.is_empty()
+                || namespaces.contains(&captures.name("namespace").unwrap().as_str().to_owned())
             {
                 let mut absolute_path = directory.to_path_buf();
                 absolute_path.push(file.file_name());

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -20,7 +20,7 @@ use tokio::{
 use tokio_stream::{StreamExt, wrappers::ReadDirStream};
 use tonic::Status;
 use tracing::{debug, info, warn};
-use types::cluster_agent::{LogMetadata, LogMetadataWatchEvent};
+use types::cluster_agent::{LogMetadata, LogMetadataFileInfo, LogMetadataWatchEvent};
 
 use crate::log_metadata::{LOG_FILE_REGEX, LogMetadataImpl};
 
@@ -339,7 +339,10 @@ fn transform_notify_event(
         object: Some(LogMetadata {
             id: metadata_spec.container_id.clone(),
             spec: Some(metadata_spec),
-            file_info: file_info.ok(),
+            file_info: Some(file_info.unwrap_or(LogMetadataFileInfo {
+                size: 0,
+                last_modified_at: None,
+            })),
         }),
     }))
 }

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -1,10 +1,11 @@
 use std::error::Error;
+use std::fs::read_to_string;
 
 use tokio::signal::ctrl_c;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::broadcast::{self, Sender};
 use tokio_util::task::TaskTracker;
-use tonic::transport::Server;
+use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tracing::info;
 use types::cluster_agent::FILE_DESCRIPTOR_SET;
 use types::cluster_agent::log_metadata_service_server::LogMetadataServiceServer;
@@ -22,16 +23,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     let (_, agent_health_service) = tonic_health::server::health_reporter();
-
     let reflection_service = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
         .build_v1()?;
-
     let (term_tx, _term_rx) = broadcast::channel(1);
-
     let task_tracker = TaskTracker::new();
+    let tls_config = build_tls_config()?;
 
     Server::builder()
+        .tls_config(tls_config)?
         .add_service(agent_health_service)
         .add_service(reflection_service)
         .add_service(LogMetadataServiceServer::new(LogMetadataImpl::new(
@@ -52,6 +52,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("Shutdown completed.");
 
     Ok(())
+}
+
+fn build_tls_config() -> Result<ServerTlsConfig, Box<dyn Error>> {
+    let cert = read_to_string("/etc/kubetail/tls.crt")?;
+    let key = read_to_string("/etc/kubetail/tls.key")?;
+    let server_identity = Identity::from_pem(cert, key);
+
+    let client_ca_cert = read_to_string("/etc/kubetail/ca.crt")?;
+    let client_ca_cert = Certificate::from_pem(client_ca_cert);
+
+    Ok(ServerTlsConfig::new()
+        .identity(server_identity)
+        .client_ca_root(client_ca_cert))
 }
 
 async fn shutdown(term_tx: Sender<()>) {

--- a/crates/rgkl/src/stream_backward.rs
+++ b/crates/rgkl/src/stream_backward.rs
@@ -113,7 +113,7 @@ fn stream_backward_internal(
     let mut printer = JSONBuilder::new().build(writer);
 
     // Remove leading and trailing whitespace
-    let trimmed_grep = grep.map(str::trim).filter(|grep| grep.is_empty());
+    let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
         let matcher = LogFileRegexMatcher::new(grep, format).unwrap();

--- a/crates/rgkl/src/stream_forward.rs
+++ b/crates/rgkl/src/stream_forward.rs
@@ -165,7 +165,7 @@ fn setup_fs_watcher<'a>(
     let mut printer = JSONBuilder::new().build(writer);
 
     // Remove leading and trailing whitespace
-    let trimmed_grep = grep.map(str::trim).filter(|grep| grep.is_empty());
+    let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
         let matcher = LogFileRegexMatcher::new(grep, format).unwrap();


### PR DESCRIPTION
Signed-off-by: Christopher Valerio <christopher@valerio.guru><!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #5233

## Summary

TLS addition and a few bug fixes to integrate with cluser-api

## Changes
- TLS config addition
- Return messages for all namespaces when the namespaces argument is not provided
- Fix grep filtering expression, grep now works
- Populate node name from env variable
- Return an empty fileInfo in metadata when the file is deleted -> null file info was causing errors in the graphql server

## Testing instructions
With this change, the new cluster agent now integrates with the API which means that we can test it using the dashboard UI. Didn't test thoroughly and I expect there will be some functionality missing which will be addressed in future PRs.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
Signed-off-by: Giannis K <ikaragi23@yahoo.gr>