### PR TITLE
🎣 Improve error message when kubeconfig is missing

### DIFF
--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -15,6 +15,8 @@
 package k8shelpers
 
 import (
+	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -53,6 +55,9 @@ func NewKubeConfigWatcher(kubeconfigPath string) (*KubeConfigWatcher, error) {
 		err = watcher.Add(pathname)
 		if err != nil {
 			watcher.Close()
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("kubeconfig file not found at '%s'.\n\nPlease ensure the file exists or use the '--kubeconfig' flag to specify a custom path.\nIf you are running inside a cluster, use the '--in-cluster' flag", pathname)
+			}
 			return nil, err
 		}
 	}

--- a/modules/shared/k8shelpers/kube-config-watcher_test.go
+++ b/modules/shared/k8shelpers/kube-config-watcher_test.go
@@ -206,3 +206,24 @@ func TestKubeConfigWatcherSubscribeModified(t *testing.T) {
 
 	assert.Equal(t, cfg1.CurrentContext, cfgActual.CurrentContext)
 }
+
+func TestKubeConfigWatcher_FileNotFound(t *testing.T) {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "kube-config-watcher-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after test
+
+	// Define non-existent path
+	nonExistentPath := filepath.Join(tempDir, "non-existent-config")
+
+	// Initialize watcher
+	_, err = NewKubeConfigWatcher(nonExistentPath)
+
+	// Assert error
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("kubeconfig file not found at '%s'", nonExistentPath))
+	assert.Contains(t, err.Error(), "use the '--kubeconfig' flag")
+	assert.Contains(t, err.Error(), "use the '--in-cluster' flag")
+}


### PR DESCRIPTION
Fixes #808

## Summary

This PR improves the error message displayed when the kubeconfig file is missing. Instead of a generic "no such file or directory" error, it now provides a helpful message guiding the user to check the file path, use the `--kubeconfig` flag, or use the `--in-cluster` flag if running inside a cluster (referencing the recently added feature in #819).

## Changes

- Updated `NewKubeConfigWatcher` in `modules/shared/k8shelpers/kube-config-watcher.go` to catch `os.IsNotExist` errors.
- Added a user-friendly error message suggesting potential solutions.
- Added a unit test `TestKubeConfigWatcher_FileNotFound` in `modules/shared/k8shelpers/kube-config-watcher_test.go` to verify the error message.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
