### PR TITLE
✨ Remove cross-workload fetching barrier from dashboard homepage

### DIFF
--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -64,7 +64,6 @@ import { LogMetadataProvider } from './log-metadata-provider';
 import {
   filteredWorkloadCountAtomFamilies,
   filteredTotalCountAtomFamily,
-  isFetchingAtomFamily,
   isLoadingAtomFamily,
   namespaceFilterAtom,
   searchQueryAtom,
@@ -463,11 +462,9 @@ const DisplayWorkloads = () => {
   const { kubeContext, workloadKindFilter } = useContext(Context);
   const searchQuery = useAtomValue(searchQueryAtom);
   const isLoading = useAtomValue(isLoadingAtomFamily(kubeContext));
-  const isFetching = useAtomValue(isFetchingAtomFamily(kubeContext));
   const totalCount = useAtomValue(filteredTotalCountAtomFamily(kubeContext));
 
   if (isLoading) return <div>Loading...</div>;
-  if (isFetching) return <div>Fetching workloads...</div>;
 
   // If loading & fetching is finished and there are no search results, display "No Results" UI
   if (searchQuery.trim() !== '' && totalCount === 0) {
@@ -612,7 +609,6 @@ const Main = () => {
   });
 
   const isLoading = useAtomValue(isLoadingAtomFamily(kubeContext));
-  const isFetching = useAtomValue(isFetchingAtomFamily(kubeContext));
 
   const [searchInputValue, setSearchInputValue] = useState('');
   const setSearchQuery = useSetAtom(searchQueryAtom);
@@ -637,7 +633,7 @@ const Main = () => {
                   debouncedSearch(e.target.value);
                 }}
                 onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}
-                disabled={isLoading || isFetching}
+                disabled={isLoading}
               />
               <div className="block w-[200px]">
                 <NamespacesPicker />

--- a/dashboard-ui/src/pages/home/state.ts
+++ b/dashboard-ui/src/pages/home/state.ts
@@ -93,14 +93,6 @@ export const workloadIsFetchingAtomFamilies = Object.fromEntries(
 ) as Record<WorkloadKind, ReturnType<typeof makeWorkloadIsFetchingAtomFamily>>;
 
 /**
- * Cross-workload query isFetching state
- */
-
-export const isFetchingAtomFamily = atomFamily((kubeContext: KubeContext) =>
-  atom((get) => Object.values(workloadIsFetchingAtomFamilies).some((family) => get(family(kubeContext)))),
-);
-
-/**
  * Stable workload items state
  */
 


### PR DESCRIPTION
## Summary

Currently there's a barrier on the dashboard homepage that waits until all workload queries have finished fetching all data before rendering the UI. This PR removes the barrier so the UI will render as soon as the initial load is complete.

## Changes

* Remove cross-workload `isFetching` barrier from dashboard homepage
* Remove `isFetchingAtomFamily` from dashboard homepage state

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
