### PR TITLE
🐋 Add support for kubectl resource shortcuts to source parser

### DIFF
--- a/modules/shared/logs/helpers.go
+++ b/modules/shared/logs/helpers.go
@@ -117,20 +117,20 @@ func (w WorkloadType) Key(args ...string) string {
 
 // Parse string and return corresponding workload
 func parseWorkloadType(workloadStr string) WorkloadType {
-	switch strings.TrimRight(strings.ToLower(workloadStr), "s") {
-	case "cronjob":
+	switch strings.ToLower(workloadStr) {
+	case "cronjobs", "cronjob", "cj":
 		return WorkloadTypeCronJob
-	case "daemonset":
+	case "daemonsets", "daemonset", "ds":
 		return WorkloadTypeDaemonSet
-	case "deployment":
+	case "deployments", "deployment", "deploy":
 		return WorkloadTypeDeployment
-	case "job":
+	case "jobs", "job":
 		return WorkloadTypeJob
-	case "pod":
+	case "pods", "pod", "po":
 		return WorkloadTypePod
-	case "replicaset":
+	case "replicasets", "replicaset", "rs":
 		return WorkloadTypeReplicaSet
-	case "statefulset":
+	case "statefulsets", "statefulset", "sts":
 		return WorkloadTypeStatefulSet
 	default:
 		return WorkloadTypeUknown

--- a/modules/shared/logs/helpers_test.go
+++ b/modules/shared/logs/helpers_test.go
@@ -364,6 +364,14 @@ func TestParseWorkloadType(t *testing.T) {
 		{name: "ReplicaSets", input: "ReplicaSets", expected: WorkloadTypeReplicaSet},
 		{name: "StatefulSets", input: "StatefulSets", expected: WorkloadTypeStatefulSet},
 
+		// Test with kubectl shortcuts
+		{name: "cj", input: "cj", expected: WorkloadTypeCronJob},
+		{name: "ds", input: "ds", expected: WorkloadTypeDaemonSet},
+		{name: "deploy", input: "deploy", expected: WorkloadTypeDeployment},
+		{name: "po", input: "po", expected: WorkloadTypePod},
+		{name: "rs", input: "rs", expected: WorkloadTypeReplicaSet},
+		{name: "sts", input: "sts", expected: WorkloadTypeStatefulSet},
+
 		// Test unknown workload types
 		{name: "unknown", input: "unknown", expected: WorkloadTypeUknown},
 		{name: "empty string", input: "", expected: WorkloadTypeUknown},


### PR DESCRIPTION
Fixes #690 

## Summary

This PR adds support for `kubectl` resource name shortcuts to workload parser:
* cj -> cronjob
* ds -> daemonset
* deploy -> deployment
* po -> pod
* rs -> replicaset
* sts -> statefulset

## Changes

* Modified `parseWorkloadType` in `modules/shared/logs/helpers.go`
* Added shortcut test to `modules/shared/logs/helpers_test.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
