### PR TITLE
🐋 Add support for init containers

### DIFF
--- a/hack/tilt/cronjob.yaml
+++ b/hack/tilt/cronjob.yaml
@@ -12,11 +12,18 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+            - name: init
+              image: busybox:1.28
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Initializing pod
           containers:
-          - name: hello
-            image: busybox:1.28
-            command:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
+            - name: hello
+              image: busybox:1.28
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure

--- a/modules/shared/logs/source-watcher.go
+++ b/modules/shared/logs/source-watcher.go
@@ -388,7 +388,7 @@ func (w *sourceWatcher) updateSources_UNSAFE() {
 		for _, workload := range w.index.GetWorkloads(pp.Namespace, pp.WorkloadType, pp.WorkloadName) {
 			for _, pod := range w.index.GetPodsOwnedByWorkload(workload.GetUID()) {
 				wantName := pp.ContainerName
-				for n, status := range pod.Status.ContainerStatuses {
+				for n, status := range slices.Concat(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses) {
 					// Wait until we have an ID
 					if status.ContainerID == "" {
 						continue


### PR DESCRIPTION
Fixes #732  

## Summary

This adds support for fetching logs from init containers. Now init containers are fetched using the "*" container name wildcard or explictily by specifying the init container's name.

## Changes

* Added an init container to the dev environment cron job (`hack/tilt/cronjob.yaml`)
* Added `InitContainerStatuses` to the container list in `modules/shared/logs/source-watcher.go`
* Added tests in `modules/shared/logs/source-watcher_test.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
