### PR TITLE
🎣 Set launchpad package name to kubetail-cli

### DIFF
--- a/.github/ci-config/launchpad/control
+++ b/.github/ci-config/launchpad/control
@@ -1,4 +1,4 @@
-Source: kubetail
+Source: kubetail-cli
 Section: utils
 Priority: optional
 Maintainer: Andres Morey <andres@kubetail.com>
@@ -11,7 +11,7 @@ Standards-Version: 4.6.2
 Homepage: https://github.com/kubetail-org/kubetail
 Rules-Requires-Root: no
 
-Package: kubetail
+Package: kubetail-cli
 Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Real-time logging dashboard for Kubernetes

--- a/.github/ci-config/launchpad/rules.tmpl
+++ b/.github/ci-config/launchpad/rules.tmpl
@@ -13,7 +13,7 @@ override_dh_auto_build:
 	cd modules/cli && /usr/lib/go-1.24/bin/go build -mod=vendor -buildmode=pie -ldflags="-s -w -X github.com/kubetail-org/kubetail/modules/cli/cmd.version=${VERSION}" -o ../../bin/kubetail main.go
 
 override_dh_auto_install:
-	install -D -m 0755 bin/kubetail debian/kubetail/usr/bin/kubetail
+	install -D -m 0755 bin/kubetail debian/kubetail-cli/usr/bin/kubetail
 
 override_dh_dwz:
 	# Skip dwz compression for Go binaries with compressed debug sections

--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -71,14 +71,14 @@ jobs:
         run: |
           tar -xJf kubetail-cli.orig.tar.xz
           rm -rf kubetail-cli.orig.tar.xz
-          mv kubetail-cli "kubetail-${VERSION}"
-          tar -cJf "kubetail_${VERSION}.orig.tar.xz" "kubetail-${VERSION}"
+          mv kubetail-cli "kubetail-cli-${VERSION}"
+          tar -cJf "kubetail-cli_${VERSION}.orig.tar.xz" "kubetail-cli-${VERSION}"
 
       - name: Create debian directory
         env:
           VERSION: ${{ steps.config.outputs.version }}
           SRC_DIR: kubetail/.github/ci-config/launchpad
-          DST_DIR: work/kubetail-${{ steps.config.outputs.version }}/debian
+          DST_DIR: work/kubetail-cli-${{ steps.config.outputs.version }}/debian
         run: |
           mkdir -p "${DST_DIR}/source"
 
@@ -108,7 +108,7 @@ jobs:
           passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
 
       - name: Build and push packages
-        working-directory: work/kubetail-${{ steps.config.outputs.version }}
+        working-directory: work/kubetail-cli-${{ steps.config.outputs.version }}
         env:
           VERSION: ${{ steps.config.outputs.version }}
           DEBFULLNAME: ${{ vars.KUBETAIL_BOT_NAME}}
@@ -119,7 +119,7 @@ jobs:
             export PKG_VERSION="${VERSION}-1~${SERIES}1"
 
             if [ "${FIRST_SERIES}" = "true" ]; then 
-              DCH_FLAGS="--create --package kubetail"
+              DCH_FLAGS="--create --package kubetail-cli"
               DEBUILD_FLAGS="-sa"
               FIRST_SERIES=false
             else
@@ -131,9 +131,9 @@ jobs:
             debuild ${DEBUILD_FLAGS} -S -k"${{ vars.KUBETAIL_BOT_PGP_FINGERPRINT }}"
 
             if [ "${{ steps.config.outputs.dry_run }}" = "false" ]; then
-              dput ppa:kubetail/kubetail "../kubetail_${PKG_VERSION}_source.changes"
+              dput ppa:kubetail/kubetail "../kubetail-cli_${PKG_VERSION}_source.changes"
             else
               cat debian/changelog
-              cat "../kubetail_${PKG_VERSION}_source.changes"
+              cat "../kubetail-cli_${PKG_VERSION}_source.changes"
             fi
           done


### PR DESCRIPTION
## Summary

This PR sets the launchpad package name to "kubetail-cli".

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
