### PR TITLE
✨ Add more k8s workload examples to dev environment

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -271,5 +271,3 @@ k8s_resource(
   'echoserver',
   port_forwards='4502:8080',
 )
-
-

--- a/hack/tilt/daemonset-example.yaml
+++ b/hack/tilt/daemonset-example.yaml
@@ -12,15 +12,16 @@ spec:
         app.kubernetes.io/name: daemonset-example
     spec:
       containers:
-      - name: daemonset-example
-        image: alpine:3.22.0
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-        # will print the name of the host machine the pod is running on
-        command: ["sh", "-c"]
-        args: 
-          - echo "This pod is running on $(NODE_NAME)"; sleep infinity
-
+        - name: daemonset-example
+          image: alpine:3.22.0
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "This pod is running on $(NODE_NAME)"
+              trap "echo 'Received SIGTERM, exiting'; exit 0" TERM
+              sleep infinity & wait $!

--- a/hack/tilt/multi-container-pod.yaml
+++ b/hack/tilt/multi-container-pod.yaml
@@ -3,14 +3,20 @@ kind: Pod
 metadata:
   name: multi-container-pod
 spec:
-  restartPolicy: Never
   containers:
-  - name: container-a
-    image: alpine:3.22.0
-    imagePullPolicy: IfNotPresent
-    command: ["/bin/sh", "-c", "while true; do echo 'Hello from container-a'; sleep 3600; done"]
-  - name: container-b
-    image: alpine:3.22.0
-    imagePullPolicy: IfNotPresent
-    command: ["/bin/sh", "-c", "while true; do echo 'Hello from container-b'; sleep 3600; done"]
-
+    - name: container-a
+      image: alpine:3.22.0
+      command: ["sh", "-c"]
+      args:
+        - |
+          echo "Hello from container-a"
+          trap "echo 'Received SIGTERM, exiting'; exit 0" TERM
+          sleep infinity & wait $!
+    - name: container-b
+      image: alpine:3.22.0
+      command: ["sh", "-c"]
+      args:
+        - |
+          echo "Hello from container-b"
+          trap "echo 'Received SIGTERM, exiting'; exit 0" TERM
+          sleep infinity & wait $!


### PR DESCRIPTION
Fixes #750 

## Summary

This PR adds more k8s workloads examples, _DaemonSet_ and a Multi-containers _Pod_, to the dev environment

## Changes

added 2 k8s resources,
  `DaemonSet` _os-release-daemonset_ 
  `Pod` _multi-containers_

`multi-containers` pod logs 

<img width="1227" height="747" alt="Screenshot From 2025-11-02 14-57-24" src="https://github.com/user-attachments/assets/348efc86-3333-4e55-865c-d3b714f891f7" />

`os-release-daemonset` logs

<img width="996" height="616" alt="Screenshot From 2025-11-02 16-30-40" src="https://github.com/user-attachments/assets/cde1e57a-21a0-424a-ac8b-f407cd9bd156" />

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
