### PR TITLE
🐋 Add default 16 KB cut-off for log messages from k8s api

### DIFF
--- a/modules/shared/logs/helpers.go
+++ b/modules/shared/logs/helpers.go
@@ -15,11 +15,14 @@
 package logs
 
 import (
+	"bufio"
+	"bytes"
 	"container/heap"
 	"context"
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -137,24 +140,86 @@ func parseWorkloadType(workloadStr string) WorkloadType {
 	}
 }
 
-// Create new log record
-func newLogRecordFromLogLine(logLine string) (LogRecord, error) {
+var bufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+func nextRecordFromReader(reader *bufio.Reader, truncateAtBytes int) (LogRecord, error) {
 	var zero LogRecord
 
-	parts := strings.SplitN(logLine, " ", 2)
-	if len(parts) != 2 {
-		return zero, fmt.Errorf("log line timestamp not found")
+	// Fetch timestamp
+	tsBytes, err := reader.ReadSlice(' ')
+	if err != nil {
+		return zero, err
 	}
+	tsBytes = tsBytes[:len(tsBytes)-1]
 
-	ts, err := time.Parse(time.RFC3339Nano, parts[0])
+	// Parse timestamp
+	ts, err := time.Parse(time.RFC3339Nano, string(tsBytes))
 	if err != nil {
 		return zero, err
 	}
 
-	return LogRecord{
-		Timestamp: ts,
-		Message:   parts[1],
-	}, nil
+	// Read the rest of the bytes until '\n' delimiter or truncateAtBytes whichever comes first
+	var isTruncated bool
+	var origSizeBytes int
+
+	// Get buffer from pool
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufferPool.Put(buf)
+
+	// Pre-allocate if we know we need space, but be conservative
+	// If the buffer from the pool already has capacity, we don't need to do anything
+	if buf.Cap() < 128 {
+		buf.Grow(128)
+	}
+
+Loop:
+	for {
+		chunk, isPrefix, err := reader.ReadLine()
+		switch err {
+		case nil, bufio.ErrBufferFull:
+			// Do nothing
+		case io.EOF:
+			// Exit loop
+			break Loop
+		default:
+			// Unexpected error
+			return zero, err
+		}
+
+		origSizeBytes += len(chunk)
+
+		if truncateAtBytes == 0 {
+			// Disable truncation
+			buf.Write(chunk)
+		} else if !isTruncated {
+			// Append as much as we can
+			remaining := max(truncateAtBytes-buf.Len(), 0)
+			writeLen := min(remaining, len(chunk))
+			buf.Write(chunk[:writeLen])
+
+			// Update isTruncated for next loop
+			isTruncated = origSizeBytes > truncateAtBytes
+		}
+
+		// Exit when no longer chunking
+		if !isPrefix {
+			break
+		}
+	}
+
+	// Initialize record
+	record := LogRecord{}
+	record.Timestamp = ts
+	record.Message = buf.String()
+	record.OriginalSizeBytes = origSizeBytes
+	record.IsTruncated = isTruncated
+
+	return record, nil
 }
 
 // mergeLogStreams merges multiple ordered log streams into a single channel

--- a/modules/shared/logs/helpers_test.go
+++ b/modules/shared/logs/helpers_test.go
@@ -15,12 +15,16 @@
 package logs
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // RoundTripperFunc type is an adapter to allow the use of ordinary functions as http.RoundTripper.
@@ -29,6 +33,89 @@ type RoundTripperFunc func(*http.Request) (*http.Response, error)
 // RoundTrip calls f(r).
 func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+func TestNextRecordFromReader(t *testing.T) {
+	tests := []struct {
+		name               string
+		setLine            string
+		setTruncateAtBytes int
+		setBufSize         int
+		wantTimestamp      time.Time
+		wantMessage        string
+		wantOrigSize       int
+		wantTruncated      bool
+		wantErr            error
+	}{
+		{
+			name:               "parses valid record",
+			setLine:            "2025-03-13T11:36:09.123456789Z hello world\n",
+			setTruncateAtBytes: 0,
+			wantTimestamp:      time.Date(2025, 3, 13, 11, 36, 9, 123456789, time.UTC),
+			wantMessage:        "hello world",
+			wantOrigSize:       len("hello world"),
+			wantTruncated:      false,
+			wantErr:            nil,
+		},
+		{
+			name:               "truncates long message",
+			setLine:            "2024-01-01T00:00:00Z 0123456789ABCDEFGHIJ\n",
+			setTruncateAtBytes: 10,
+			wantTimestamp:      time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantMessage:        "0123456789",
+			wantOrigSize:       len("0123456789ABCDEFGHIJ"),
+			wantTruncated:      true,
+			wantErr:            nil,
+		},
+		{
+			name:               "handles chunked lines",
+			setLine:            "2024-06-15T12:00:00Z " + strings.Repeat("x", 200) + "\n",
+			setTruncateAtBytes: 0,
+			setBufSize:         30, // force multiple ReadLine chunks
+			wantTimestamp:      time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC),
+			wantMessage:        strings.Repeat("x", 200),
+			wantOrigSize:       200,
+			wantTruncated:      false,
+			wantErr:            nil,
+		},
+		{
+			name:    "returns proper error at EOF",
+			setLine: "",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "invalid timestamp",
+			setLine: "not-a-timestamp message body\n",
+			wantErr: &time.ParseError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := func() *bufio.Reader {
+				if tt.setBufSize > 0 {
+					return bufio.NewReaderSize(strings.NewReader(tt.setLine), tt.setBufSize)
+				}
+				return bufio.NewReader(strings.NewReader(tt.setLine))
+			}()
+
+			record, err := nextRecordFromReader(reader, tt.setTruncateAtBytes)
+			if tt.wantErr != nil {
+				if tt.wantErr == io.EOF {
+					assert.ErrorIs(t, tt.wantErr, err)
+				} else if tt.wantErr != nil {
+					assert.ErrorAs(t, tt.wantErr, &err)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTimestamp, record.Timestamp)
+			assert.Equal(t, tt.wantMessage, record.Message)
+			assert.Equal(t, tt.wantOrigSize, record.OriginalSizeBytes)
+			assert.Equal(t, tt.wantTruncated, record.IsTruncated)
+		})
+	}
 }
 
 func TestMergeLogStreams(t *testing.T) {
@@ -261,65 +348,6 @@ func TestMergeLogStreamsContextCancellation(t *testing.T) {
 	// Verify channel is closed
 	_, ok := <-merged
 	assert.False(t, ok, "channel should be closed after context cancellation")
-}
-
-func TestNewLogRecordFromLogLine(t *testing.T) {
-	tests := []struct {
-		name        string
-		logLine     string
-		wantTime    time.Time
-		wantMessage string
-		wantErr     bool
-	}{
-		{
-			name:        "valid log line",
-			logLine:     "2025-03-13T11:36:09.123456789Z Hello world",
-			wantTime:    time.Date(2025, 3, 13, 11, 36, 9, 123456789, time.UTC),
-			wantMessage: "Hello world",
-			wantErr:     false,
-		},
-		{
-			name:        "valid log line with multiple spaces in message",
-			logLine:     "2025-03-13T11:36:09.123456789Z   Multiple   spaces   here   ",
-			wantTime:    time.Date(2025, 3, 13, 11, 36, 9, 123456789, time.UTC),
-			wantMessage: "  Multiple   spaces   here   ",
-			wantErr:     false,
-		},
-		{
-			name:    "missing timestamp",
-			logLine: "Hello world",
-			wantErr: true,
-		},
-		{
-			name:    "invalid timestamp format",
-			logLine: "2025-03-13 11:36:09 Hello world",
-			wantErr: true,
-		},
-		{
-			name:    "empty string",
-			logLine: "",
-			wantErr: true,
-		},
-		{
-			name:    "only timestamp",
-			logLine: "2025-03-13T11:36:09.123456789Z",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := newLogRecordFromLogLine(tt.logLine)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.wantTime, got.Timestamp, "timestamps should match")
-			assert.Equal(t, tt.wantMessage, got.Message, "messages should match")
-		})
-	}
 }
 
 func TestParseWorkloadType(t *testing.T) {

--- a/modules/shared/logs/options.go
+++ b/modules/shared/logs/options.go
@@ -238,6 +238,7 @@ func WithAllowedNamespaces(allowedNamespaces []string) Option {
 	}
 }
 
