### PR TITLE
✨ Sign docker images in workflows

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   deployments: write
+  id-token: write
 
 on:
   push:
@@ -107,6 +108,9 @@ jobs:
       - name: Setup jq
         uses: dcarbone/install-jq-action@v3.2.0
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -156,3 +160,29 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Get image digest
+        id: digest
+        run: |
+          # Pull metadata to get digest for this arch
+          DIGEST=$(docker buildx imagetools inspect kubetail/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Sign Docker Hub image
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            kubetail/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest }}
+
+      - name: Sign GHCR image
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest }}


### PR DESCRIPTION
Fixes #759 

## Summary
Signing the docker images for various environment that require signed docker images.

## Changes
- Added the `cosign-installer` github action to install cosign
- Added another step to finally use the cosign to sign (keyless signing using github OIDC token)

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit