### PR TITLE
🐋 Add Docker image support for CLI component

### DIFF
--- a/.github/workflows/release-docker-cli.yml
+++ b/.github/workflows/release-docker-cli.yml
@@ -1,0 +1,293 @@
+name: release-docker-cli
+
+permissions:
+  contents: read
+  packages: write
+  deployments: write
+  id-token: write
+
+on:
+  push:
+    tags:
+      - "cli/v*"
+  workflow_dispatch:
+    inputs:
+      git_tag:
+        description: "Git tag"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  config:
+    name: Configure workflow
+    runs-on: ubuntu-24.04
+    outputs:
+      git_tag: ${{ steps.config.outputs.git_tag }}
+      component: ${{ steps.config.outputs.component }}
+      image_name: ${{ steps.config.outputs.image_name }}
+      image_tag: ${{ steps.config.outputs.image_tag }}
+      dry_run: ${{ steps.config.outputs.dry_run }}
+    steps:
+      - id: config
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            GIT_TAG="${{ github.event.inputs.git_tag }}"
+            DRY_RUN="${{ github.event.inputs.dry_run }}"
+          else
+            GIT_TAG="${GITHUB_REF#refs/tags/}"
+            DRY_RUN=false
+          fi
+
+          COMPONENT=${GIT_TAG%%/*}
+          IMAGE_TAG=${GIT_TAG#*/v}
+
+          echo "git_tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          echo "component=$COMPONENT" >> $GITHUB_OUTPUT
+          echo "image_name=kubetail-$COMPONENT" >> $GITHUB_OUTPUT
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
+
+  build-and-publish:
+    needs: [config]
+    environment: production
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.config.outputs.git_tag }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (busybox)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/package/Dockerfile.${{ needs.config.outputs.component }}
+          push: ${{ needs.config.outputs.dry_run == 'false' }}
+          target: final-busybox
+          build-args: |
+            VERSION=${{ needs.config.outputs.image_tag }}
+          tags: |
+            kubetail/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}-${{ matrix.arch }}
+
+      - name: Build and push (alpine)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/package/Dockerfile.${{ needs.config.outputs.component }}
+          push: ${{ needs.config.outputs.dry_run == 'false' }}
+          target: final-alpine
+          build-args: |
+            VERSION=${{ needs.config.outputs.image_tag }}
+          tags: |
+            kubetail/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}-${{ matrix.arch }}-alpine
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}-${{ matrix.arch }}-alpine
+
+  create-and-publish-manifest:
+    environment: production
+    runs-on: ubuntu-24.04
+    needs: [config, build-and-publish]
+    steps:
+      - name: Setup jq
+        uses: dcarbone/install-jq-action@v3.2.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifests (busybox)
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        env:
+          IMAGE_NAME: ${{ needs.config.outputs.image_name }}
+          IMAGE_TAG: ${{ needs.config.outputs.image_tag }}
+        run: |
+          # Create versioned manifest (busybox)
+          docker buildx imagetools create -t kubetail/$IMAGE_NAME:$IMAGE_TAG \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-amd64 \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-amd64 \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-arm64
+
+          # Create latest manifest (busybox)
+          docker buildx imagetools create -t kubetail/$IMAGE_NAME:latest \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-amd64 \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-amd64 \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-arm64
+
+      - name: Create and push manifests (alpine)
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        env:
+          IMAGE_NAME: ${{ needs.config.outputs.image_name }}
+          IMAGE_TAG: ${{ needs.config.outputs.image_tag }}
+        run: |
+          # Create versioned alpine manifest
+          docker buildx imagetools create -t kubetail/$IMAGE_NAME:$IMAGE_TAG-alpine \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-amd64-alpine \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-arm64-alpine
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-alpine \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-amd64-alpine \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-arm64-alpine
+
+          # Create latest-alpine manifest
+          docker buildx imagetools create -t kubetail/$IMAGE_NAME:latest-alpine \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-amd64-alpine \
+            kubetail/$IMAGE_NAME:$IMAGE_TAG-arm64-alpine
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest-alpine \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-amd64-alpine \
+            ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG-arm64-alpine
+
+      - name: Fetch docker token
+        run: |
+          TOKEN=$(curl -X POST "https://hub.docker.com/v2/users/login" -H "Content-Type: application/json" -d '{"username": "${{ vars.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' | jq -r '.token')
+          echo "TOKEN=$TOKEN" >> $GITHUB_ENV
+
+      - name: Delete extra arch manifests
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          declare -a tags=("${{ needs.config.outputs.image_tag }}-amd64" "${{ needs.config.outputs.image_tag }}-arm64" "${{ needs.config.outputs.image_tag }}-amd64-alpine" "${{ needs.config.outputs.image_tag }}-arm64-alpine")
+          for tag in "${tags[@]}"
+          do
+            RESPONSE=$(curl -s -w "%{http_code}" \
+              -X DELETE \
+              -H "Authorization: Bearer $TOKEN" \
+              "https://hub.docker.com/v2/repositories/kubetail/${{ needs.config.outputs.image_name }}/tags/$tag")
+            if [ "$RESPONSE" -ne 204 ]; then
+              echo "DELETE for $tag failed with status $RESPONSE"
+              exit 1
+            fi
+          done
+
+      - name: Get image digests
+        id: digest
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          # Get busybox digest
+          DIGEST_BUSYBOX=$(docker buildx imagetools inspect kubetail/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest_busybox=$DIGEST_BUSYBOX" >> $GITHUB_OUTPUT
+
+          # Get latest digest
+          DIGEST_LATEST=$(docker buildx imagetools inspect kubetail/${{ needs.config.outputs.image_name }}:latest \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest_latest=$DIGEST_LATEST" >> $GITHUB_OUTPUT
+
+          # Get alpine digest
+          DIGEST_ALPINE=$(docker buildx imagetools inspect kubetail/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}-alpine \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest_alpine=$DIGEST_ALPINE" >> $GITHUB_OUTPUT
+
+          # Get latest-alpine digest
+          DIGEST_LATEST_ALPINE=$(docker buildx imagetools inspect kubetail/${{ needs.config.outputs.image_name }}:latest-alpine \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest_latest_alpine=$DIGEST_LATEST_ALPINE" >> $GITHUB_OUTPUT
+
+      - name: Sign Docker Hub images
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          # Sign busybox variant
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            kubetail/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_busybox }}
+
+          # Sign latest
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            kubetail/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_latest }}
+
+          # Sign alpine variant
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            kubetail/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_alpine }}
+
+          # Sign latest-alpine
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            kubetail/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_latest_alpine }}
+
+      - name: Sign GHCR images
+        if: ${{ needs.config.outputs.dry_run == 'false' }}
+        run: |
+          # Sign busybox variant
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_busybox }}
+
+          # Sign latest
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_latest }}
+
+          # Sign alpine variant
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_alpine }}
+
+          # Sign latest-alpine
+          cosign sign \
+            --yes \
+            -r \
+            --upload=${{needs.config.outputs.dry_run == 'false'}} \
+            ghcr.io/${{ github.repository_owner }}/${{ needs.config.outputs.image_name }}@${{ steps.digest.outputs.digest_latest_alpine }}

