### PR TITLE
🐋 Fix for write on closed channels from source-watcher and kubeconfig-watcher

### DIFF
--- a/modules/shared/k8shelpers/kube-config-watcher.go
+++ b/modules/shared/k8shelpers/kube-config-watcher.go
@@ -92,7 +92,7 @@ func (w *KubeConfigWatcher) Get() *api.Config {
 
 // Subscribe
 func (w *KubeConfigWatcher) Subscribe(fn any) {
-	w.eventbus.SubscribeAsync("MODIFIED", fn, true)
+	w.eventbus.Subscribe("MODIFIED", fn)
 }
 
 // Unsubscribe

--- a/modules/shared/logs/source-watcher.go
+++ b/modules/shared/logs/source-watcher.go
@@ -165,6 +165,7 @@ func (w *sourceWatcher) Unsubscribe(event SourceWatcherEvent, fn any) {
 func (w *sourceWatcher) Close() {
 	w.closeOnce.Do(func() {
 		close(w.stopCh)
+		w.eventbus.WaitAsync()
 	})
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a race condition I ran into in development where there was a write on a closed channel due to the `SourceWatcher` using async callbacks. Claude also found the potential for the same bug in the `KubeConfigWatcher` and this PR fixes that as well.  

## Changes

* Added `eventbus.WaitAsync()` to `SourceWatcher.Close()` method
* Switched from using eventbus `SubscribeAsync()` to `Subscribe()` in `KubeConfigWatcher`
* Added channel write guards to `modules/dashboard/graphql/schema.resolvers.go`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
