### PR TITLE
🎣 Add -mod=vendor and specify bash shell in release-cli

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -135,9 +135,12 @@ jobs:
         env:
           GOWORK: off
           CGO_ENABLED: 0
+          GOOS: ${{ matrix.GOOS }}
+          GOARCH: ${{ matrix.GOARCH }}
           LDFLAGS: "-s -w -X 'github.com/kubetail-org/kubetail/modules/cli/cmd.version=${{ needs.config.outputs.version }}'"
+        shell: bash
         run: |
-          go build -ldflags="${LDFLAGS}" -o ../../bin/kubetail .
+          go build -mod=vendor -ldflags="${LDFLAGS}" -o ../../bin/kubetail .
       - name: Append os/arch to binary file name
         run: mv bin/kubetail bin/kubetail-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
       - name: Upload artifact


### PR DESCRIPTION
## Summary

This adds missing `-mod=vendor` arg to `go build` command in release-cli workflow and also sets `shell: bash` so that windows runners can handle build command env args properly.

## Changes

* Modified `release-cli.yml`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
