### PR TITLE
✨ Improve gRPC stream shutdown handling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,8 +5,10 @@
 *.md    @rxinui @amorey
 .github/    @rxinui @amorey
 
-# kubetail CLI ownership
+# kubetail go ownership
 /modules/cli/   @rxinui @amorey
 /modules/shared/    @rxinui @amorey
 /modules/cluster-api/    @rxinui @amorey
-/crates/    @rxinui @amorey @gikaragia
+
+# kubetail rust ownership
+/crates/    @gikaragia @amorey


### PR DESCRIPTION
## Summary

This PR adds support for returning gRPC stream shutdown error codes when SIGTERM is received. Previously, streams would shutdown cleanly on SIGTERM which meant it wasn't possible to distinguish between a server shutdown and a stream finish. Now clients will receive proper error codes and can react accordingly.

Test code written by Claude and Codex with human supervision.

## Changes

- Modified LogMetadata and LogRecords services and added support for returning gRPC `Unavailable` status on server shutdown while streaming
- Added unit tests for new functionality
- Updated CODEOWNERS

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
