### PR TITLE
🎣  Bug fix for modules/dashboard `param` flag support

### DIFF
--- a/modules/dashboard/cmd/main.go
+++ b/modules/dashboard/cmd/main.go
@@ -67,6 +67,14 @@ func main() {
 			v.BindPFlag("dashboard.addr", cmd.Flags().Lookup("addr"))
 			v.BindPFlag("dashboard.gin-mode", cmd.Flags().Lookup("gin-mode"))
 
+			// Override params from cli
+			for _, param := range params {
+				split := strings.SplitN(param, ":", 2)
+				if len(split) == 2 {
+					v.Set(split[0], split[1])
+				}
+			}
+
 			// Init config
 			cfg, err := config.NewConfig(v, cli.Config)
 			if err != nil {
@@ -75,14 +83,6 @@ func main() {
 
 			// set gin mode
 			gin.SetMode(cfg.Dashboard.GinMode)
-
-			// Override params from cli
-			for _, param := range params {
-				split := strings.SplitN(param, ":", 2)
-				if len(split) == 2 {
-					v.Set(split[0], split[1])
-				}
-			}
 
 			// Configure logger
 			config.ConfigureLogger(config.LoggerOptions{


### PR DESCRIPTION
## Summary

This PR fixes a bug in modules/dashboard which was reading `param` CLI flags after initializing the config.

## Changes

* Moved param parser step before cfg create step

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
