### PR TITLE
✨ Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/release-cluster-agent.yml
+++ b/.github/workflows/release-cluster-agent.yml
@@ -2,6 +2,7 @@ name: release-cluster-agent
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:
@@ -20,19 +21,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.cluster-agent
           push: true
-          tags: kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64
+          tags: |
+            kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64
 
   build-and-publish-arm64:
     runs-on: ubuntu-24.04-arm
@@ -45,19 +54,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.cluster-agent
           push: true
-          tags: kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
+          tags: |
+            kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
         
   create-and-publish-manifest:
     runs-on: ubuntu-24.04
@@ -71,17 +88,26 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v3.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create and push manifest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifests
         run: |
           docker buildx imagetools create -t kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token
         run: |
           TOKEN=$(curl -X POST "https://hub.docker.com/v2/users/login" -H "Content-Type: application/json" -d '{"username": "${{ secrets.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' | jq -r '.token')

--- a/.github/workflows/release-cluster-api.yml
+++ b/.github/workflows/release-cluster-api.yml
@@ -2,6 +2,7 @@ name: release-cluster-api
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:
@@ -20,19 +21,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.cluster-api
           push: true
-          tags: kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64
+          tags: |
+            kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64
 
   build-and-publish-arm64:
     runs-on: ubuntu-24.04-arm
@@ -45,19 +54,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.cluster-api
           push: true
-          tags: kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
+          tags: |
+            kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
         
   create-and-publish-manifest:
     runs-on: ubuntu-24.04
@@ -71,17 +88,26 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v3.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create and push manifest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifests
         run: |
           docker buildx imagetools create -t kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token
         run: |
           TOKEN=$(curl -X POST "https://hub.docker.com/v2/users/login" -H "Content-Type: application/json" -d '{"username": "${{ secrets.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' | jq -r '.token')

--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -2,6 +2,7 @@ name: release-dashboard
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:
@@ -20,19 +21,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.dashboard
           push: true
-          tags: kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64
+          tags: |
+            kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64
+            ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64
 
   build-and-publish-arm64:
     runs-on: ubuntu-24.04-arm
@@ -45,19 +54,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/package/Dockerfile.dashboard
           push: true
-          tags: kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
+          tags: |
+            kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
+            ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
         
   create-and-publish-manifest:
     runs-on: ubuntu-24.04
@@ -71,17 +88,26 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v3.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3        
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create and push manifest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifests
         run: |
           docker buildx imagetools create -t kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
+            ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token
         run: |
           TOKEN=$(curl -X POST "https://hub.docker.com/v2/users/login" -H "Content-Type: application/json" -d '{"username": "${{ secrets.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' | jq -r '.token')


### PR DESCRIPTION
Fixes #644 

## Summary

This PR pushes Docker release images (`kubetail-dashboard`, `kubetail-cluster-api`, `kubetail-cluster-agent`) to GHCR in addition to Docker Hub.

Work performed by Codex: https://chatgpt.com/codex/tasks/task_e_68c9b90331ac8323ad8fdefe05a27be4

## Changes

* Modified release workflows and added push to GHCR

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
