### PR TITLE
🎣 Fix next-cursor bug in TAIL mode

### DIFF
--- a/modules/cluster-api/graph/schema.resolvers.go
+++ b/modules/cluster-api/graph/schema.resolvers.go
@@ -125,12 +125,19 @@ func (r *queryResolver) LogRecordsFetch(ctx context.Context, kubeContext *string
 		logs.WithContainers(sourceFilterVal.Container),
 	}
 
+	modeVal := ptr.Deref(mode, model.LogRecordsQueryModeTail)
 	limitVal := int64(ptr.Deref(limit, 100))
-	switch ptr.Deref(mode, model.LogRecordsQueryModeTail) {
+	effectiveLimit := limitVal
+	if limitVal > 0 {
+		// Fetch one extra record so we can compute nextCursor for the next page.
+		effectiveLimit = limitVal + 1
+	}
+
+	switch modeVal {
 	case model.LogRecordsQueryModeHead:
-		streamOpts = append(streamOpts, logs.WithHead(limitVal))
+		streamOpts = append(streamOpts, logs.WithHead(effectiveLimit))
 	case model.LogRecordsQueryModeTail:
-		streamOpts = append(streamOpts, logs.WithTail(limitVal))
+		streamOpts = append(streamOpts, logs.WithTail(effectiveLimit))
 	default:
 		return nil, fmt.Errorf("not implemented %s", mode)
 	}
@@ -147,10 +154,28 @@ func (r *queryResolver) LogRecordsFetch(ctx context.Context, kubeContext *string
 	}
 
 	// Write out records
-	out := &model.LogRecordsQueryResponse{Records: []*logs.LogRecord{}}
+	records := make([]logs.LogRecord, 0, int(effectiveLimit))
 	for record := range stream.Records() {
-		out.Records = append(out.Records, &record)
-		out.NextCursor = ptr.To(record.Timestamp.Format(time.RFC3339Nano))
+		records = append(records, record)
+	}
+
+	// Apply pagination
+	var paginationMode logs.PaginationMode
+	if modeVal == model.LogRecordsQueryModeHead {
+		paginationMode = logs.PaginationModeHead
+	} else {
+		paginationMode = logs.PaginationModeTail
+	}
+	records, nextCursor := logs.PaginateLogRecords(records, limitVal, paginationMode)
+
+	outRecords := make([]*logs.LogRecord, 0, len(records))
+	for i := range records {
+		outRecords = append(outRecords, &records[i])
+	}
+
+	out := &model.LogRecordsQueryResponse{
+		Records:    outRecords,
+		NextCursor: nextCursor,
 	}
 
 	if ctx.Err() != nil {


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `nextCursor` generator when fetching logs both from the Dashboard server and the ClusterAPI server. Previously, the nextCursor was the last record in the list which for `TAIL` mode was the last temporal record which is incorrect. Now the code correctly peeks into the next record in the log and currectly performs pagination.

## Changes

* Added shared `PaginateLogRecords` to `modules/shared/logs/helpers.go`
* Modified `modules/dashboard/graph/schema.resolvers.go` and `modules/cluster-api/graph/schema.resolvers.go` to fetch an extra record for peek and use shared PaginateLogRecords

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
