### PR TITLE
🎣 Fix GHA Rust toolchain issue

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -22,10 +22,6 @@ inputs:
     description: 'Whether to set up Rust'
     required: false
     default: 'false'
-  rust-toolchain:
-    description: 'Rust toolchain to install'
-    required: false
-    default: '1.90.0'
   setup-protoc:
     description: 'Whether to set up Protoc'
     required: false
@@ -56,7 +52,6 @@ runs:
       if: inputs.setup-rust == 'true'
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: ${{ inputs.rust-toolchain }}
         components: rustfmt, clippy
 
     - name: Set up Rust cache


### PR DESCRIPTION
## Summary

Recently, the rust-toolchain action we use in our workflows started returning an error. It's probably related to the recent release of Rust 1.90.0. This PR fixes the problem by removing the toolchain version override. The default version is 1.90.0 so it won't affect our current actions but we may need to revisit this issue in the future.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
