### PR TITLE
🎣 Fix stale searchparams issue with jump to beginning/end buttons

### DIFF
--- a/dashboard-ui/src/pages/console/header.tsx
+++ b/dashboard-ui/src/pages/console/header.tsx
@@ -135,23 +135,25 @@ export function Header() {
 
   const handleJumpToBeginningPress = useCallback(async () => {
     // Update location
-    searchParams.set('mode', 'head');
-    searchParams.delete('cursor');
-    setSearchParams(searchParams, { replace: true });
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set('mode', 'head');
+    nextSearchParams.delete('cursor');
+    setSearchParams(nextSearchParams, { replace: true });
 
     // Execute command
     await logViewerRef.current?.jumpToBeginning();
-  }, []);
+  }, [logViewerRef, searchParams, setSearchParams]);
 
   const handleJumpToEndPress = useCallback(async () => {
     // Update location
-    searchParams.set('mode', 'tail');
-    searchParams.delete('cursor');
-    setSearchParams(new URLSearchParams(searchParams), { replace: true });
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set('mode', 'tail');
+    nextSearchParams.delete('cursor');
+    setSearchParams(nextSearchParams, { replace: true });
 
     // Execute command
     await logViewerRef.current?.jumpToEnd();
-  }, []);
+  }, [logViewerRef, searchParams, setSearchParams]);
 
   const handlePlayPress = useCallback(() => {
     setIsFollow(true);


### PR DESCRIPTION
## Summary

This PR fixes an issue where jump to beginning/end buttons were removing applied filters because they were mutating stale `searchparams` instances.

## Changes

* Added `searchparams` to handler dependencies in `dashboard-ui/src/pages/console/header.tsx`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
