### PR TITLE
🐋 Push new releases to choco-packages repo automatically

### DIFF
--- a/.github/ci-config/chocolatey/chocolateyInstall.ps1.tmpl
+++ b/.github/ci-config/chocolatey/chocolateyInstall.ps1.tmpl
@@ -1,0 +1,23 @@
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Dectect drchitecture (9 = x64 (AMD64), 12 = ARM64)
+$osArch = (Get-CimInstance Win32_Processor).Architecture
+
+if ($osArch -eq 12) {
+    $url      = 'https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-windows-arm64'
+    $checksum = '${ARM64_SHA256}'
+}
+else {
+    $url      = 'https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-windows-amd64'
+    $checksum = '${AMD64_SHA256}'
+}
+
+$packageArgs = @{
+    PackageName    = 'kubetail'
+    Url64bit       = $url
+    Checksum64     = $checksum
+    ChecksumType64 = 'sha256'
+    FileFullPath   = "$toolsDir\kubetail.exe"
+}
+
+Get-ChocolateyWebFile @packageArgs

--- a/.github/ci-config/chocolatey/kubetail.nuspec.tmpl
+++ b/.github/ci-config/chocolatey/kubetail.nuspec.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>kubetail</id>
+    <version>${VERSION}</version>
+    <packageSourceUrl>https://github.com/kubetail-org/choco-packages</packageSourceUrl>
+    <owners>Andres Morey</owners>
+    <title>Kubetail (CLI)</title>
+    <authors>Kubetail</authors>
+    <projectUrl>https://www.kubetail.com</projectUrl>
+    <iconUrl>https://assets.kubetail.com/choco/icon.cd5e01aa.png</iconUrl>
+    <copyright>(c) 2024-2025 Andres Morey</copyright>
+    <licenseUrl>https://github.com/kubetail-org/kubetail/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/kubetail-org/kubetail</projectSourceUrl>
+    <docsUrl>https://www.kubetail.com/docs</docsUrl>
+    <bugTrackerUrl>https://github.com/kubetail-org/kubetail/issues</bugTrackerUrl>
+    <tags>kubernetes docker logs monitoring observability real-time</tags>
+    <summary>Kubetail is a real-time logging dashboard for Kubernetes</summary>
+    <description><![CDATA[## Kubetail (CLI)
+### Introduction
+
+The Kubetail CLI tool (kubetail) acts as an entry point into Kubetail on your desktop. Using the CLI tool you can start/stop the Kubetail Dashboard and perform other Kubetail-related operations on your cluster.
+
+### Sub-commands
+
+kubetail cluster
+kubetail completion
+kubetail help
+kubetail logs
+kubetail serve
+]]></description>
+    <releaseNotes>https://github.com/kubetail-org/kubetail/releases/tag/cli%2Fv${VERSION}</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -1,0 +1,84 @@
+name: publish-chocolatey
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  update-choco-packages-repo:
+    name: Update choco-packages repo
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download sha256 files
+        id: release-info
+        uses: robinraju/release-downloader@v1.12
+        with:
+          latest: true
+          fileName: "kubetail-windows-*.sha256"
+
+      - name: Sparse checkout only templates
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/ci-config/**
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          path: choco-templates
+
+      - name: Clone choco-packages repo
+        uses: actions/checkout@v4
+        with:
+          repository: kubetail-org/choco-packages
+          path: choco-packages
+
+      - name: Extract tags and shasums
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          AMD64_SHA256=$( tr -d '\r' < './kubetail-windows-amd64.sha256' )
+          ARM64_SHA256=$( tr -d '\r' < './kubetail-windows-arm64.sha256' )
+          TAG_NAME="${{ steps.release-info.outputs.tag_name }}"
+
+          echo "version=${TAG_NAME#cli/v}" >> $GITHUB_OUTPUT
+          echo "amd64_sha256=$AMD64_SHA256" >> $GITHUB_OUTPUT
+          echo "arm64_sha256=$ARM64_SHA256" >> $GITHUB_OUTPUT
+
+      - name: Execute templates in choco-packages
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          AMD64_SHA256: ${{ steps.meta.outputs.amd64_sha256 }}
+          ARM64_SHA256: ${{ steps.meta.outputs.arm64_sha256 }}
+          SRC_DIR: choco-templates/.github/ci-config/chocolatey
+          DST_DIR: choco-packages/kubetail
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # kubetail.nuspec
+          envsubst '${VERSION}' \
+            < "${SRC_DIR}/kubetail.nuspec.tmpl" \
+            > "${DST_DIR}/kubetail.nuspec"
+
+          # chocolateyInstall.ps1
+          envsubst '${VERSION} ${AMD64_SHA256} ${ARM64_SHA256}' \
+            < "${SRC_DIR}/chocolateyInstall.ps1.tmpl" \
+            > "${DST_DIR}/tools/chocolateyInstall.ps1"
+
+      - name: Commit and raise PR
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ secrets.PUBLISH_CHOCO_PACKAGES_TOKEN }}
+          path: ./choco-packages
+          commit-message: "release: kubetail- ${{ steps.meta.outputs.version }}"
+          branch: release/kubetail-${{ steps.meta.outputs.version }}
+          delete-branch: true
+          base: main
+          sign-commits: true
+          title: "Release: kubetail-${{ steps.meta.outputs.version }}"
+          body: "This PR adds the manifest files for kubetail-${{ steps.meta.outputs.version }}."


### PR DESCRIPTION
Fixes #315  

## Summary

This PR adds a GitHub Actions workflow that pushes new Kubetail CLI releases to the Kubetail [choco-packages](https://github.com/kubetail-org/choco-packages) repo automatically. When a new CLI release is created, it fetches the shasums from the release and uses them to create new manifest files for the package. Then it creates a new PR in choco-packages repo where further processing is done.

## Changes

* Add `kubetail.nuspec.tmpl` file
* Add `chocolateyInstall.ps1.tmpl` file
* Add `publish-chocolatey.yml` workflow

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
