### PR TITLE
🎣 Fix memoization issue with `isClusterAPIEnabled` in dashboard home page

### DIFF
--- a/dashboard-ui/src/lib/hooks.ts
+++ b/dashboard-ui/src/lib/hooks.ts
@@ -462,7 +462,7 @@ export function useIsClusterAPIEnabled(kubeContext: string | null) {
 
   if (import.meta.env.MODE === 'development') {
     const overrideValue = localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (overrideValue !== null) return JSON.parse(overrideValue);
+    if (overrideValue !== null) return Boolean(JSON.parse(overrideValue));
   }
 
   // Return if running in cluster with ClusterAPI enabled

--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -281,6 +281,8 @@ type DataTableRowProps = {
   row: Row<WorkloadTableData>;
   // eslint-disable-next-line react/no-unused-prop-types
   isChecked: boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  isClusterAPIEnabled: boolean;
 };
 
 const DataTableRow = (props: DataTableRowProps) => {
@@ -301,7 +303,9 @@ const DataTableRow = (props: DataTableRowProps) => {
 const MemoizedDataTableRow = memo(
   DataTableRow,
   (prevProps, nextProps) =>
-    prevProps.row.original.id === nextProps.row.original.id && prevProps.isChecked === nextProps.isChecked,
+    prevProps.row.original.id === nextProps.row.original.id &&
+    prevProps.isChecked === nextProps.isChecked &&
+    prevProps.isClusterAPIEnabled === nextProps.isClusterAPIEnabled,
 );
 
 MemoizedDataTableRow.displayName = 'MemoizedDataTableRow';
@@ -312,7 +316,7 @@ type DisplayWorkloadItemsProps = {
 
 const DisplayWorkloadItems = memo(({ kind }: DisplayWorkloadItemsProps) => {
   const { kubeContext, workloadKindFilter } = useContext(Context);
-  const isClusterAPIEnabled = useIsClusterAPIEnabled(kubeContext);
+  const isClusterAPIEnabled = Boolean(useIsClusterAPIEnabled(kubeContext));
 
   const isFetching = useAtomValue(workloadIsFetchingAtomFamilies[kind](kubeContext));
   const items = useAtomValue(filteredWorkloadItemsAtomFamilies[kind](kubeContext));
@@ -478,6 +482,7 @@ const DisplayWorkloadItems = memo(({ kind }: DisplayWorkloadItemsProps) => {
                 key={row.original.id}
                 row={row}
                 isChecked={isChecked.get(row.original.id) ?? false}
+                isClusterAPIEnabled={isClusterAPIEnabled}
               />
             ))}
           </>


### PR DESCRIPTION
Fixes #791  

## Summary

This PR fixes a memoization issue with the dashboard home page where the log metadata columns are still appearing even when the ClusterAPI isn't available.

## Changes

* Added `isClusterAPIEnabled` to the component props and added a memoization check

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
