### PR TITLE
🐋 Add publish-snapcraft GHA workflow

### DIFF
--- a/.github/ci-config/snapcraft.yaml.tmpl
+++ b/.github/ci-config/snapcraft.yaml.tmpl
@@ -1,0 +1,35 @@
+name: kubetail
+title: Kubetail
+base: core22
+version: '${TMPL_VERSION}'
+
+grade: stable
+confinement: strict
+
+apps:
+  kubetail:
+    command: kubetail
+    plugs:
+      - home
+      - network
+
+parts:
+  kubetail:
+    plugin: dump
+    source: .
+    override-build: |
+      set -eux
+
+      ARCH="${CRAFT_ARCH_BUILD_ON}"
+      VERSION="${SNAPCRAFT_PROJECT_VERSION}"
+
+      # Download the prebuilt tarball for this architecture
+      curl -L -o kubetail.tar.gz \
+        "https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-linux-${ARCH}.tar.gz"
+
+      # Extract and install the binary
+      tar -xzf kubetail.tar.gz
+      install -Dm755 kubetail "${CRAFT_PART_INSTALL}/kubetail"
+    build-packages:
+      - curl
+      - tar

--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -1,0 +1,78 @@
+name: publish-snapcraft
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy"
+        required: true
+        type: string
+        default: "latest"
+      dry_run:
+        description: "If true, only simulate action"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Configure
+        id: config
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/ci-config/snapcraft.yaml.tmpl
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Execute snapcraft templates
+        env:
+          TMPL_VERSION: ${{ steps.config.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          envsubst '${TMPL_VERSION}' \
+            < ".github/ci-config/snapcraft.yaml.tmpl" \
+            > "snapcraft.yaml"
+
+      - name: Build
+        id: build
+        uses: snapcore/action-build@v1
+
+      - name: Publish
+        uses: snapcore/action-publish@v1
+        if: ${{ steps.config.outputs.dry_run != 'true' }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.PUBLISH_SNAPCRAFT_TOKEN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable


### PR DESCRIPTION
## Summary

This adds a publish-snapcraft GHA workflow that builds and publishes snaps triggered by new releases or workflow_dispatch.

## Changes

* Adds `.github/ci-config/snapcraft.yaml.tmpl`
* Adds `.github/workflows/publish-snapcraft.yml`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
