### PR TITLE
🐋 Set default dashboard environment to "cluster" and upgrade pnpm

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -92,7 +92,7 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.15"
   },
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
+  "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501",
   "pnpm": {
     "minimumReleaseAge": 14400,
     "onlyBuiltDependencies": [

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -13,7 +13,6 @@ data:
       auth-mode: auto
       base-path: /
       cluster-api-endpoint: http://kubetail-cluster-api.kubetail-system.svc:8080
-      environment: cluster
       gin-mode: debug
       ui:
         cluster-api-enabled: true

--- a/modules/dashboard/hack/config.yaml
+++ b/modules/dashboard/hack/config.yaml
@@ -3,6 +3,7 @@ dashboard:
   addr: :4000
   base-path: /
   gin-mode: debug
+  environment: desktop
   logging:
     format: pretty
   session:

--- a/modules/shared/config/config.go
+++ b/modules/shared/config/config.go
@@ -240,7 +240,7 @@ func DefaultConfig() *Config {
 	cfg.Dashboard.AuthMode = AuthModeAuto
 	cfg.Dashboard.BasePath = "/"
 	cfg.Dashboard.ClusterAPIEndpoint = ""
-	cfg.Dashboard.Environment = EnvironmentDesktop
+	cfg.Dashboard.Environment = EnvironmentCluster
 	cfg.Dashboard.GinMode = "release"
 	cfg.Dashboard.CSRF.Enabled = true
 	cfg.Dashboard.Logging.Enabled = true


### PR DESCRIPTION
## Summary

This PR sets the dashboard environment to "cluster" which should make it easier to run the dashboard in a docker container without extra config. It also upgrades the pnpm dependency.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
