### PR TITLE
✨ Update macports portfile and switch to real upstream

### DIFF
--- a/.github/ci-config/macports/Portfile.tmpl
+++ b/.github/ci-config/macports/Portfile.tmpl
@@ -33,7 +33,7 @@ build.env-append GO111MODULE=on \
 build.dir ${worksrcpath}/modules/cli
 build.args-append \
     -mod=vendor \
-    -ldflags \"-s -w -X github.com/kubetail-org/kubetail/modules/cli/cmd.version=${version}\" \
+    -ldflags \"-s -w -X ${go.package}/modules/cli/cmd.version=${version}\" \
     -o ../../bin/kubetail
 
 destroot {

--- a/.github/workflows/publish-macports.yml
+++ b/.github/workflows/publish-macports.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     env:
-      UPSTREAM_REPO: kubetail-org/macports-ports
+      UPSTREAM_REPO: macports/macports-ports
       FORK_REPO: kubetail-org/macports-ports
     steps:
       - name: Config


### PR DESCRIPTION
## Summary

This PR updates the macports Portfile template to match the latest upstream version and sets the upstream repo to macports/macports-ports in the publish-macports workflow.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
