### PR TITLE
🐋Implement k8s authorization

### DIFF
--- a/crates/cluster_agent/src/authorizer.rs
+++ b/crates/cluster_agent/src/authorizer.rs
@@ -1,0 +1,107 @@
+use k8s_openapi::api::authorization::v1::{
+    ResourceAttributes, SelfSubjectAccessReview, SelfSubjectAccessReviewSpec,
+};
+use kube::{Api, Client, Config, api::PostParams, config::AuthInfo};
+use tonic::{Status, metadata::MetadataMap};
+
+pub struct Authorizer {
+    k8s_config: Config,
+}
+
+/// Checks that the the k8s doing the request has proper rights to access the log files.
+#[cfg(not(test))]
+impl Authorizer {
+    /// Creates a new Authorizer, using the k8s authorization token to construct the proper
+    /// client set during authorization.
+    pub async fn new(request_metadata: &MetadataMap) -> Result<Self, Status> {
+        let token = request_metadata
+            .get("authorization")
+            .and_then(|token| token.to_str().ok())
+            .ok_or_else(|| {
+                Status::new(
+                    tonic::Code::Unauthenticated,
+                    "authentication token not found",
+                )
+            })?
+            .to_owned();
+
+        let mut k8s_config = Config::infer().await.map_err(|error| {
+            Status::new(
+                tonic::Code::Unknown,
+                format!("unable to infer k8s config {error}"),
+            )
+        })?;
+
+        k8s_config.auth_info = AuthInfo {
+            token: Some(token.into()),
+            ..Default::default()
+        };
+
+        Ok(Self { k8s_config })
+    }
+
+    /// Checks if the request is authorized by calling the k8s API.
+    pub async fn is_authorized(
+        &self,
+        mut namespaces: &Vec<String>,
+        verb: &str,
+    ) -> Result<(), Status> {
+        let client = Client::try_from(self.k8s_config.clone())
+            .map_err(|error| Status::new(tonic::Code::Unauthenticated, error.to_string()))?;
+
+        // Default to all namespaces if no namespace is provided.
+        let empty_namespace = vec![String::new()];
+        if namespaces.is_empty() {
+            namespaces = &empty_namespace;
+        }
+
+        let access_reviews: Api<SelfSubjectAccessReview> = Api::all(client);
+        for namespace in namespaces {
+            let access_review = SelfSubjectAccessReview {
+                spec: SelfSubjectAccessReviewSpec {
+                    resource_attributes: Some(ResourceAttributes {
+                        namespace: Some(namespace.to_owned()),
+                        group: None,
+                        verb: Some(verb.to_owned()),
+                        resource: Some("pods/log".to_owned()),
+                        ..ResourceAttributes::default()
+                    }),
+                    non_resource_attributes: None,
+                },
+                ..SelfSubjectAccessReview::default()
+            };
+
+            let response = access_reviews
+                .create(&PostParams::default(), &access_review)
+                .await
+                .map_err(|error| {
+                    Status::new(
+                        tonic::Code::Unknown,
+                        format!("failed to authenticate {error}"),
+                    )
+                })?;
+
+            if response.status.is_none() || !response.status.unwrap().allowed {
+                return Err(Status::new(
+                    tonic::Code::Unauthenticated,
+                    format!("permission denied: `{verb} pods/log` in namespace `{namespace}`"),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Authorizer {
+    pub async fn new(_request_metadata: &MetadataMap) -> Result<Self, Status> {
+        Ok(Self {
+            k8s_config: Config::infer().await.unwrap(),
+        })
+    }
+
+    pub async fn is_authorized(self, _namespaces: &Vec<String>, _verb: &str) -> Result<(), Status> {
+        Ok(())
+    }
+}

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -596,7 +596,13 @@ mod test {
         if let Some(file_size) = file_size {
             assert_eq!(event_file_info.as_ref().unwrap().size, file_size as i64);
         } else {
-            assert_eq!(event_file_info, None);
+            assert_eq!(
+                event_file_info,
+                Some(LogMetadataFileInfo {
+                    size: 0,
+                    last_modified_at: None,
+                })
+            );
         }
     }
 }

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -14,6 +14,7 @@ use types::cluster_agent::FILE_DESCRIPTOR_SET;
 use types::cluster_agent::log_metadata_service_server::LogMetadataServiceServer;
 use types::cluster_agent::log_records_service_server::LogRecordsServiceServer;
 
+mod authorizer;
 mod config;
 mod log_metadata;
 mod log_records;


### PR DESCRIPTION
Fixes #616

## Summary

Similarly with the old cluster agent, we now check that the pods making a request have the proper rights.

## Changes
- Adds a new struct, the authorizer which is responsible for communicating with the k8s to confirm the requests are authorized.

## Testing instructions
- Observe first that everything is still working
- Go to kubetail.yaml and remove the watch or list verb from the kubetail-cli cluster role:
```
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: kubetail-cli
  labels:
    app.kubernetes.io/name: kubetail
    app.kubernetes.io/component: cli
rules:
  - apiGroups: [""]
    resources: [nodes]
-    verbs: [get, list, watch]
+   verbs: [get, watch]
  - apiGroups: ["", apps, batch]
    resources:
      - cronjobs
      - daemonsets
      - deployments
      - jobs
      - pods
      - replicasets
      - statefulsets
    verbs: [get, list, watch]
  - apiGroups: [""]
    resources: [pods/log]
-   verbs: [list, watch]
+  verbs: [ watch]
```
- Observe that now the dashboard is broken

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
