### PR TITLE
✨ Switch to jotai-family for atomFamily support

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -33,6 +33,7 @@
     "graphql": "^16.12.0",
     "graphql-ws": "^6.0.5",
     "jotai": "^2.16.0",
+    "jotai-family": "^1.0.1",
     "lucide-react": "^0.561.0",
     "numeral": "^2.0.6",
     "react": "^19.2.3",

--- a/dashboard-ui/pnpm-lock.yaml
+++ b/dashboard-ui/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       jotai:
         specifier: ^2.16.0
         version: 2.16.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.3)
+      jotai-family:
+        specifier: ^1.0.1
+        version: 1.0.1(jotai@2.16.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.3))
       lucide-react:
         specifier: ^0.561.0
         version: 0.561.0(react@19.2.3)
@@ -3557,6 +3560,12 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jotai-family@1.0.1:
+    resolution: {integrity: sha512-Zb/79GNDhC/z82R+6qTTpeKW4l4H6ZCApfF5W8G4SH37E4mhbysU7r8DkP0KX94hWvjB/6lt/97nSr3wB+64Zg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      jotai: '>=2.9.0'
 
   jotai@2.16.0:
     resolution: {integrity: sha512-NmkwPBet0SHQ28GBfEb10sqnbVOYyn6DL4iazZgGRDUKxSWL0iqcm+IK4TqTSFC2ixGk+XX2e46Wbv364a3cKg==}
@@ -8439,6 +8448,10 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.6.1: {}
+
+  jotai-family@1.0.1(jotai@2.16.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.3)):
+    dependencies:
+      jotai: 2.16.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.3)
 
   jotai@2.16.0(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.7)(react@19.2.3):
     optionalDependencies:

--- a/dashboard-ui/src/pages/home/state.ts
+++ b/dashboard-ui/src/pages/home/state.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { atom } from 'jotai';
-import { atomFamily, selectAtom } from 'jotai/utils';
+import { selectAtom } from 'jotai/utils';
+import { atomFamily } from 'jotai-family';
 
 import { HomePodsListItemFragmentFragment } from '@/lib/graphql/dashboard/__generated__/graphql';
 import { WorkloadKind, ALL_WORKLOAD_KINDS } from '@/lib/workload';


### PR DESCRIPTION
## Summary

This PR switches to importing `atomFamily()` from `jotai-family` to fix deprecation warning in `jotai`.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
