### PR TITLE
✨ Upgrade to Rust 1.90.0

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -25,7 +25,7 @@ inputs:
   rust-toolchain:
     description: 'Rust toolchain to install'
     required: false
-    default: '1.89.0'
+    default: '1.90.0'
   setup-protoc:
     description: 'Whether to set up Protoc'
     required: false

--- a/build/package/Dockerfile.cluster-agent
+++ b/build/package/Dockerfile.cluster-agent
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM rust:1.89.0-slim AS builder
+FROM rust:1.90.0-slim AS builder
 
 WORKDIR /work
 

--- a/crates/cluster_agent/src/main.rs
+++ b/crates/cluster_agent/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-async fn parse_config() -> Result<Config, Box<(dyn Error + 'static)>> {
+async fn parse_config() -> Result<Config, Box<dyn Error + 'static>> {
     let matches = command!()
         .arg(
             arg!(

--- a/hack/tilt/Dockerfile.kubetail-cluster-agent
+++ b/hack/tilt/Dockerfile.kubetail-cluster-agent
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-slim AS builder
+FROM rust:1.90.0-slim AS builder
 
 WORKDIR /work
 


### PR DESCRIPTION
Fixes #655 

## Summary

This PR upgrades to Rust 1.90.0. It also fixes a compiler warning about unnecessary parentheses in a type argument.

## Changes

* Upgrades to Rust 1.90.0 in dev and production Cluster Agent docker images
* Upgrades to Rust 1.90.0 in CI workflow
* Removes unnecessary parentheses in type argument in `crates/cluster_agent/main.rs`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
