### PR TITLE
🐋 Add publish-guru workflow

### DIFF
--- a/.github/ci-config/guru/kubetail-bin.ebuild
+++ b/.github/ci-config/guru/kubetail-bin.ebuild
@@ -1,0 +1,43 @@
+# Copyright 2021-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit shell-completion
+
+DESCRIPTION="Real-time logging dashboard for Kubernetes"
+
+HOMEPAGE="https://github.com/kubetail-org/kubetail"
+
+SRC_URI="
+amd64? ( https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${PV}/kubetail-linux-amd64.tar.gz
+-> ${P}-linux-amd64.tar.gz )
+arm64? ( https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${PV}/kubetail-linux-arm64.tar.gz
+-> ${P}-linux-arm64.tar.gz )
+"
+
+S="${WORKDIR}"
+
+LICENSE="Apache-2.0"
+
+SLOT="0"
+
+KEYWORDS="~amd64 ~arm64"
+
+QA_PREBUILT="usr/bin/kubetail"
+
+src_compile() {
+	chmod +x kubetail
+
+	./kubetail completion bash > "kubetail.bash" || die
+	./kubetail completion zsh > "kubetail.zsh" || die
+	./kubetail completion fish > "kubetail.fish" || die
+}
+
+src_install() {
+	dobin kubetail || die
+
+	newbashcomp "kubetail.bash" kubetail
+	newzshcomp "kubetail.zsh" "_kubetail"
+	dofishcomp "kubetail.fish"
+}

--- a/.github/ci-config/guru/kubetail.ebuild
+++ b/.github/ci-config/guru/kubetail.ebuild
@@ -1,0 +1,49 @@
+# Copyright 2021-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit shell-completion
+
+DESCRIPTION="Real-time logging dashboard for Kubernetes"
+
+HOMEPAGE="https://github.com/kubetail-org/kubetail"
+
+SRC_URI="https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv${PV}/kubetail-cli.orig.tar.xz -> kubetail-cli_${PV}.orig.tar.xz"
+
+S="${WORKDIR}/kubetail-cli"
+
+LICENSE="Apache-2.0"
+
+SLOT="0"
+
+KEYWORDS="~amd64 ~arm64"
+
+BDEPEND="
+	>=dev-lang/go-1.24.7
+"
+
+QA_PREBUILT="usr/bin/kubetail"
+
+src_compile() {
+	(
+		cd modules/cli || die
+		GOWORK=off CGO_ENABLED=0 go build \
+			-mod=vendor \
+			-ldflags "-s -w -X github.com/kubetail-org/kubetail/modules/cli/cmd.version=${PV}" \
+			-o ../../bin/kubetail \
+			. || die
+	)
+
+	./bin/kubetail completion bash > "kubetail.bash" || die
+	./bin/kubetail completion zsh > "kubetail.zsh" || die
+	./bin/kubetail completion fish > "kubetail.fish" || die
+}
+
+src_install() {
+	dobin bin/kubetail || die
+
+	newbashcomp "kubetail.bash" kubetail
+	newzshcomp "kubetail.zsh" "_kubetail"
+	dofishcomp "kubetail.fish"
+}