--- a/build/package/Dockerfile.cli
+++ b/build/package/Dockerfile.cli
@@ -1,0 +1,97 @@
+# Copyright 2024-2025 Andres Morey
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------
+
+FROM node:22.16.0-alpine3.21 AS frontend-builder
+WORKDIR /dashboard-ui
+
+# enable pnpm
+RUN corepack enable
+RUN corepack prepare pnpm@10.11.0 --activate
+
+# fetch dependencies
+COPY dashboard-ui/package.json ./
+COPY dashboard-ui/pnpm-lock.yaml ./
+RUN pnpm install
+
+# copy code
+COPY dashboard-ui/ .
+
+# build
+RUN pnpm build
+
+ENTRYPOINT []
+CMD []
+
+# -----------------------------------------------------------
+
+FROM golang:1.24.5 AS builder
+
+ARG VERSION=dev
+
+WORKDIR /work
+
+# install dependencies (for cache)
+COPY modules/shared/go.mod ./shared/go.mod
+COPY modules/shared/go.sum ./shared/go.sum
+COPY modules/dashboard/go.mod ./dashboard/go.mod
+COPY modules/dashboard/go.sum ./dashboard/go.sum
+COPY modules/cli/go.mod ./cli/go.mod
+COPY modules/cli/go.sum ./cli/go.sum
+RUN cd cli && go mod download all
+
+# copy code
+COPY modules/shared ./shared
+COPY modules/dashboard ./dashboard
+COPY modules/cli ./cli
+
+# copy frontend
+COPY --from=frontend-builder /dashboard-ui/dist ./dashboard/website
+
+# build cli
+RUN cd cli && CGO_ENABLED=0 go build -ldflags="-s -w -X 'github.com/kubetail-org/kubetail/modules/cli/cmd.version=${VERSION}'" -o ../bin/kubetail .
+
+ENTRYPOINT ["./bin/kubetail"]
+CMD []
+
+# -----------------------------------------------------------
+
+FROM busybox:1.37.0 AS final-busybox
+
+WORKDIR /usr/local/bin
+
+# copy certs for tls verification
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# copy kubetail binary
+COPY --from=builder /work/bin/kubetail /usr/local/bin/kubetail
+
+ENTRYPOINT ["kubetail"]
+CMD []
+
+# -----------------------------------------------------------
+
+FROM alpine:3.22.0 AS final-alpine
+
+WORKDIR /usr/local/bin
+
+# copy certs for tls verification
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# copy kubetail binary
+COPY --from=builder /work/bin/kubetail /usr/local/bin/kubetail
+
+ENTRYPOINT ["kubetail"]
+CMD []


### PR DESCRIPTION
Fixes #789

## Summary

This PR adds Docker image publishing support for the kubetail CLI tool with two base image variants (busybox and alpine). Images will be published to both Docker Hub and GHCR with cosign signing.

## Changes

- **New: Dockerfile.cli** - Multi-stage Dockerfile with frontend builder, Go builder, and two final stages (busybox and alpine variants)
  - Static binary compilation with `CGO_ENABLED=0` for portability
  - Embeds dashboard frontend for `kubetail serve` command

- **New: .github/workflows/release-docker-cli.yml** - Dedicated release workflow for CLI component
  - Triggers on `cli/v*` tags
  - Builds both busybox (default) and alpine variants in parallel
  - Creates four manifest tags: `VERSION`, `latest`, `VERSION-alpine`, `latest-alpine`
  - Signs all four variants to both Docker Hub and GHCR with cosign
  - Separate workflow keeps logic simple and avoids conditionals in main release-docker.yml

## Usage

```bash
# Busybox variant (default)
docker run -v ~/.kube:/root/.kube:ro kubetail/kubetail:latest logs <pod-name>

# Alpine variant
docker run -v ~/.kube:/root/.kube:ro kubetail/kubetail:latest-alpine logs <pod-name>
```

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]