### PR TITLE
 🎣 Fix intermittent race test failure in modules/shared

### DIFF
--- a/modules/shared/logs/stream.go
+++ b/modules/shared/logs/stream.go
@@ -315,8 +315,8 @@ func (s *Stream) startHead_UNSAFE() error {
 
 	// Process in goroutine
 	go func() {
-		defer cancel()
 		defer s.closePastCh()
+		defer cancel()
 
 		N := int(s.maxNum)
 		var count int
@@ -376,8 +376,8 @@ func (s *Stream) startTail_UNSAFE() error {
 
 	// Process in goroutine
 	go func() {
-		defer cancel()
 		defer s.closePastCh()
+		defer cancel()
 
 		N := int(s.maxNum)
 		var count int


### PR DESCRIPTION
## Summary

This PR fixes an intermittent race test failure in `modules/shared/logs/stream_test.go`:

```
<nil>
&{{0 0 <nil>} {0 0 <nil>} false  <nil> 0xc0004dd540 0x54be00 0 0 0xc000218840 test 0xc0000dc160 0xc000114ee0 false {{} {{} {} 0} 0} 0xc00001ed20 0xc00001ed90 0xc00001ee00 <nil> {{} {0 0}} {{} {{} 0} {{} {0 0}}} {{} {{} 0} {{} {0 0}}} {{} {{} 0} {{} {0 0}}} {{} {{} 0} {{} {0 0}}}}
--- FAIL: TestStreamTail (0.02s)
    --- FAIL: TestStreamTail/with_maxNum_same_as_number_of_records (0.00s)
        stream_test.go:457: 
            	Error Trace:	/home/runner/work/kubetail/kubetail/modules/shared/logs/stream_test.go:457
            	Error:      	Not equal: 
            	            	expected: *errors.errorString(&errors.errorString{s:"context canceled"})
            	            	actual  : <nil>(<nil>)
            	Test:       	TestStreamTail/with_maxNum_same_as_number_of_records
        stream_test.go:458: 
            	Error Trace:	/home/runner/work/kubetail/kubetail/modules/shared/logs/stream_test.go:458
            	Error:      	Not equal: 
            	            	expected: *errors.errorString(&errors.errorString{s:"context canceled"})
            	            	actual  : <nil>(<nil>)
            	Test:       	TestStreamTail/with_maxNum_same_as_number_of_records
FAIL
FAIL	github.com/kubetail-org/kubetail/modules/shared/logs	0.205s
```

The issue appears to be a timing issue between when the context is canceled and when the streaming channel is closed which causes the test to miss the context cancelation error its expecting.

## Changes

* Change order of context cancelation and channel close in `modules/shared/stream.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
