### PR TITLE
📜 Remove Glasskube install instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,23 +196,7 @@ kubectl port-forward -n kubetail-system svc/kubetail-dashboard 8080:8080
 
 Visit [http://localhost:8080](http://localhost:8080). Have fun tailing your logs!
 
-### Option 3: Glasskube
-
-To install Kubetail using [Glasskube](https://glasskube.dev/), you can select "Kubetail" from the "ClusterPackages" tab in the Glasskube GUI then click "install" or you can run the following command:
-
-```console
-glasskube install kubetail
-```
-
-Once Kubetail is installed you can use it by clicking "open" in the Glasskube GUI or by using the `open` command:
-
-```console
-glasskube open kubetail
-```
-
-Have fun tailing your logs!
-
-### Option 4: minikube
+### Option 3: minikube
 
 As of minikube v1.36.0, you can install Kubetail easily as an addon:
 


### PR DESCRIPTION
## Summary

Removes Glasskube install instructions from README (project is deprecated).

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
