### PR TITLE
🎣 Use kubeconfig `CurrentContext` when `kubeContext` argument is empty

### DIFF
--- a/modules/shared/k8shelpers/connection-manager.go
+++ b/modules/shared/k8shelpers/connection-manager.go
@@ -218,10 +218,15 @@ func (cm *DesktopConnectionManager) GetDefaultNamespace(kubeContext string) stri
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
+	if kubeContext == "" {
+		kubeContext = cm.kubeConfig.CurrentContext
+	}
+
 	context, exists := cm.kubeConfig.Contexts[kubeContext]
 	if !exists || context.Namespace == "" {
 		return metav1.NamespaceDefault
 	}
+
 	return context.Namespace
 }
 


### PR DESCRIPTION
Fixes #691

## Summary

This PR fixes a bug that missed kubeconfig default namespaces for the `CurrentContext` when `kubeContext` argument was empty.

## Changes

* Modified `/modules/shared/k8helpers/connection-manager.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
