### PR TITLE
✨ Add docker-builds CI tests for CLI component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,14 @@ jobs:
             image: cluster-agent
             target: final
             dockerfile: build/package/Dockerfile.cluster-agent
+          - name: cli-busybox
+            image: cli
+            target: final-busybox
+            dockerfile: build/package/Dockerfile.cli
+          - name: cli-alpine
+            image: cli
+            target: final-alpine
+            dockerfile: build/package/Dockerfile.cli
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
           - runner: ubuntu-24.04


### PR DESCRIPTION
Fixes #809

## Summary

Following the merge of #806, which added Docker image support for the kubetail CLI, this PR adds build tests to the CI workflow to ensure the new Dockerfiles continue to build successfully across all supported architectures.

## Changes

- **Updated `.github/workflows/ci.yml`** - Added two new build configurations to the `docker-builds` job matrix:
  - `cli-busybox` - Tests the `final-busybox` target from `Dockerfile.cli`
  - `cli-alpine` - Tests the `final-alpine` target from `Dockerfile.cli`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]