### PR TITLE
🐋Allow env variable substitution

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "rgkl",
  "serde",
  "serial_test",
+ "subst",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2676,6 +2677,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subst"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
+dependencies = [
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3255,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -46,6 +46,7 @@ regex = "1.11.1"
 clap = { version = "4.5.45", features = ["cargo"] }
 config = "0.15.14"
 serde = "1.0"
+subst = "0.3.8"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -24,7 +24,7 @@ use crate::config::{Config, LoggingConfig, TlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let config = parse_config()?;
+    let config = parse_config().await?;
 
     configure_logging(&config.logging)?;
 
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn parse_config() -> Result<Config, Box<(dyn Error + 'static)>> {
+async fn parse_config() -> Result<Config, Box<(dyn Error + 'static)>> {
     let matches = command!()
         .arg(
             arg!(
@@ -75,7 +75,7 @@ fn parse_config() -> Result<Config, Box<(dyn Error + 'static)>> {
         .get_matches();
 
     let config_path = matches.get_one::<PathBuf>("config").unwrap();
-    let config = Config::parse(config_path)?;
+    let config = Config::parse(config_path).await?;
 
     Ok(config)
 }


### PR DESCRIPTION
Fixes #608

## Summary

Updates the configuration to be populated with env variables

## Changes
- File is now loaded by our code instead of config to grab the contents as a string
- We use subst crate to replace the env variables

## Testing instructions
- Add an env variable to `kubetail.yaml`, for example:
```yaml
      containers:
        - name: kubetail-cluster-agent
          image: kubetail-cluster-agent
          ports:
            - name: grpc
              protocol: TCP
              containerPort: 50051
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
+            - name: DEBUG_LEVEL
+              value: debug
```
- Add the variable for the cluster agent config file (both $DEBUG_LEVEL and ${DEBUG_LEVEL} should work):
```yaml
  labels:
    app.kubernetes.io/name: kubetail
    app.kubernetes.io/component: cluster-agent
data:
  config.yaml: |
    cluster-agent:
      addr: :50051
      logging:
        enabled: true
-       level: info
+       level: $DEBUG_LEVEL
        format: pretty
      tls:
        enabled: true
```
- Observe that the change in the configuration works

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
