### PR TITLE
🐋 Add publish-nix workflow

### DIFF
--- a/.github/workflows/publish-nix.yml
+++ b/.github/workflows/publish-nix.yml
@@ -1,0 +1,25 @@
+name: publish-nix
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  trigger-release-workflow:
+    name: Trigger release workflow in kubetail-org/kubetail-nix repo
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
+      - name: Trigger workflow
+        uses: benc-uk/workflow-dispatch@v1.2.4
+        with:
+          repo: kubetail-org/kubetail-nix
+          workflow: release
+          token: ${{ secrets.PUBLISH_NIX_TOKEN }}
+          inputs: '{ "version": "${{ steps.version.outputs.version }}", "dry_run": false }'


### PR DESCRIPTION
## Summary

This adds a workflow to this repo that triggers the `release` workflow in the `kubetail-org/kubetail-nix` repo when a new CLI release is published here.

## Changes

* Added `.github/workflows/publish-nix.yml`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
