### PR TITLE
🎣 Fix default border color issue

### DIFF
--- a/dashboard-ui/src/index.css
+++ b/dashboard-ui/src/index.css
@@ -44,25 +44,6 @@
   }
 }
 
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
-@layer base {
-
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
-  }
-}
-
 @utility no-scrollbar {
   /* Hide scrollbar for Chrome, Safari and Opera */
   &::-webkit-scrollbar {

--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -536,7 +536,7 @@ const Sidebar = () => {
                 </div>
                 <div
                   className={cn(
-                    'text-xs font-medium border not-dark:group-has-hover:border-chrome-300 min-w-[24px] h-[24px] px-[4px] rounded-sm flex items-center justify-center',
+                    'text-xs font-medium border not-dark:group-has-hover:border-chrome-300 dark:group-has-hover:border-gray-600 min-w-[24px] h-[24px] px-[4px] rounded-sm flex items-center justify-center',
                     kind === workloadKindFilter && 'border-chrome-300 dark:border-chrome-700',
                   )}
                 >


### PR DESCRIPTION
## Summary

This PR removes unnecessary code from the Tailwind V4 migration that re-defined the default border color as `--gray-200`. Now the default border color is `var(--border)`. It also makes a hover border color in the homepage sidebar lighter for dark mode.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
