### PR TITLE
 🎣  Add HTTP/2 `:authority` to non-TLS gRPC requests

### DIFF
--- a/modules/cluster-api/internal/app/helpers.go
+++ b/modules/cluster-api/internal/app/helpers.go
@@ -66,7 +66,10 @@ func mustNewGrpcDispatcher(cfg *config.Config) *grpcdispatcher.Dispatcher {
 
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	} else {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		dialOpts = append(dialOpts,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithAuthority("kubetail-cluster-agent.kubetail-system.svc"),
+		)
 	}
 
 	// TODO: reuse app clientset


### PR DESCRIPTION
## Summary

The new Rust-based Cluster Agent requires HTTP/2 `:authority` to accept gRPC requests which is causing errors on non-TLS connections. This PR adds `:authority` to non-TLS connections to the Cluster Agent.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
