### PR TITLE
✨ Add GPG signing to release SHA256SUMS file

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -336,6 +336,7 @@ jobs:
   release:
     name: Create GitHub release
     needs: [config, package-tarball]
+    environment: production
     runs-on: ubuntu-24.04
     steps:
       - name: Download binaries
@@ -362,11 +363,23 @@ jobs:
         run: |
           sha256sum * > SHA256SUMS
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.KUBETAIL_BOT_PGP_SIGNING_KEY }}
+          passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
+
+      - name: Sign SHA256SUMS with GPG
+        working-directory: ./assets
+        run: |
+          gpg --armor --detach-sign SHA256SUMS
+
       - name: Debug
         if: ${{ needs.config.outputs.dry_run == 'true' }}
         run: |
           ls -lah assets/*
           cat assets/SHA256SUMS
+          cat assets/SHA256SUMS.asc
 
       - name: Create release
         uses: softprops/action-gh-release@v2.3.2


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #797 

## Summary
Add GPG signing to the SHA256SUMS file published with each GitHub release. This lets users verify release authenticity and detect tampering.

## Changes
- Added environment: production to the release job to access GPG secrets.
- Added a step to import the GPG key using `crazy-max/ghaction-import-gpg@v6.3.0` with existing secrets(KUBETAIL_BOT_PGP_SIGNING_KEY and KUBETAIL_BOT_PGP_PASSWORD)`.
- Added a step to sign SHA256SUMS with GPG, generating `SHA256SUMS.asc` (detached signature in ASCII format).
- Updated the debug step to also display the contents of `SHA256SUMS.asc` during dry runs.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