+// WithAllContainers adds all containers to stream
 func WithAllContainers(allContainers bool) Option {
 	return func(target any) error {
 		switch t := target.(type) {
@@ -245,6 +246,18 @@ func WithAllContainers(allContainers bool) Option {
 			t.allContainers = allContainers
 		}
 
+		return nil
+	}
+}
+
+// WithTruncateAtBytes sets the maximum number of bytes
+// to read for log messages
+func WithTruncateAtBytes(n int) Option {
+	return func(target any) error {
+		switch t := target.(type) {
+		case *Stream:
+			t.truncateAtBytes = n
+		}
 		return nil
 	}
 }

--- a/modules/shared/logs/stream.go
+++ b/modules/shared/logs/stream.go
@@ -27,12 +27,16 @@ import (
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
+const DEFAULT_TRUNCATE_AT_BYTES = 16 * 1024 // 16 KB
+
 // LogRecord represents a log record
 type LogRecord struct {
-	Timestamp time.Time
-	Message   string
-	Source    LogSource
-	err       error // for use internally
+	Timestamp         time.Time
+	Message           string
+	Source            LogSource
+	OriginalSizeBytes int
+	IsTruncated       bool
+	err               error // for use internally
 }
 
 // streamMode enum type
@@ -62,6 +66,8 @@ type Stream struct {
 	maxNum  int64
 	sources set.Set[LogSource]
 
+	truncateAtBytes int
+
 	kubeContext string
 	sw          SourceWatcher
 	logFetcher  LogFetcher
@@ -86,12 +92,13 @@ func NewStream(ctx context.Context, cm k8shelpers.ConnectionManager, sourcePaths
 
 	// Init stream instance
 	stream := &Stream{
-		rootCtx:       rootCtx,
-		rootCtxCancel: rootCtxCancel,
-		sources:       set.NewSet[LogSource](),
-		pastCh:        make(chan LogRecord),
-		futureCh:      make(chan LogRecord),
-		outCh:         make(chan LogRecord),
+		rootCtx:         rootCtx,
+		rootCtxCancel:   rootCtxCancel,
+		sources:         set.NewSet[LogSource](),
+		truncateAtBytes: DEFAULT_TRUNCATE_AT_BYTES,
+		pastCh:          make(chan LogRecord),
+		futureCh:        make(chan LogRecord),
+		outCh:           make(chan LogRecord),
 	}
 
 	// Apply options
@@ -231,9 +238,10 @@ func (s *Stream) handleSourceAdd(source LogSource) {
 
 	// Stream from beginning and keep following
 	opts := FetcherOptions{
-		Grep:       s.grep,
-		GrepRegex:  s.grepRegex,
-		FollowFrom: FollowFromDefault,
+		Grep:            s.grep,
+		GrepRegex:       s.grepRegex,
+		FollowFrom:      FollowFromDefault,
+		TruncateAtBytes: s.truncateAtBytes,
 	}
 
 	stream, err := s.logFetcher.StreamForward(s.rootCtx, source, opts)
@@ -297,10 +305,11 @@ func (s *Stream) startHead_UNSAFE() error {
 	ctx, cancel := context.WithCancel(s.rootCtx)
 
 	opts := FetcherOptions{
-		StartTime: s.sinceTime,
-		StopTime:  s.untilTime,
-		Grep:      s.grep,
-		GrepRegex: s.grepRegex,
+		StartTime:       s.sinceTime,
+		StopTime:        s.untilTime,
+		Grep:            s.grep,
+		GrepRegex:       s.grepRegex,
+		TruncateAtBytes: s.truncateAtBytes,
 	}
 
 	streams := make([]<-chan LogRecord, s.sources.Cardinality())
@@ -357,11 +366,12 @@ func (s *Stream) startTail_UNSAFE() error {
 	}
 
 	opts := FetcherOptions{
-		StartTime:     s.sinceTime,
-		StopTime:      s.untilTime,
-		Grep:          s.grep,
-		GrepRegex:     s.grepRegex,
-		BatchSizeHint: batchSize,
+		StartTime:       s.sinceTime,
+		StopTime:        s.untilTime,
+		Grep:            s.grep,
+		GrepRegex:       s.grepRegex,
+		BatchSizeHint:   batchSize,
+		TruncateAtBytes: s.truncateAtBytes,
 	}
 
 	streams := make([]<-chan LogRecord, s.sources.Cardinality())
@@ -418,10 +428,11 @@ func (s *Stream) startFollow_UNSAFE() error {
 	var wg sync.WaitGroup
 
 	opts := FetcherOptions{
-		StopTime:   s.untilTime,
-		Grep:       s.grep,
-		GrepRegex:  s.grepRegex,
-		FollowFrom: FollowFromEnd,
+		StopTime:        s.untilTime,
+		Grep:            s.grep,
+		GrepRegex:       s.grepRegex,
+		FollowFrom:      FollowFromEnd,
+		TruncateAtBytes: s.truncateAtBytes,
 	}
 
 	for _, source := range s.sources.ToSlice() {


### PR DESCRIPTION
Fixes #779 

## Summary

Although Kubernetes splits up long log messages into 16 KB chunks, the Kubernetes podLogs API will concatenate partial messages into one long message so it's possible to get arbitrarily long messages when retrieving logs from the API. This presents a problem for us because currently we read full messages into memory before sending them to the client. More immediately, we've seen users run into the current 1MB buffer limit when consuming data from podLogs. To solve this problem and prevent buffer errors, this PR adds a default cut-off at 16 KB per-message which essentially only shows the first chunk of a long message. This PR also puts in place machinery to make the cut-off configurable and also to send back original size information to the client which we will use in subsequent PRs to make the feature more user-friendly.

## Changes

* Replaces `bufio.Scanner()` with `bufio.Reader()` for lower-level access in `modules/shared/logs`
* Implements internally-configurable `TruncateAtBytes` functionality
* Sets default `TruncateAtBytes` value to 16 KB

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
