### PR TITLE
✨Add coverage for newly created file updates in log metadata watcher

### DIFF
--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -413,21 +413,20 @@ impl LogMetadataWatchEventType {
 
 #[cfg(test)]
 mod test {
+    use std::fs::{File, remove_file};
+    use std::io::Write;
+
     #[cfg(not(target_os = "macos"))]
-    use std::{
-        fs::{File, remove_file, rename},
-        io::Write,
-    };
+    use std::fs::rename;
+
+    use notify::{PollWatcher, RecommendedWatcher};
+    use serial_test::{parallel, serial};
+    use tokio::sync::{broadcast, mpsc::error::TryRecvError};
+    use tokio::task;
 
     use crate::log_metadata::test::create_test_file;
 
     use super::*;
-    use notify::{PollWatcher, RecommendedWatcher};
-    use serial_test::{parallel, serial};
-    use tokio::{
-        sync::{broadcast, mpsc::error::TryRecvError},
-        task,
-    };
 
     #[tokio::test]
     #[serial]


### PR DESCRIPTION
Fixes #632

## Summary

This PR adds comprehensive test coverage for the LogMetadataWatcher to verify it correctly handles updates to newly created files. Previously, tests focused on files that existed before the watcher started or on simple create/delete scenarios. These new tests ensure the watcher properly tracks the lifecycle of files that are created and modified during runtime.

## Changes

`test_newly_created_file_receives_modify_events`
- Verifies that a file created after the watcher starts receives both ADDED and MODIFIED events 
- Handles debounced events where create and modify may be combined 
- Tests file size tracking across events

`test_multiple_updates_to_newly_created_file`
- Tests multiple sequential modifications to a newly created file
- Ensures the watcher tracks all modifications with correct file sizes
- Verifies at least one ADDED event and multiple MODIFIED events

`test_create_and_immediate_modify_before_watcher_starts`

- Tests files that exist before the watcher starts
- Ensures only MODIFIED events are generated (not ADDED)
- Verifies proper tracking of pre-existing files

`test_created_file_with_wrong_namespace_not_watched`
- Ensures namespace filtering works for newly created files
- Verifies that files in unwatched namespaces don't generate events
- Tests that modifications to filtered files are ignored

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
