### PR TITLE
✨ add support for --all-containers flag to log subcommand

### DIFF
--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -241,6 +241,7 @@ var logsCmd = &cobra.Command{
 
 		withTs := !hideTs
 		withDot := !hideDot
+		allContainers, _ := flags.GetBool("all-containers")
 
 		withNode, _ := flags.GetBool("with-node")
 		withRegion, _ := flags.GetBool("with-region")
@@ -265,6 +266,7 @@ var logsCmd = &cobra.Command{
 			withPod = false
 			withContainer = false
 			withDot = false
+			allContainers = false
 		}
 
 		// Stream mode
@@ -327,6 +329,7 @@ var logsCmd = &cobra.Command{
 			logs.WithOSes(osList),
 			logs.WithArches(archList),
 			logs.WithNodes(nodeList),
+			logs.WithAllContainers(allContainers),
 		}
 
 		switch streamMode {
@@ -654,6 +657,7 @@ func init() {
 
 	flagset.Bool("hide-header", false, "Hide table header")
 	flagset.Bool("hide-dot", false, "Hide the dot indicator in the records")
+	flagset.Bool("all-containers", false, "Show logs from all containers in a Pod")
 
 	//flagset.BoolP("reverse", "r", false, "List records in reverse order")
 

--- a/modules/shared/logs/options.go
+++ b/modules/shared/logs/options.go
@@ -237,3 +237,14 @@ func WithAllowedNamespaces(allowedNamespaces []string) Option {
 		return nil
 	}
 }
+
+func WithAllContainers(allContainers bool) Option {
+	return func(target any) error {
+		switch t := target.(type) {
+		case *sourceWatcher:
+			t.allContainers = allContainers
+		}
+
+		return nil
+	}
+}

--- a/modules/shared/logs/source-watcher_test.go
+++ b/modules/shared/logs/source-watcher_test.go
@@ -397,11 +397,13 @@ func TestParsePath(t *testing.T) {
 	tests := []struct {
 		name           string
 		setPath        string
+		allContainers  bool
 		wantParsedPath parsedPath
 	}{
 		{
 			"<pod-name>",
 			"pod-123",
+			false,
 			parsedPath{
 				Namespace:     defaultNamespace,
 				WorkloadType:  WorkloadTypePod,
@@ -412,6 +414,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<pod-name>/<container-name>",
 			"pod-123/container-1",
+			false,
 			parsedPath{
 				Namespace:     defaultNamespace,
 				WorkloadType:  WorkloadTypePod,
@@ -422,6 +425,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<workload-type>/<workload-name>",
 			"deployments/web",
+			false,
 			parsedPath{
 				Namespace:     defaultNamespace,
 				WorkloadType:  WorkloadTypeDeployment,
@@ -432,6 +436,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<workload-type>/<workload-name>/<container-name>",
 			"deployments/web/container-1",
+			false,
 			parsedPath{
 				Namespace:     defaultNamespace,
 				WorkloadType:  WorkloadTypeDeployment,
@@ -442,6 +447,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<namespace>:<pod-name>",
 			"frontend:pod-123",
+			false,
 			parsedPath{
 				Namespace:     "frontend",
 				WorkloadType:  WorkloadTypePod,
@@ -452,6 +458,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<namespace>:<pod-name>/<container-name>",
 			"frontend:pod-123/container-1",
+			false,
 			parsedPath{
 				Namespace:     "frontend",
 				WorkloadType:  WorkloadTypePod,
@@ -462,6 +469,7 @@ func TestParsePath(t *testing.T) {
 		{
 			"<namespace>:<workload-type>/<workload-name>",
 			"frontend:deployments/web",
+			false,
 			parsedPath{
 				Namespace:     "frontend",
 				WorkloadType:  WorkloadTypeDeployment,
@@ -472,8 +480,31 @@ func TestParsePath(t *testing.T) {
 		{
 			"<namespace>:<workload-type>/<workload-name>/<container-name>",
 			"frontend:deployments/web/container-1",
+			false,
 			parsedPath{
 				Namespace:     "frontend",
+				WorkloadType:  WorkloadTypeDeployment,
+				WorkloadName:  "web",
+				ContainerName: "container-1",
+			},
+		},
+		{
+			"<workload-type>/<workload-name>",
+			"deployments/web",
+			true,
+			parsedPath{
+				Namespace:     defaultNamespace,
+				WorkloadType:  WorkloadTypeDeployment,
+				WorkloadName:  "web",
+				ContainerName: "*",
+			},
+		},
+		{
+			"<workload-type>/<workload-name>/<container-name>",
+			"deployments/web/container-1",
+			true,
+			parsedPath{
+				Namespace:     defaultNamespace,
 				WorkloadType:  WorkloadTypeDeployment,
 				WorkloadName:  "web",
 				ContainerName: "container-1",
@@ -483,7 +514,7 @@ func TestParsePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, err := parsePath(tt.setPath, defaultNamespace)
+			parsed, err := parsePath(tt.setPath, defaultNamespace, tt.allContainers)
 			require.Nil(t, err)
 			assert.Equal(t, tt.wantParsedPath, parsed)
 		})


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #753 

## Summary
Add support for --all-containers to logs subcommand. so when we pass the `--all-containers` flag with the logs command we get logs from all the containers in a Pod.

## Changes
- added a allContainers variable to Sourcewatcher.
- conditional set containerName to "*" if --all-containers is true.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
