### PR TITLE
 ✨ Improve Linux browser dependency error handling in serve command

### DIFF
--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -166,12 +166,6 @@ var serveCmd = &cobra.Command{
 			err = browser.OpenURL(fmt.Sprintf("http://%s:%d/", host, port))
 			if err != nil {
 				if runtime.GOOS == "linux" {
-					// zlog.Warn().Msgf("Unable to open browser automatically. On Linux systems, you may need to install one of the following packages:")
-					// zlog.Warn().Msgf("  - xdg-utils (provides xdg-open)")
-					// zlog.Warn().Msgf("  - x-www-browser")
-					// zlog.Warn().Msgf("  - www-browser")
-					// zlog.Warn().Msgf("Alternatively, you can use the --skip-open flag to skip browser opening.")
-					// zlog.Warn().Msgf("Please open the dashboard URL manually.")
 					zlog.Warn().Msg(`Unable to open browser automatically. 
 					On Linux systems, you may need to install one of the following packages:
 					- xdg-utils (provides xdg-open)


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #531

## Summary

* Improves error handling when the `serve` command fails to open a browser on Linux systems.

## Changes

* Improved user guidance: Provides clear installation instructions for required Linux packages (`xdg-utils`, `x-www-browser`, `www-browser`)

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
