### PR TITLE
✨ Improve GPG usage in gha workflows

### DIFF
--- a/.github/workflows/publish-guru.yml
+++ b/.github/workflows/publish-guru.yml
@@ -113,9 +113,9 @@ jobs:
       - name: Configure gpg
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.ANDRES_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.ANDRES_PGP_PASSWORD }}
-          fingerprint: ${{ vars.ANDRES_PGP_SIGNING_KEY_FINGERPRINT }}
+          gpg_private_key: ${{ secrets.ANDRES_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.ANDRES_GPG_PASSWORD }}
+          fingerprint: ${{ vars.ANDRES_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Configure git
         working-directory: guru
@@ -127,7 +127,7 @@ jobs:
 
           git config user.name "Andres Morey"
           git config user.email "andres@kubetail.com"
-          git config user.signingkey "${{ vars.ANDRES_PGP_SIGNING_KEY_FINGERPRINT }}"
+          git config user.signingkey "${{ vars.ANDRES_GPG_SIGNING_KEY_FINGERPRINT }}"
 
       - name: Debug
         if: ${{ needs.config.outputs.dry_run == 'true' }}
@@ -153,6 +153,10 @@ jobs:
           # Commit and push
           git commit -a -s -S -m "dev-util/kubetail: add ${{ needs.config.outputs.version }}"
           git push origin
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg
 
   update-kubetail-bin:
     name: Update `kubetail-bin` package
@@ -245,9 +249,9 @@ jobs:
       - name: Configure gpg
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.ANDRES_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.ANDRES_PGP_PASSWORD }}
-          fingerprint: ${{ vars.ANDRES_PGP_SIGNING_KEY_FINGERPRINT }}
+          gpg_private_key: ${{ secrets.ANDRES_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.ANDRES_GPG_PASSWORD }}
+          fingerprint: ${{ vars.ANDRES_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Configure git
         working-directory: guru
@@ -259,7 +263,7 @@ jobs:
 
           git config user.name "Andres Morey"
           git config user.email "andres@kubetail.com"
-          git config user.signingkey "${{ vars.ANDRES_PGP_SIGNING_KEY_FINGERPRINT }}"
+          git config user.signingkey "${{ vars.ANDRES_GPG_SIGNING_KEY_FINGERPRINT }}"
 
       - name: Debug
         if: ${{ needs.config.outputs.dry_run == 'true' }}
@@ -285,3 +289,7 @@ jobs:
           # Commit and push
           git commit -a -s -m "dev-util/kubetail-bin: add ${{ needs.config.outputs.version }}"
           git push origin
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg

--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -96,8 +96,9 @@ jobs:
       - name: Configure gpg
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.KUBETAIL_BOT_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
+          gpg_private_key: ${{ secrets.KUBETAIL_BOT_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.KUBETAIL_BOT_GPG_PASSWORD }}
+          fingerprint: ${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Build and push packages
         working-directory: work/kubetail-cli-${{ steps.config.outputs.version }}
@@ -120,7 +121,7 @@ jobs:
             fi
 
             dch ${DCH_FLAGS} -D "${SERIES}" -v "${PKG_VERSION}" "Initial release for ${SERIES}."
-            debuild ${DEBUILD_FLAGS} -S -d -k"${{ vars.KUBETAIL_BOT_PGP_FINGERPRINT }}"
+            debuild ${DEBUILD_FLAGS} -S -d -k"${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}"
 
             if [ "${{ steps.config.outputs.dry_run }}" = "false" ]; then
               dput ppa:kubetail/kubetail "../kubetail-cli_${PKG_VERSION}_source.changes"
@@ -129,3 +130,7 @@ jobs:
               cat "../kubetail-cli_${PKG_VERSION}_source.changes"
             fi
           done
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg

--- a/.github/workflows/publish-macports.yml
+++ b/.github/workflows/publish-macports.yml
@@ -179,8 +179,9 @@ jobs:
       - name: Configure gpg
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.KUBETAIL_BOT_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
+          gpg_private_key: ${{ secrets.KUBETAIL_BOT_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.KUBETAIL_BOT_GPG_PASSWORD }}
+          fingerprint: ${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Configure git
         working-directory: "${{ steps.temp.outputs.dir }}/macports-ports/devel/kubetail"
@@ -191,7 +192,7 @@ jobs:
 
           git config --local user.name "${{ vars.KUBETAIL_BOT_NAME }}"
           git config --local user.email "${{ vars.KUBETAIL_BOT_EMAIL }}"
-          git config --local user.signingkey "${{ vars.KUBETAIL_BOT_PGP_FINGERPRINT }}"
+          git config --local user.signingkey "${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}"
 
       - name: Commit changes and raise PR
         working-directory: "${{ steps.temp.outputs.dir }}/macports-ports"
@@ -244,3 +245,7 @@ jobs:
             --base master \
             --title "kubetail: update to ${{ steps.config.outputs.version }}" \
             --body-file "${{ steps.pr_body.outputs.file }}"
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -113,8 +113,9 @@ jobs:
       - name: Configure gpg
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.KUBETAIL_BOT_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
+          gpg_private_key: ${{ secrets.KUBETAIL_BOT_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.KUBETAIL_BOT_GPG_PASSWORD }}
+          fingerprint: ${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Configure git
         working-directory: winget-pkgs
@@ -125,7 +126,7 @@ jobs:
 
           git config --local user.name "${{ vars.KUBETAIL_BOT_NAME }}"
           git config --local user.email "${{ vars.KUBETAIL_BOT_EMAIL }}"
-          git config --local user.signingkey "${{ vars.KUBETAIL_BOT_PGP_FINGERPRINT }}"
+          git config --local user.signingkey "${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}"
 
       - name: Commit changes and raise PR
         working-directory: winget-pkgs
@@ -179,3 +180,7 @@ jobs:
             --base master \
             --title "New version: Kubetail.Kubetail version ${{ steps.config.outputs.version }}" \
             --body "This PR adds the manifest for Kubetail.Kubetail version ${{ steps.config.outputs.version }}."
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -366,8 +366,9 @@ jobs:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
-          gpg_private_key: ${{ secrets.KUBETAIL_BOT_PGP_SIGNING_KEY }}
-          passphrase: ${{ secrets.KUBETAIL_BOT_PGP_PASSWORD }}
+          gpg_private_key: ${{ secrets.KUBETAIL_BOT_GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.KUBETAIL_BOT_GPG_PASSWORD }}
+          fingerprint: ${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}
 
       - name: Sign SHA256SUMS with GPG
         working-directory: ./assets
@@ -387,3 +388,7 @@ jobs:
         with:
           files: assets/*
           draft: true
+
+      - name: Cleanup GPG
+        if: always()
+        run: rm -rf ~/.gnupg


### PR DESCRIPTION
## Summary

This PR improves GPG usage in our GHA workflows by using subkeys instead of primary keys, it also deletes the `~/.gnupg` directory as a cleanup step to get around a subkey-related [bug](https://github.com/crazy-max/ghaction-import-gpg/issues/124) in the crazy-max/ghaction-import-gpg action.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
