### PR TITLE
🎣 Fix stream cancellation spillover bug

### DIFF
--- a/crates/rgkl/src/util/matcher.rs
+++ b/crates/rgkl/src/util/matcher.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use grep::{
-    matcher::{self, Match, Matcher},
-    regex::{self, RegexMatcher, RegexMatcherBuilder},
-};
+use grep::matcher::{self, Match, Matcher};
+use grep::regex::{self, RegexMatcher, RegexMatcherBuilder};
 use memchr::memmem;
 use serde::Deserialize;
 

--- a/crates/rgkl/src/util/offset.rs
+++ b/crates/rgkl/src/util/offset.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    fs::File,
-    io::{BufRead, BufReader, Result as IoResult, Seek, SeekFrom},
-};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Result as IoResult, Seek, SeekFrom};
 
 use chrono::{DateTime, Utc};
 use serde_json;


### PR DESCRIPTION
Fixes #800 

## Summary

This PR implements termination signal propagation in the `cluster-agent` using `CancellationToken`'s instead of broadcast signals. The problem with broadcast signals is that by default they bubble up as well as trickle down and this was causing a bug in search streaming where a normal client cancellation in one task was triggering cancellation in all tasks. `CancellationToken`'s allow you to scope signals easily using child tokens so now each streaming task gets its own child token so they still listen for termination signals from the parent but signals originating in the task itself don't affect other tasks.
 
## Changes

* Switches to use of `CancellationToken`'s to propagate termination signals
* Adds lifecycle event hooks to `stream_forward` function to improve testability
* Refactors `stream_forward` tests to use lifecycle hooks
* Adds lifecycle event hooks to `log_metadata_watcher` struct to improve testability
* Refactors `log_metadata_watcher` tests to use lifecycle hooks
* Readability improvements to import statements

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
