### PR TITLE
🎣 Add opencontainer annotations to GHCR image manifest

### DIFF
--- a/.github/workflows/release-cluster-agent.yml
+++ b/.github/workflows/release-cluster-agent.yml
@@ -75,7 +75,7 @@ jobs:
           tags: |
             kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
             ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
-        
+
   create-and-publish-manifest:
     runs-on: ubuntu-24.04
     needs: [build-and-publish-amd64, build-and-publish-arm64]
@@ -102,10 +102,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push manifests
         run: |
-          docker buildx imagetools create -t kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            -t kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            --annotation index.org.opencontainers.image.source=https://github.com/${{ github.repository }} \
+            --annotation index.org.opencontainers.image.revision=${{ github.sha }} \
+            --annotation index.org.opencontainers.image.version=${{ steps.tagName.outputs.tag }} \
+            -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }} \
             ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-amd64 \
             ghcr.io/${{ github.repository_owner }}/kubetail-cluster-agent:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token

--- a/.github/workflows/release-cluster-api.yml
+++ b/.github/workflows/release-cluster-api.yml
@@ -102,10 +102,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push manifests
         run: |
-          docker buildx imagetools create -t kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            -t kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            --annotation index.org.opencontainers.image.source=https://github.com/${{ github.repository }} \
+            --annotation index.org.opencontainers.image.revision=${{ github.sha }} \
+            --annotation index.org.opencontainers.image.version=${{ steps.tagName.outputs.tag }} \
+            -t ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }} \
             ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-amd64 \
             ghcr.io/${{ github.repository_owner }}/kubetail-cluster-api:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token

--- a/.github/workflows/release-dashboard.yml
+++ b/.github/workflows/release-dashboard.yml
@@ -102,10 +102,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push manifests
         run: |
-          docker buildx imagetools create -t kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            -t kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
             kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64 \
             kubetail/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
+          docker buildx imagetools create \
+            --annotation index.org.opencontainers.image.source=https://github.com/${{ github.repository }} \
+            --annotation index.org.opencontainers.image.revision=${{ github.sha }} \
+            --annotation index.org.opencontainers.image.version=${{ steps.tagName.outputs.tag }} \
+            -t ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }} \
             ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-amd64 \
             ghcr.io/${{ github.repository_owner }}/kubetail-dashboard:${{ steps.tagName.outputs.tag }}-arm64
       - name: Fetch docker token


### PR DESCRIPTION
## Summary

This PR adds opencontainer annotations to the GHCR image manifests to fix issue with missing package links on GitHub repo page.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
