### PR TITLE
🎣 Add missing `basePath` to ClusterAPI proxy handler in Dashboard

### DIFF
--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -79,7 +79,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		app.cm = cm
 
 		// Init Cluster API proxy
-		clusterAPIProxy, err := newClusterAPIProxy(cfg, app.cm, "/cluster-api-proxy")
+		clusterAPIProxy, err := newClusterAPIProxy(cfg, app.cm, path.Join(cfg.Dashboard.BasePath, "/cluster-api-proxy"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #738

## Summary

This adds a missing `basePath` when initializing the ClusterAPI proxy in the Dashboard. Previously this was missing which was causing the proxy to ignore requests.

## Changes

* Modified `modules/dashboard/pkg/app/app.go`
* Modified `modules/dashboard/pkg/app/app_test.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
