### PR TITLE
🎣 Set trigger ref to main in publish-nix workflow

### DIFF
--- a/.github/workflows/publish-nix.yml
+++ b/.github/workflows/publish-nix.yml
@@ -52,5 +52,6 @@ jobs:
         with:
           repo: kubetail-org/kubetail-nix
           workflow: release
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
           inputs: '{ "version": "${{ steps.config.outputs.version }}", "dry_run": ${{ steps.config.outputs.dry_run }} }'


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `publish-nix` workflow that was triggering the workflow in the `kubetail-org/kubetail-nix` repo with the same ref as the workflow in this repo. Now the ref is set to `main`.

## Changes

* Set `ref: main` in workflow trigger action in `publish-nix` workflow

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
