### PR TITLE
✨Add barriers instead of sleeping in tests, use kqueue in macos

### DIFF
--- a/crates/cluster_agent/src/log_metadata.rs
+++ b/crates/cluster_agent/src/log_metadata.rs
@@ -1,3 +1,4 @@
+use notify::RecommendedWatcher;
 use prost_types::Timestamp;
 use regex::{Captures, Regex};
 use std::env;
@@ -197,7 +198,7 @@ impl LogMetadataService for LogMetadataImpl {
         );
 
         self.task_tracker.spawn(async move {
-            log_metadata_watcher.watch().await;
+            log_metadata_watcher.watch::<RecommendedWatcher>(None).await;
         });
 
         Ok(Response::new(ReceiverStream::new(log_metadata_rx)))

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -399,6 +399,7 @@ impl LogMetadataWatchEventType {
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(target_os = "macos"))]
     use std::{
         fs::{File, remove_file, rename},
         io::Write,
@@ -408,7 +409,7 @@ mod test {
 
     use super::*;
     use notify::{PollWatcher, RecommendedWatcher};
-    use serial_test::serial;
+    use serial_test::{parallel, serial};
     use tokio::{
         sync::{broadcast, mpsc::error::TryRecvError},
         task,
@@ -495,6 +496,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn test_error_is_returned_on_unknown_directory() {
         let namespaces = vec!["namespace".into()];
         let (term_tx, _term_rx) = broadcast::channel(1);
@@ -518,7 +520,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[serial]
+    #[parallel]
     async fn test_delete_events_are_generated() {
         let file = create_test_file("pod-name_delete-namespace_container-name-containerid", 4);
         let namespaces = vec!["delete-namespace".into()];
@@ -559,7 +561,7 @@ mod test {
 
     #[tokio::test]
     #[cfg(not(target_os = "macos"))]
-    #[serial]
+    #[parallel]
     async fn test_renamed_file_is_being_watched() {
         let file = create_test_file("pod-name_rename-namespace_container-name-containerid", 4);
         let namespaces = vec!["rename-namespace".into()];

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -5,8 +5,8 @@ use std::{
     time::Duration,
 };
 
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode};
-use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer};
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
 use thiserror::Error;
 use tokio::{
     fs::read_dir,
@@ -63,9 +63,10 @@ impl LogMetadataWatcher {
 
     /// Starts watching the log directory for log updates. Blocks until a message is sent in the
     /// termination channel.
-    pub async fn watch(&self) {
+    pub async fn watch<T: Watcher>(&self, watcher_config: Option<notify::Config>) {
         let (internal_tx, internal_rx) = channel(10);
-        let setup_result = self.setup_notify_watcher(internal_tx).await;
+        let setup_result: Result<Debouncer<T, RecommendedCache>, WatcherError> =
+            self.setup_notify_watcher(internal_tx, watcher_config).await;
 
         if let Err(watcher_error) = setup_result {
             let _ = self.log_metadata_tx.send(Err(watcher_error.into())).await;
@@ -85,15 +86,16 @@ impl LogMetadataWatcher {
     /// # Arguments
     ///
     /// * `internal_tx` - The sender to use to propagate filesystem updates.
-    async fn setup_notify_watcher(
+    async fn setup_notify_watcher<T: Watcher>(
         &self,
         internal_tx: Sender<VecDeque<Result<LogMetadataWatchEvent, WatcherError>>>,
-    ) -> Result<Debouncer<RecommendedWatcher, RecommendedCache>, WatcherError> {
+        watcher_config: Option<notify::Config>,
+    ) -> Result<Debouncer<T, RecommendedCache>, WatcherError> {
         let runtime_handle = Handle::current();
         let namespaces = self.namespaces.clone();
         let node_name = self.node_name.clone();
 
-        let mut debouncer = new_debouncer(
+        let mut debouncer = new_debouncer_opt(
             Duration::from_secs(2),
             None,
             move |result: DebounceEventResult| {
@@ -103,6 +105,8 @@ impl LogMetadataWatcher {
                         .await;
                 });
             },
+            RecommendedCache::new(),
+            watcher_config.unwrap_or_default(),
         )?;
 
         let paths_to_add = find_log_files(&self.directory, &self.namespaces).await?;
@@ -124,10 +128,10 @@ impl LogMetadataWatcher {
     /// * `internal_rx` - Receiver of filesystem updates.
     /// * `debouncer` - The notify filesystem watcher.
     /// * `term_rx` - Receiver of the termination channel.
-    async fn listen_for_changes(
+    async fn listen_for_changes<T: Watcher>(
         &self,
         mut internal_rx: Receiver<VecDeque<Result<LogMetadataWatchEvent, WatcherError>>>,
-        mut debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
+        mut debouncer: Debouncer<T, RecommendedCache>,
         mut term_rx: tokio::sync::broadcast::Receiver<()>,
     ) {
         'outer: loop {
@@ -163,10 +167,10 @@ impl LogMetadataWatcher {
     // In case of a new log file creation, it adds the path to the notify watcher in order to
     // receive updates for the file in the future. On removal, the path is removed from the watcher
     // accordingly.
-    fn update_watcher(
+    fn update_watcher<T: Watcher>(
         &self,
         watch_event: &LogMetadataWatchEvent,
-        watcher: &mut Debouncer<RecommendedWatcher, RecommendedCache>,
+        watcher: &mut Debouncer<T, RecommendedCache>,
     ) {
         let event_type = LogMetadataWatchEventType::from_str(&watch_event.r#type).unwrap();
 
@@ -403,6 +407,7 @@ mod test {
     use crate::log_metadata::test::create_test_file;
 
     use super::*;
+    use notify::{PollWatcher, RecommendedWatcher};
     use serial_test::serial;
     use tokio::{
         sync::{broadcast, mpsc::error::TryRecvError},
@@ -413,8 +418,8 @@ mod test {
     #[tokio::test]
     #[serial]
     async fn test_create_events_are_generated() {
-        let file = create_test_file("pod-name_namespace_container-name-containerid", 4);
-        let namespaces = vec!["namespace".into()];
+        let file = create_test_file("pod-name_create-namespace_container-name-containerid", 4);
+        let namespaces = vec!["create-namespace".into()];
         let (term_tx, _term_rx) = broadcast::channel(1);
         let logs_dir = file.path().parent().unwrap().to_owned();
 
@@ -425,43 +430,64 @@ mod test {
             "The node name".to_owned(),
         );
 
-        // Start the watcher and give it some time to execute before creating events.
-        task::spawn(async move { log_metadata_watcher.watch().await });
-        sleep(Duration::from_millis(100)).await;
+        task::spawn(async move {
+            log_metadata_watcher
+                .watch::<PollWatcher>(Some(
+                    notify::Config::default().with_poll_interval(Duration::from_millis(100)),
+                ))
+                .await
+        });
+
+        // Wait until the watcher has started listening for changes
+        while term_tx.receiver_count() != 2 {
+            sleep(Duration::from_millis(50)).await;
+        }
 
         // Create three files, one with an unrelated namespace.
-        let _first_file =
-            create_test_file("pod-name_namespace_firstContainer-name-firstContainerid", 4);
+        let _first_file = create_test_file(
+            "pod-name_create-namespace_firstContainer-name-firstContainerid",
+            4,
+        );
         let _second_file = create_test_file(
-            "pod-name_namespace_secondContainer-name-secondContainerid",
+            "pod-name_create-namespace_secondContainer-name-secondContainerid",
             4,
         );
         let _third_file = create_test_file("pod-name_wrongNamespace_container-name-containerid", 4);
 
-        // Get the events and verify them.
-        let first_event = log_metadata_rx.recv().await.unwrap().unwrap();
-        verify_event(
-            first_event,
-            "ADDED",
-            "firstContainerid",
-            "The node name",
-            "namespace",
-            "pod-name",
-            "firstContainer-name",
-            Some(4),
-        );
+        // Get the events and verify them. Events can appear in different order when using PollWatcher.
+        for _i in 0..2 {
+            let event = log_metadata_rx.recv().await.unwrap().unwrap();
 
-        let second_event = log_metadata_rx.recv().await.unwrap().unwrap();
-        verify_event(
-            second_event,
-            "ADDED",
-            "secondContainerid",
-            "The node name",
-            "namespace",
-            "pod-name",
-            "secondContainer-name",
-            Some(4),
-        );
+            if event
+                .object
+                .as_ref()
+                .unwrap()
+                .id
+                .starts_with("firstContainerid")
+            {
+                verify_event(
+                    event,
+                    "ADDED",
+                    "firstContainerid",
+                    "The node name",
+                    "create-namespace",
+                    "pod-name",
+                    "firstContainer-name",
+                    Some(4),
+                );
+            } else {
+                verify_event(
+                    event,
+                    "ADDED",
+                    "secondContainerid",
+                    "The node name",
+                    "create-namespace",
+                    "pod-name",
+                    "secondContainer-name",
+                    Some(4),
+                );
+            }
+        }
 
         // Ensure no more events are created.
         let result = log_metadata_rx.try_recv();
@@ -481,8 +507,7 @@ mod test {
             "The node name".to_owned(),
         );
 
-        task::spawn(async move { log_metadata_watcher.watch().await });
-        sleep(Duration::from_millis(100)).await;
+        task::spawn(async move { log_metadata_watcher.watch::<RecommendedWatcher>(None).await });
 
         let result = log_metadata_rx.recv().await.unwrap();
         assert!(matches!(result, Err(_)));
@@ -495,8 +520,8 @@ mod test {
     #[tokio::test]
     #[serial]
     async fn test_delete_events_are_generated() {
-        let file = create_test_file("pod-name_namespace_container-name-containerid", 4);
-        let namespaces = vec!["namespace".into()];
+        let file = create_test_file("pod-name_delete-namespace_container-name-containerid", 4);
+        let namespaces = vec!["delete-namespace".into()];
         let (term_tx, _term_rx) = broadcast::channel(1);
         let logs_dir = file.path().parent().unwrap().to_owned();
 
@@ -507,9 +532,13 @@ mod test {
             "The node name".to_owned(),
         );
 
-        // Start the watcher and give it some time to execute before creating events.
-        task::spawn(async move { log_metadata_watcher.watch().await });
-        sleep(Duration::from_millis(100)).await;
+        // File deletions return errors when using PollWatcher so we use RecommendedWatcher
+        task::spawn(async move { log_metadata_watcher.watch::<RecommendedWatcher>(None).await });
+
+        // Wait until the watcher has started listening for changes
+        while term_tx.receiver_count() != 2 {
+            sleep(Duration::from_millis(50)).await;
+        }
 
         // Delete the file.
         let _ = file.close();
@@ -521,7 +550,7 @@ mod test {
             "DELETED",
             "containerid",
             "The node name",
-            "namespace",
+            "delete-namespace",
             "pod-name",
             "container-name",
             None,
@@ -529,10 +558,11 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "macos"))]
     #[serial]
     async fn test_renamed_file_is_being_watched() {
-        let file = create_test_file("pod-name_namespace_container-name-containerid", 4);
-        let namespaces = vec!["namespace".into()];
+        let file = create_test_file("pod-name_rename-namespace_container-name-containerid", 4);
+        let namespaces = vec!["rename-namespace".into()];
         let (term_tx, _term_rx) = broadcast::channel(1);
         let logs_dir = file.path().parent().unwrap().to_owned();
 
@@ -544,12 +574,16 @@ mod test {
         );
 
         // Start the watcher and give it some time to execute before creating events.
-        task::spawn(async move { log_metadata_watcher.watch().await });
-        sleep(Duration::from_millis(100)).await;
+        task::spawn(async move { log_metadata_watcher.watch::<RecommendedWatcher>(None).await });
+
+        // Wait until the watcher has started listening for changes
+        while term_tx.receiver_count() != 2 {
+            sleep(Duration::from_millis(50)).await;
+        }
 
         // Rename the file.
         let mut new_path = file.path().to_owned();
-        new_path.set_file_name("pod-name_namespace_container-name-updatedcontainerid.log");
+        new_path.set_file_name("pod-name_rename-namespace_container-name-updatedcontainerid.log");
         let _ = rename(file.path(), &new_path);
 
         // Edit the file.
@@ -560,18 +594,17 @@ mod test {
             .unwrap();
         let _ = renamed_file.write_all(&vec![1; 5]);
 
+        // Get the events and verify them. Events can appear in different order when using PollWatcher.
         for _i in 0..2 {
             let event = log_metadata_rx.recv().await.unwrap().unwrap();
 
-            // Events can appear in different order depending on the platform that the test
-            // is executed.
             if event.r#type == "DELETED" {
                 verify_event(
                     event,
                     "DELETED",
                     "containerid",
                     "The node name",
-                    "namespace",
+                    "rename-namespace",
                     "pod-name",
                     "container-name",
                     None,
@@ -582,7 +615,7 @@ mod test {
                     "MODIFIED",
                     "updatedcontainerid",
                     "The node name",
-                    "namespace",
+                    "rename-namespace",
                     "pod-name",
                     "container-name",
                     Some(9),

--- a/crates/rgkl/Cargo.toml
+++ b/crates/rgkl/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { workspace = true}
 prost = { workspace = true}
 prost-types = { workspace = true}
 tempfile = { workspace = true }
-notify = { workspace = true, features = ["crossbeam-channel"] }
+notify = { workspace = true, features = ["crossbeam-channel", "macos_kqueue"] }
 thiserror = { workspace = true }
 
 tracing = { workspace = true }


### PR DESCRIPTION
Fixes #635

## Summary

Improves the stability and reduces the run time of Rust tests

## Changes
- Specify a different namespace on each test, to allow the tests to run independently.
- Allow callers of LogMetadataWatcher::watch to specify the watcher type, to allow using stable watchers during testing
- Change all tests apart from `test_create_events_are_generated` to run in parallel. This test isn't possible to run in parallel, as `PollWatcher` throws errors when a tracked file is deleted from another test running in parallel.
- Use barriers or waiting on a precondition instead of sleeping to synchronise threads when testing.
- Use async tasks everywhere instead of creating new threads

## Testing instructions
- Observe that the tests pass.
- Run the tests and observe that the running time is reduced.

## Notes on macOS stability
Generally, the notify `Watcher`s for macOS do not have a consistent behavior, which makes it difficult to test our file watchers on a macOS development environment. Three `Watcher`s exist in macOS:
- `FsEventWatcher`: Optimized to watch whole directories, but it can miss updates on individual files. Good for the LogMetadataService, where the most important part is watching for files getting created/deleted.
- `KqueueWatcher`: Low-level watcher which is good for watching individual files but can miss events on the directories. Good use case for the LogRecordService
- `PollWatcher`: More stable, but it has a performance penalty. Used in testing only.

Currently, in macOS the `RecommendedWatcher` uses `KqueueWatcher`. This means that in order to test consistently file creation scenarios, `PollWatcher` should be used. File deletion scenarios can't be tested consistently because in such a case `PollWatcher` throws errors.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
