### PR TITLE
🎣 Add `:authority` to non-TLS gRPC requests (#638)

### DIFF
--- a/modules/cluster-api/internal/app/helpers.go
+++ b/modules/cluster-api/internal/app/helpers.go
@@ -66,7 +66,10 @@ func mustNewGrpcDispatcher(cfg *config.Config) *grpcdispatcher.Dispatcher {
 
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	} else {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		dialOpts = append(dialOpts,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithAuthority("kubetail-cluster-agent.kubetail-system.svc"),
+		)
 	}
 
 	// TODO: reuse app clientset


### PR DESCRIPTION
## Summary

This PR fixes an issue with missing HTTP/2 `:authority` pseudo-headers on non-TLS connections between the Cluster API and the Cluster Agent. When using TLS, `:authority` gets populated automatically from the certificate but without TLS it has to get set explicitly. This wasn't a problem with the Go-based Cluster Agent previously but the behavior changed with Rust because tonic rejects requests without `:authority`.

## Changes

- Adds `grpc.WithAuthority()` to the DialOptions when making non-TLS connections

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
