### PR TITLE
🎣 Fix warning from missing rustc when running `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ else
 endif
 
 # Rust toolchain detection
-RUST_VERSION := $(shell rustc --version | cut -d' ' -f2)
-RUST_ARCH := $(shell rustc -vV | grep host | cut -d' ' -f2)
+RUST_VERSION := $(shell command -v rustc >/dev/null 2>&1 && rustc --version | cut -d' ' -f2)
+RUST_ARCH := $(shell command -v rustc >/dev/null 2>&1 && rustc -vV | grep host | cut -d' ' -f2)
 
 # Allow version override via CLI argument (default to "dev")
 VERSION ?= dev


### PR DESCRIPTION
## Summary

This modifies the rustc version check in our Makefile to fail silently if rustc isn't available in order to remove warnings when running `make build` in systems without rustc (Rust isn't required for a CLI build).

## Changes

* Modified `Makefile`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
