### PR TITLE
✨ Migrate full publish-chocolatey workflow into repo

### DIFF
--- a/.github/ci-config/chocolatey/README.md
+++ b/.github/ci-config/chocolatey/README.md
@@ -1,0 +1,1 @@
+Kubetail CLI Chocolatey Package

--- a/.github/ci-config/chocolatey/kubetail.nuspec.tmpl
+++ b/.github/ci-config/chocolatey/kubetail.nuspec.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>kubetail</id>
+    <version>${VERSION}</version>
+    <packageSourceUrl>https://github.com/kubetail-org/choco-packages</packageSourceUrl>
+    <owners>Andres Morey</owners>
+    <title>Kubetail (CLI)</title>
+    <authors>Kubetail</authors>
+    <projectUrl>https://www.kubetail.com</projectUrl>
+    <iconUrl>https://assets.kubetail.com/choco/icon.cd5e01aa.png</iconUrl>
+    <copyright>(c) 2024-2025 Andres Morey</copyright>
+    <licenseUrl>https://github.com/kubetail-org/kubetail/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/kubetail-org/kubetail</projectSourceUrl>
+    <docsUrl>https://www.kubetail.com/docs</docsUrl>
+    <bugTrackerUrl>https://github.com/kubetail-org/kubetail/issues</bugTrackerUrl>
+    <tags>kubernetes docker logs monitoring observability real-time</tags>
+    <summary>Kubetail is a real-time logging dashboard for Kubernetes</summary>
+    <description><![CDATA[## Kubetail (CLI)
+### Introduction
+
+The Kubetail CLI tool (kubetail) acts as an entry point into Kubetail on your desktop. Using the CLI tool you can start/stop the Kubetail Dashboard and perform other Kubetail-related operations on your cluster.
+
+### Sub-commands
+
+kubetail cluster
+kubetail completion
+kubetail help
+kubetail logs
+kubetail serve
+]]></description>
+    <releaseNotes>https://github.com/kubetail-org/kubetail/releases/tag/cli%2Fv${VERSION}</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/.github/ci-config/chocolatey/tools/chocolateyInstall.ps1.tmpl
+++ b/.github/ci-config/chocolatey/tools/chocolateyInstall.ps1.tmpl
@@ -1,0 +1,23 @@
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Dectect drchitecture (9 = x64 (AMD64), 12 = ARM64)
+$osArch = (Get-CimInstance Win32_Processor).Architecture
+
+if ($osArch -eq 12) {
+    $url      = 'https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-windows-arm64'
+    $checksum = '${ARM64_SHA256}'
+}
+else {
+    $url      = 'https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-windows-amd64'
+    $checksum = '${AMD64_SHA256}'
+}
+
+$packageArgs = @{
+    PackageName    = 'kubetail'
+    Url64bit       = $url
+    Checksum64     = $checksum
+    ChecksumType64 = 'sha256'
+    FileFullPath   = "$toolsDir\kubetail.exe"
+}
+
+Get-ChocolateyWebFile @packageArgs

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -7,19 +7,134 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy"
+        required: true
+        type: string
+      dry_run:
+        description: "If true, only simulate action"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  trigger-choco-packages-publish-workflow:
-    name: Trigger choco-packages publish workflow
+  generate-nuspec:
+    name: Generate nuspec
     runs-on: ubuntu-24.04
     steps:
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
-      - name: Trigger workflow
-        uses: benc-uk/workflow-dispatch@v1.2.4
+      - name: Config
+        id: config
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download sha256 files
+        id: release-info
+        uses: robinraju/release-downloader@v1.12
         with:
-          repo: kubetail-org/choco-packages
-          workflow: publish
-          token: ${{ secrets.PUBLISH_CHOCOLATEY_TOKEN }}
-          inputs: '{ "version": "${{ steps.version.outputs.version }}", "merge_on_push": true }'
+          tag: ${{ format('cli/v{0}', steps.config.outputs.version) }}
+          fileName: "kubetail-windows-*.sha256"
+          out-file-path: "downloads"
+
+      - name: Extract tags and shasums
+        id: meta
+        shell: bash
+        working-directory: ./downloads
+        run: |
+          set -euo pipefail
+
+          AMD64_SHA256=$( tr -d '\r' < './kubetail-windows-amd64.sha256' | awk '{print $1}' )
+          ARM64_SHA256=$( tr -d '\r' < './kubetail-windows-arm64.sha256' | awk '{print $1}' )
+          TAG_NAME="${{ steps.release-info.outputs.tag_name }}"
+
+          echo "version=${TAG_NAME#cli/v}" >> $GITHUB_OUTPUT
+          echo "amd64_sha256=$AMD64_SHA256" >> $GITHUB_OUTPUT
+          echo "arm64_sha256=$ARM64_SHA256" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Execute templates
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          AMD64_SHA256: ${{ steps.meta.outputs.amd64_sha256 }}
+          ARM64_SHA256: ${{ steps.meta.outputs.arm64_sha256 }}
+          SRC_DIR: .github/ci-config/chocolatey
+          DST_DIR: nuspec
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${DST_DIR}/tools"
+
+          # kubetail.nuspec
+          envsubst '${VERSION}' \
+            < "${SRC_DIR}/kubetail.nuspec.tmpl" \
+            > "${DST_DIR}/kubetail.nuspec"
+
+          # chocolateyInstall.ps1
+          envsubst '${VERSION} ${AMD64_SHA256} ${ARM64_SHA256}' \
+            < "${SRC_DIR}/tools/chocolateyInstall.ps1.tmpl" \
+            > "${DST_DIR}/tools/chocolateyInstall.ps1"
+
+          cp "${SRC_DIR}/README.md" "${DST_DIR}/"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuspec
+          path: nuspec/*
+
+  push-to-chocolatey:
+    name: Push to chocolatey
+    runs-on: windows-latest
+    needs: generate-nuspec
+    steps:
+      - name: Config
+        id: config
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
+          else
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nuspec
+          path: nuspec
+
+      - name: Get version number
+        id: nuspec
+        shell: pwsh
+        run: |
+          [xml]$nuspec = Get-Content ".\nuspec\kubetail.nuspec"
+          $version = $nuspec.package.metadata.version
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Configure API key
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.PUBLISH_CHOCOLATEY_TOKEN }}
+        run: |
+          choco apikey --source https://push.chocolatey.org/ --key $env:CHOCOLATEY_API_KEY
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          choco pack .\nuspec\kubetail.nuspec --output-directory .\
+
+      - name: Push to Chocolatey
+        if: ${{ steps.config.outputs.dry_run != 'true' }}
+        shell: pwsh
+        run: |
+          choco push .\kubetail.${{ steps.nuspec.outputs.version }}.nupkg --source https://push.chocolatey.org/


### PR DESCRIPTION
Fixes #722

## Summary

This migrates the publish workflow from the `choco-packages` directory into this repo.

## Changes

* Adds nuspec templates to `.github/ci-config/chocolatey`
* Modifies `.github/workflows/publish-chocolatey.yml`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
