### PR TITLE
🐋 Add publish-aur workflow

### DIFF
--- a/.github/ci-config/aur/PKGBUILD.tmpl
+++ b/.github/ci-config/aur/PKGBUILD.tmpl
@@ -1,0 +1,33 @@
+# Maintainer: Andres Morey <andres@kubetail.com>
+
+pkgname=kubetail-bin
+pkgver=${VERSION}
+pkgrel=1
+pkgdesc="Real-time logging dashboard for Kubernetes"
+arch=('x86_64' 'aarch64')
+url="https://github.com/kubetail-org/kubetail"
+license=('apache')
+depends=()
+provides=('kubetail')
+conflicts=('kubetail')
+
+source_x86_64=("https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${pkgver}/kubetail-linux-amd64")
+source_aarch64=("https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${pkgver}/kubetail-linux-arm64")
+
+sha256sums_x86_64=('${AMD64_SHA256}')
+sha256sums_aarch64=('${ARM64_SHA256}')
+
+package() {
+  # Map Arch → filename in release assets
+  local _bin
+  case "$CARCH" in
+    x86_64)  _bin="kubetail-linux-amd64" ;;
+    aarch64) _bin="kubetail-linux-arm64" ;;
+    *) echo "Unsupported arch: $CARCH" >&2; return 1 ;;
+  esac
+
+  install -Dm755 "${srcdir}/${_bin}" "${pkgdir}/usr/bin/kubetail"
+
+  "${pkgdir}/usr/bin/kubetail" completion bash | install -Dm644 /dev/stdin "${pkgdir}/usr/share/bash-completion/completions/kubetail"
+  "${pkgdir}/usr/bin/kubetail" completion zsh | install -Dm644 /dev/stdin "${pkgdir}/usr/share/zsh/site-functions/_kubetail"
+}

--- a/.github/ci-config/aur/SRCINFO.tmpl
+++ b/.github/ci-config/aur/SRCINFO.tmpl
@@ -1,0 +1,16 @@
+pkgbase = kubetail-bin
+	pkgdesc = Real-time logging dashboard for Kubernetes
+	pkgver = ${VERSION}
+	pkgrel = 1
+	url = https://github.com/kubetail-org/kubetail
+	arch = x86_64
+	arch = aarch64
+	license = apache
+	provides = kubetail
+	conflicts = kubetail
+	source_x86_64 = https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-linux-amd64
+	sha256sums_x86_64 = ${AMD64_SHA256}
+	source_aarch64 = https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${VERSION}/kubetail-linux-arm64
+	sha256sums_aarch64 = ${ARM64_SHA256}
+
+pkgname = kubetail-bin

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,134 @@
+name: publish-aur
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy"
+        required: true
+        type: string
+      dry_run:
+        description: "If true, only simulate action"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  update-repo:
+    name: Update AUR kubetail-bin repo
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Config
+        id: config
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download sha256 files
+        id: release-info
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: kubetail-org/kubetail
+          tag: ${{ format('cli/v{0}', steps.config.outputs.version) }}
+          fileName: "kubetail-linux-*.sha256"
+          out-file-path: "downloads"
+
+      - name: Extract tags and shasums
+        id: meta
+        shell: bash
+        working-directory: ./downloads
+        run: |
+          set -euo pipefail
+
+          AMD64_SHA256=$( tr -d '\r' < './kubetail-linux-amd64.sha256' | awk '{print $1}' )
+          ARM64_SHA256=$( tr -d '\r' < './kubetail-linux-arm64.sha256' | awk '{print $1}' )
+
+          echo "amd64_sha256=$AMD64_SHA256" >> $GITHUB_OUTPUT
+          echo "arm64_sha256=$ARM64_SHA256" >> $GITHUB_OUTPUT
+
+      - name: Checkout kubetail repo
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/ci-config/aur
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          path: kubetail
+
+      - name: Load AUR SSH key
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+
+          mkdir -p ~/.ssh
+          echo "${{ secrets.AUR_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+
+          # Configure SSH to use the key for AUR
+          cat >> ~/.ssh/config <<EOF
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Checkout kubetail-bin repo
+        run: |
+          git clone ssh://aur@aur.archlinux.org/kubetail-bin.git
+
+      - name: Execute templates
+        env:
+          VERSION: ${{ steps.config.outputs.version }}
+          AMD64_SHA256: ${{ steps.meta.outputs.amd64_sha256 }}
+          ARM64_SHA256: ${{ steps.meta.outputs.arm64_sha256 }}
+          SRC_DIR: kubetail/.github/ci-config/aur
+          DST_DIR: kubetail-bin
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # PKGBUILD
+          envsubst '${VERSION} ${AMD64_SHA256} ${ARM64_SHA256}' \
+            < "${SRC_DIR}/PKGBUILD.tmpl" \
+            > "${DST_DIR}/PKGBUILD"
+
+          # .SRCINFO
+          envsubst '${VERSION} ${AMD64_SHA256} ${ARM64_SHA256}' \
+            < "${SRC_DIR}/SRCINFO.tmpl" \
+            > "${DST_DIR}/.SRCINFO"
+
+      - name: Push changes to AUR repo
+        working-directory: ./kubetail-bin
+        if: ${{ steps.config.outputs.dry_run != 'true' }}
+        run: |
+          set -euo pipefail
+
+          # Set name and email
+          git config user.name "Andres Morey"
+          git config user.email "andres@kubetail.com"
+
+          # Stage changes
+          git add PKGBUILD .SRCINFO
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          # Commit and push
+          git commit -m "release: ${{ steps.config.outputs.version }}"
+          git push origin master

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -50,9 +50,7 @@ jobs:
 
           AMD64_SHA256=$( tr -d '\r' < './kubetail-windows-amd64.sha256' | awk '{print $1}' )
           ARM64_SHA256=$( tr -d '\r' < './kubetail-windows-arm64.sha256' | awk '{print $1}' )
-          TAG_NAME="${{ steps.release-info.outputs.tag_name }}"
 
-          echo "version=${TAG_NAME#cli/v}" >> $GITHUB_OUTPUT
           echo "amd64_sha256=$AMD64_SHA256" >> $GITHUB_OUTPUT
           echo "arm64_sha256=$ARM64_SHA256" >> $GITHUB_OUTPUT
 
@@ -63,7 +61,7 @@ jobs:
 
       - name: Execute templates
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ steps.config.outputs.version }}
           AMD64_SHA256: ${{ steps.meta.outputs.amd64_sha256 }}
           ARM64_SHA256: ${{ steps.meta.outputs.arm64_sha256 }}
           SRC_DIR: .github/ci-config/chocolatey


### PR DESCRIPTION
Fixes #723

## Summary

This adds a publish-aur workflow that publishes new releases to Arch Linux AUR. It also makes a small improvement to the publish-chocolatey workflow.

## Changes

* Adds `.github/ci-config/aur`
* Adds `.github/workflows/publish-aur.yml`
* Modifies `.github/workflows/publish-chocolatey.yml`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
