### PR TITLE
🎣  Disable Apollo v4 query deduplication and other bug fixes

### DIFF
--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -34,6 +34,7 @@ const basename = getBasename();
 
 const wsClientOptions: ClientOptions = {
   url: '',
+  lazy: true,
   connectionAckWaitTimeout: 3000,
   keepAlive: 3000,
   retryAttempts: Infinity,
@@ -199,6 +200,7 @@ const { link: dashboardLink, wsClient: dashboardWSClient } = createLink(basename
 export const dashboardClient = new ApolloClient({
   cache: new DashboardCustomCache(),
   link: dashboardLink,
+  queryDeduplication: false,
 });
 
 export { dashboardWSClient };
@@ -253,6 +255,7 @@ export const getClusterAPIClient = (context: ClusterAPIContext) => {
     client = new ApolloClient({
       cache: new ClusterAPICustomCache(),
       link,
+      queryDeduplication: false,
     });
 
     // Add to cache


### PR DESCRIPTION
## Summary

Apollo v4 enables query deduplication by default which was causing problems with our health checks. We should revisit this later but as a quick fix, I disabled query deduplication globally in the client.

This PR also sets ApolloClient connection initialization to lazy and switches to a polling strategy for query retries on graphql errors. The first change is to try to mitigate an issue where the initial websocket connection hangs intermittently. The second change fixes an issue with the previous retry strategy that could result in multiple queries in-flight simultaneously.

## Changes

* Disabled query deduplication
* Set ApolloClient `lazy` to true
* Switched to polling strategy for error retries

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