--- a/.github/workflows/publish-guru.yml
+++ b/.github/workflows/publish-guru.yml
@@ -1,0 +1,212 @@
+name: publish-guru
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  config:
+    name: Configure workflow
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.config.outputs.version }}
+      dry_run: ${{ steps.config.outputs.dry_run }}
+    steps:
+      - id: config
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+  update-kubetail:
+    name: Update `kubetail` package
+    needs: [config]
+    runs-on: ubuntu-24.04
+    env:
+      ARCHIVE_NAME: "kubetail-cli.orig.tar.xz"
+    steps:
+      - name: Download source bundle
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: kubetail-org/kubetail
+          tag: ${{ format('cli/v{0}', needs.config.outputs.version) }}
+          fileName: ${{ env.ARCHIVE_NAME }}
+          out-file-path: "downloads"
+
+      - name: Extract metadata
+        id: meta
+        working-directory: ./downloads
+        run: |
+          SIZE=$(stat --format '%s' "$ARCHIVE_NAME")
+          BLAKE2B=$(b2sum "$ARCHIVE_NAME" | awk '{print $1}')
+          SHA512=$(sha512sum "$ARCHIVE_NAME" | awk '{print $1}')
+
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+          echo "blake2b=$BLAKE2B" >> "$GITHUB_OUTPUT"
+          echo "sha512=$SHA512" >> "$GITHUB_OUTPUT"
+
+      - name: Load GURU SSH key
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.GENTOO_SSH_PRIVATE_KEY }}
+
+      - name: Checkout GURU repo
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GENTOO_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+
+          git clone --depth 1 --branch dev --single-branch git@git.gentoo.org:repo/proj/guru.git
+
+      - name: Checkout kubetail repo
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/ci-config/guru
+          sparse-checkout-cone-mode: false
+          path: kubetail
+
+      - name: Create ebuild file
+        env:
+          SRC_DIR: kubetail/.github/ci-config/guru
+          DST_DIR: guru/dev-util/kubetail
+        run: |
+          cp "$SRC_DIR/kubetail.ebuild" "$DST_DIR/kubetail-${{ needs.config.outputs.version}}.ebuild"
+
+      - name: Update Manifest
+        working-directory: guru/dev-util/kubetail
+        run: |
+          echo "DIST kubetail-cli_${{ needs.config.outputs.version }}.orig.tar.xz ${{ steps.meta.outputs.size }} BLAKE2B ${{ steps.meta.outputs.blake2b }} SHA512 ${{ steps.meta.outputs.sha512 }}" >> Manifest
+
+      - name: Debug
+        if: ${{ needs.config.outputs.dry_run == 'true' }}
+        working-directory: guru/dev-util/kubetail
+        run: |
+          ls -lah *
+          cat kubetail-${{ needs.config.outputs.version }}.ebuild
+          cat Manifest
+
+      - name: Push changes to GURU repo
+        working-directory: guru
+        if: ${{ needs.config.outputs.dry_run != 'true' }}
+        run: |
+          # Set name and email
+          git config user.name "Andres Morey"
+          git config user.email "andres@kubetail.com"
+
+          # Stage changes
+          git add . --all
+
+          # Commit and push
+          git commit -a -s -m "dev-util/kubetail: add ${{ needs.config.outputs.version }}"
+          git push origin
+
+  update-kubetail-bin:
+    name: Update `kubetail-bin` package
+    needs: [config, update-kubetail]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download source bundle
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: kubetail-org/kubetail
+          tag: ${{ format('cli/v{0}', needs.config.outputs.version) }}
+          fileName: "kubetail-linux-*.tar.gz"
+          out-file-path: "downloads"
+
+      - name: Extract metadata
+        id: meta
+        working-directory: ./downloads
+        run: |
+          AMD64_NAME="kubetail-linux-amd64.tar.gz"
+          ARM64_NAME="kubetail-linux-arm64.tar.gz"
+
+          AMD64_SIZE=$(stat --format '%s' "$AMD64_NAME")
+          AMD64_BLAKE2B=$(b2sum "$AMD64_NAME" | awk '{print $1}')
+          AMD64_SHA512=$(sha512sum "$AMD64_NAME" | awk '{print $1}')
+
+          ARM64_SIZE=$(stat --format '%s' "$ARM64_NAME")
+          ARM64_BLAKE2B=$(b2sum "$ARM64_NAME" | awk '{print $1}')
+          ARM64_SHA512=$(sha512sum "$ARM64_NAME" | awk '{print $1}')
+
+          echo "amd64_size=$AMD64_SIZE" >> "$GITHUB_OUTPUT"
+          echo "amd64_blake2b=$AMD64_BLAKE2B" >> "$GITHUB_OUTPUT"
+          echo "amd64_sha512=$AMD64_SHA512" >> "$GITHUB_OUTPUT"
+
+          echo "arm64_size=$ARM64_SIZE" >> "$GITHUB_OUTPUT"
+          echo "arm64_blake2b=$ARM64_BLAKE2B" >> "$GITHUB_OUTPUT"
+          echo "arm64_sha512=$ARM64_SHA512" >> "$GITHUB_OUTPUT"
+
+      - name: Load GURU SSH key
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.GENTOO_SSH_PRIVATE_KEY }}
+
+      - name: Checkout GURU repo
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GENTOO_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+
+          git clone --depth 1 --branch dev --single-branch git@git.gentoo.org:repo/proj/guru.git
+
+      - name: Checkout kubetail repo
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/ci-config/guru
+          sparse-checkout-cone-mode: false
+          path: kubetail
+
+      - name: Create ebuild file
+        env:
+          SRC_DIR: kubetail/.github/ci-config/guru
+          DST_DIR: guru/dev-util/kubetail-bin
+        run: |
+          cp "$SRC_DIR/kubetail-bin.ebuild" "$DST_DIR/kubetail-bin-${{ needs.config.outputs.version}}.ebuild"
+
+      - name: Update Manifest
+        working-directory: guru/dev-util/kubetail-bin
+        env:
+          P: "kubetail-bin-${{ needs.config.outputs.version }}"
+        run: |
+          echo "DIST $P-linux-amd64.tar.gz ${{ steps.meta.outputs.amd64_size }} BLAKE2B ${{ steps.meta.outputs.amd64_blake2b }} SHA512 ${{ steps.meta.outputs.amd64_sha512 }}" >> Manifest
+          echo "DIST $P-linux-arm64.tar.gz ${{ steps.meta.outputs.arm64_size }} BLAKE2B ${{ steps.meta.outputs.arm64_blake2b }} SHA512 ${{ steps.meta.outputs.arm64_sha512 }}" >> Manifest
+
+      - name: Debug
+        if: ${{ needs.config.outputs.dry_run == 'true' }}
+        working-directory: guru/dev-util/kubetail-bin
+        run: |
+          ls -lah *
+          cat kubetail-bin-${{ needs.config.outputs.version }}.ebuild
+          cat Manifest
+
+      - name: Push changes to GURU repo
+        working-directory: guru
+        if: ${{ needs.config.outputs.dry_run != 'true' }}
+        run: |
+          # Set name and email
+          git config user.name "Andres Morey"
+          git config user.email "andres@kubetail.com"
+
+          # Stage changes
+          git add . --all
+
+          # Commit and push
+          git commit -a -s -m "dev-util/kubetail-bin: add ${{ needs.config.outputs.version }}"
+          git push origin


### PR DESCRIPTION
## Summary

This adds a `publish-guru` workflow that pushes new versions of `kubetail` after cli releases.

## Changes

* Add `.github/workflows/publish-guru.yml`
* Add `.github/ci-config/guru/kubetail.ebuild`
* Add `.github/ci-config/guru/kubetail-cli.ebuild`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
