### PR TITLE
✨ Simplify config variable names and add docs to default config files

### DIFF
--- a/config/default/cluster-agent.yaml
+++ b/config/default/cluster-agent.yaml
@@ -1,15 +1,101 @@
+## Kubetail Cluster Agent Configuration File
+#
+# This file defines the behavior for the kubetail cluster agent,
+# which runs in Kubernetes clusters to stream and process container logs.
+#
+
+## addr ##
+#
+# The network address and port the gRPC server should bind to.
+#
+# Default value: :50051
+#
 addr: :50051
+
+## container-logs-dir ##
+#
+# The directory path where Kubernetes stores container log files.
+# This is typically a mount from the host node's filesystem.
+#
+# Default value: /var/log/containers
+#
 container-logs-dir: /var/log/containers
 
+## logging ##
+#
+# Configuration for the agent's logging output
+#
 logging:
+
+  ## enabled ##
+  #
+  # Whether logging is enabled for the agent.
+  #
+  # Default value: true
+  #
   enabled: true
+
+  ## level ##
+  #
+  # The minimum log level to output.
+  # Valid values: debug, info, warn, error
+  #
+  # Default value: info
+  #
   level: info
+
+  ## format ##
+  #
+  # The format of log output.
+  # Valid values: json, text
+  #
+  # Default value: json
+  #
   format: json
 
+## tls ##
+#
+# TLS configuration for secure gRPC connections
+#
 tls:
-  enabled: false
-  cert-file: ""
-  key-file: ""
-  ca-file: ""
-  client-auth: none
 
+  ## enabled ##
+  #
+  # Whether TLS is enabled for gRPC connections.
+  #
+  # Default value: false
+  #
+  enabled: false
+
+  ## cert-file ##
+  #
+  # Path to the TLS certificate file.
+  #
+  # Default value: ""
+  #
+  cert-file: ""
+
+  ## key-file ##
+  #
+  # Path to the TLS private key file.
+  #
+  # Default value: ""
+  #
+  key-file: ""
+
+  ## ca-file ##
+  #
+  # Path to the CA certificate file for client verification.
+  #
+  # Default value: ""
+  #
+  ca-file: ""
+
+  ## client-auth ##
+  #
+  # The client authentication policy for TLS connections.
+  # Valid values: none, request, require, verify, require-and-verify
+  #
+  # Default value: none
+  #
+  client-auth: none

--- a/config/default/cluster-api.yaml
+++ b/config/default/cluster-api.yaml
@@ -1,31 +1,199 @@
+## Kubetail Cluster API Configuration File
+#
+# This file defines the behavior for the kubetail cluster API server,
+# which provides the GraphQL API for cluster operations.
+#
+
+## allowed-namespaces ##
+#
+# List of namespaces the API is allowed to access.
+# If empty, all namespaces are accessible.
+#
+# Default value: []
+#
 allowed-namespaces: []
 
+## addr ##
+#
+# The network address and port the HTTP server should bind to.
+#
+# Default value: :8080
+#
 addr: :8080
+
+## base-path ##
+#
+# The base URL path for all API endpoints.
+#
+# Default value: /
+#
 base-path: /
+
+## gin-mode ##
+#
+# The Gin framework mode.
+# Valid values: debug, release, test
+#
+# Default value: release
+#
 gin-mode: release
 
+## cluster-agent ##
+#
+# Configuration for connecting to the cluster agent
+#
 cluster-agent:
+
+  ## dispatch-url ##
+  #
+  # The URL used to connect to the cluster agent.
+  # Supports kubernetes:// scheme for in-cluster service discovery.
+  #
+  # Default value: kubernetes://kubetail-cluster-agent:50051
+  #
   dispatch-url: kubernetes://kubetail-cluster-agent:50051
+
+  ## tls ##
+  #
+  # TLS configuration for cluster agent connections
+  #
   tls:
+
+    ## enabled ##
+    #
+    # Whether TLS is enabled for cluster agent connections.
+    #
+    # Default value: false
+    #
     enabled: false
+
+    ## cert-file ##
+    #
+    # Path to the TLS certificate file.
+    #
+    # Default value: ""
+    #
     cert-file: ""
+
+    ## key-file ##
+    #
+    # Path to the TLS private key file.
+    #
+    # Default value: ""
+    #
     key-file: ""
+
+    ## ca-file ##
+    #
+    # Path to the CA certificate file for server verification.
+    #
+    # Default value: ""
+    #
     ca-file: ""
+
+    ## server-name ##
+    #
+    # The server name to use for TLS verification.
+    # If empty, the hostname from dispatch-url is used.
+    #
+    # Default value: ""
+    #
     server-name: ""
 
+## csrf ##
+#
+# CSRF protection settings
+#
 csrf:
+
+  ## enabled ##
+  #
+  # Whether CSRF protection is enabled.
+  #
+  # Default value: true
+  #
   enabled: true
 
+## logging ##
+#
+# Configuration for the API server's logging output
+#
 logging:
+
+  ## enabled ##
+  #
+  # Whether logging is enabled for the server.
+  #
+  # Default value: true
+  #
   enabled: true
+
+  ## level ##
+  #
+  # The minimum log level to output.
+  # Valid values: debug, info, warn, error
+  #
+  # Default value: info
+  #
   level: info
+
+  ## format ##
+  #
+  # The format of log output.
+  # Valid values: json, text
+  #
+  # Default value: json
+  #
   format: json
+
+  ## access-log ##
+  #
+  # Configuration for HTTP access logging
+  #
   access-log:
+
+    ## enabled ##
+    #
+    # Whether access logging is enabled.
+    #
+    # Default value: true
+    #
     enabled: true
+
+    ## hide-health-checks ##
+    #
+    # Whether to hide health check requests from access logs.
+    #
+    # Default value: false
+    #
     hide-health-checks: false
 
+## tls ##
+#
+# TLS configuration for the HTTP server
+#
 tls:
-  enabled: false
-  cert-file: ""
-  key-file: ""
 
+  ## enabled ##
+  #
+  # Whether TLS is enabled for HTTP connections.
+  #
+  # Default value: false
+  #
+  enabled: false
+
+  ## cert-file ##
+  #
+  # Path to the TLS certificate file.
+  #
+  # Default value: ""
+  #
+  cert-file: ""
+
+  ## key-file ##
+  #
+  # Path to the TLS private key file.
+  #
+  # Default value: ""
+  #
+  key-file: ""

--- a/config/default/dashboard.yaml
+++ b/config/default/dashboard.yaml
@@ -1,40 +1,265 @@
+## Kubetail Dashboard Configuration File
+#
+# This file defines the behavior for the kubetail dashboard server,
+# which serves the web UI and provides the backend API for the dashboard.
+#
+
+## allowed-namespaces ##
+#
+# List of namespaces the dashboard is allowed to access.
+# If empty, all namespaces are accessible.
+#
+# Default value: []
+#
 allowed-namespaces: []
+
+## kubeconfig ##
+#
+# Path to the kubeconfig file to use for Kubernetes API requests.
+# If empty, the default path (~/.kube/config) or KUBECONFIG env var is used.
+#
+# Default value: ""
+#
 kubeconfig: ""
 
+## addr ##
+#
+# The network address and port the HTTP server should bind to.
+#
+# Default value: :80
+#
 addr: :80
+
+## auth-mode ##
+#
+# The authentication mode for the dashboard.
+# Valid values: auto, cluster, local
+#
+# Default value: auto
+#
 auth-mode: auto
+
+## base-path ##
+#
+# The base URL path for all dashboard endpoints.
+#
+# Default value: /
+#
 base-path: /
+
+## cluster-api-endpoint ##
+#
+# The URL of the cluster API server.
+#
+# Default value: http://kubetail-cluster-api
+#
 cluster-api-endpoint: http://kubetail-cluster-api
+
+## environment ##
+#
+# The environment the dashboard is running in.
+# Valid values: desktop, cluster
+#
+# Default value: desktop
+#
 environment: desktop
+
+## gin-mode ##
+#
+# The Gin framework mode.
+# Valid values: debug, release, test
+#
+# Default value: release
+#
 gin-mode: release
 
+## csrf ##
+#
+# CSRF protection settings
+#
 csrf:
+
+  ## enabled ##
+  #
+  # Whether CSRF protection is enabled.
+  #
+  # Default value: true
+  #
   enabled: true
 
+## logging ##
+#
+# Configuration for the dashboard server's logging output
+#
 logging:
+
+  ## enabled ##
+  #
+  # Whether logging is enabled for the server.
+  #
+  # Default value: true
+  #
   enabled: true
+
+  ## level ##
+  #
+  # The minimum log level to output.
+  # Valid values: debug, info, warn, error
+  #
+  # Default value: info
+  #
   level: info
+
+  ## format ##
+  #
+  # The format of log output.
+  # Valid values: json, text
+  #
+  # Default value: json
+  #
   format: json
+
+  ## access-log ##
+  #
+  # Configuration for HTTP access logging
+  #
   access-log:
+
+    ## enabled ##
+    #
+    # Whether access logging is enabled.
+    #
+    # Default value: true
+    #
     enabled: true
+
+    ## hide-health-checks ##
+    #
+    # Whether to hide health check requests from access logs.
+    #
+    # Default value: false
+    #
     hide-health-checks: false
 
+## session ##
+#
+# Session management settings
+#
 session:
+
+  ## secret ##
+  #
+  # The secret key used to sign session tokens.
+  # If empty, a random secret is generated on startup.
+  #
+  # Default value: ""
+  #
   secret: ""
+
+  ## cookie ##
+  #
+  # Session cookie configuration
+  #
   cookie:
+
+    ## name ##
+    #
+    # The name of the session cookie.
+    #
+    # Default value: session
+    #
     name: session
+
+    ## path ##
+    #
+    # The URL path for which the cookie is valid.
+    #
+    # Default value: /
+    #
     path: /
+
+    ## domain ##
+    #
+    # The domain for which the cookie is valid.
+    # If empty, the cookie is valid for the current domain only.
+    #
+    # Default value: ""
+    #
     domain: ""
+
+    ## max-age ##
+    #
+    # The maximum age of the cookie in seconds.
+    #
+    # Default value: 1092000
+    #
     max-age: 1092000
+
+    ## secure ##
+    #
+    # Whether the cookie should only be sent over HTTPS.
+    #
+    # Default value: false
+    #
     secure: false
+
+    ## http-only ##
+    #
+    # Whether the cookie is inaccessible to JavaScript.
+    #
+    # Default value: true
+    #
     http-only: true
+
+    ## same-site ##
+    #
+    # The SameSite attribute for the cookie.
+    # Valid values: strict, lax, none
+    #
+    # Default value: lax
+    #
     same-site: lax
 
+## tls ##
+#
+# TLS configuration for the HTTP server
+#
 tls:
+
+  ## enabled ##
+  #
+  # Whether TLS is enabled for HTTP connections.
+  #
+  # Default value: false
+  #
   enabled: false
+
+  ## cert-file ##
+  #
+  # Path to the TLS certificate file.
+  #
+  # Default value: ""
+  #
   cert-file: ""
+
+  ## key-file ##
+  #
+  # Path to the TLS private key file.
+  #
+  # Default value: ""
+  #
   key-file: ""
 
+## ui ##
+#
+# UI-specific configuration options
+#
 ui:
-  cluster-api-enabled: true
 
+  ## cluster-api-enabled ##
+  #
+  # Whether the cluster API integration is enabled in the UI.
+  #
+  # Default value: true
+  #
+  cluster-api-enabled: true

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -33,13 +33,13 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 
 	"github.com/kubetail-org/kubetail/modules/cli/internal/cli"
 	"github.com/kubetail-org/kubetail/modules/cli/internal/tablewriter"
+	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 )
 
 var headFlag config.OptionalInt64
@@ -227,13 +227,13 @@ var logsCmd = &cobra.Command{
 		// Get flags
 		flags := cmd.Flags()
 
-		configPath, _ := cmd.Flags().GetString("config")
+		configPath, _ := flags.GetString("config")
 		inCluster, _ := flags.GetBool(InClusterFlag)
 
 		v := viper.New()
 
-		v.BindPFlag("general.kubeconfig", cmd.Flags().Lookup(KubeconfigFlag))
-		v.BindPFlag("commands.logs.kube-context", cmd.Flags().Lookup(KubeContextFlag))
+		v.BindPFlag("general.kubeconfig", flags.Lookup(KubeconfigFlag))
+		v.BindPFlag("commands.logs.kube-context", flags.Lookup(KubeContextFlag))
 		if headFlag.IsValueProvided {
 			v.Set("commands.logs.head", headFlag.Value)
 		}
@@ -241,18 +241,18 @@ var logsCmd = &cobra.Command{
 			v.Set("commands.logs.tail", tailFlag.Value)
 		}
 
-		cliCfg, err := config.NewCLIConfig(configPath, v)
+		cfg, err := config.NewConfig(configPath, v)
 		if err != nil {
 			zlog.Fatal().Caller().Err(err).Send()
 		}
-		kubeContext := cliCfg.Commands.Logs.KubeContext
-		kubeconfigPath := cliCfg.General.KubeconfigPath
+		kubeContext := cfg.Commands.Logs.KubeContext
+		kubeconfigPath := cfg.General.KubeconfigPath
 
 		head := flags.Changed("head")
-		headVal := cliCfg.Commands.Logs.Head
+		headVal := cfg.Commands.Logs.Head
 
 		tail := flags.Changed("tail")
-		tailVal := cliCfg.Commands.Logs.Tail
+		tailVal := cfg.Commands.Logs.Tail
 
 		all, _ := flags.GetBool("all")
 		follow, _ := flags.GetBool("follow")

--- a/modules/cli/cmd/serve.go
+++ b/modules/cli/cmd/serve.go
@@ -37,7 +37,6 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 
-	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/app"
 	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
@@ -45,6 +44,7 @@ import (
 	"github.com/kubetail-org/kubetail/modules/shared/logging"
 
 	"github.com/kubetail-org/kubetail/modules/cli/internal/tunnel"
+	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 )
 
 type serveOptions struct {
@@ -236,31 +236,31 @@ func loadServerConfig(cmd *cobra.Command) (*dashcfg.Config, *serveOptions, error
 	v.BindPFlag("commands.serve.skip-open", cmd.Flags().Lookup("skip-open"))
 
 	// Init config
-	cliCfg, err := config.NewCLIConfig(configPath, v)
+	cfg, err := config.NewConfig(configPath, v)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	cfg := dashcfg.DefaultConfig()
+	dashCfg := dashcfg.DefaultConfig()
 
-	cfg.KubeconfigPath = cliCfg.General.KubeconfigPath
-	cfg.Addr = fmt.Sprintf("%s:%d", cliCfg.Commands.Serve.Host, cliCfg.Commands.Serve.Port)
-	cfg.Environment = sharedcfg.EnvironmentDesktop
-	cfg.Logging.Level = logLevel
+	dashCfg.KubeconfigPath = cfg.General.KubeconfigPath
+	dashCfg.Addr = fmt.Sprintf("%s:%d", cfg.Commands.Serve.Host, cfg.Commands.Serve.Port)
+	dashCfg.Environment = sharedcfg.EnvironmentDesktop
+	dashCfg.Logging.Level = logLevel
 	if inCluster {
-		cfg.Environment = sharedcfg.EnvironmentCluster
+		dashCfg.Environment = sharedcfg.EnvironmentCluster
 	}
-	cfg.Logging.AccessLog.Enabled = false
+	dashCfg.Logging.AccessLog.Enabled = false
 
 	serveOptions := &serveOptions{
-		port:     cliCfg.Commands.Serve.Port,
-		host:     cliCfg.Commands.Serve.Host,
-		skipOpen: cliCfg.Commands.Serve.SkipOpen,
+		port:     cfg.Commands.Serve.Port,
+		host:     cfg.Commands.Serve.Host,
+		skipOpen: cfg.Commands.Serve.SkipOpen,
 		remote:   remote,
 		test:     test,
 	}
 
-	return cfg, serveOptions, nil
+	return dashCfg, serveOptions, nil
 }
 
 func serveRemote(kubeconfigPath string, localPort int, skipOpen bool) {

--- a/modules/cli/cmd/serve_test.go
+++ b/modules/cli/cmd/serve_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 )
 
 func TestLoadServerConfig_Defaults(t *testing.T) {

--- a/modules/cli/pkg/config/config.go
+++ b/modules/cli/pkg/config/config.go
@@ -30,8 +30,8 @@ type CLI struct {
 	Config string `validate:"omitempty,file"`
 }
 
-// Application configuration
-type CLIConfig struct {
+// CLI configuration
+type Config struct {
 	// Global settings
 	General struct {
 		KubeconfigPath string `mapstructure:"kubeconfig"`
@@ -56,12 +56,12 @@ type CLIConfig struct {
 }
 
 // Validate config
-func (cfg *CLIConfig) validate() error {
+func (cfg *Config) validate() error {
 	return validator.New().Struct(cfg)
 }
 
-func DefaultCLIConfig() *CLIConfig {
-	cfg := &CLIConfig{}
+func DefaultCLIConfig() *Config {
+	cfg := &Config{}
 
 	cfg.Commands.Logs.KubeContext = ""
 	cfg.Commands.Logs.Head = 10
@@ -85,7 +85,7 @@ func DefaultConfigPath(format string) (string, error) {
 	return filepath.Join(home, ".kubetail", fmt.Sprintf("config.%s", format)), nil
 }
 
-func NewCLIConfig(configPath string, v *viper.Viper) (*CLIConfig, error) {
+func NewConfig(configPath string, v *viper.Viper) (*Config, error) {
 	// Use viper instance from user or create a new one
 	if v == nil {
 		v = viper.New()

--- a/modules/cli/pkg/config/config_test.go
+++ b/modules/cli/pkg/config/config_test.go
@@ -68,7 +68,7 @@ func TestNewCLIConfigSuccess(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(validCLIConfig), 0644)
 		require.NoError(t, err)
 
-		cfg, err := NewCLIConfig(filePath, nil)
+		cfg, err := NewConfig(filePath, nil)
 		require.Nil(t, err)
 		assert.Equal(t, "/path/to/kubeconfig", cfg.General.KubeconfigPath)
 		assert.Equal(t, "my-context", cfg.Commands.Logs.KubeContext)
@@ -92,7 +92,7 @@ func TestNewCLIConfigSuccess(t *testing.T) {
 		v := viper.New()
 		v.Set("commands.logs.head", headVal)
 
-		cfg, err := NewCLIConfig(filePath, v)
+		cfg, err := NewConfig(filePath, v)
 		require.Nil(t, err)
 		assert.Equal(t, headVal, cfg.Commands.Logs.Head)
 	})
@@ -106,13 +106,13 @@ func TestNewCLIConfigError(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(invalidCLIConfig), 0644)
 		require.NoError(t, err)
 
-		cfg, err := NewCLIConfig(filePath, nil)
+		cfg, err := NewConfig(filePath, nil)
 		require.NotNil(t, err)
 		require.Nil(t, cfg)
 	})
 
 	t.Run("missing file", func(t *testing.T) {
-		cfg, err := NewCLIConfig("/does/not/exist.yaml", nil)
+		cfg, err := NewConfig("/does/not/exist.yaml", nil)
 		require.NotNil(t, err)
 		require.Nil(t, cfg)
 	})
@@ -124,7 +124,7 @@ func TestNewCLIConfigError(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(validCLIConfig), 0644)
 		require.NoError(t, err)
 
-		cfg, err := NewCLIConfig(filePath, nil)
+		cfg, err := NewConfig(filePath, nil)
 		require.NotNil(t, err)
 		require.Nil(t, cfg)
 	})

--- a/modules/cluster-api/cmd/main.go
+++ b/modules/cluster-api/cmd/main.go
@@ -30,10 +30,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/logging"
 
 	"github.com/kubetail-org/kubetail/modules/cluster-api/internal/app"
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 type CLI struct {
@@ -64,7 +64,7 @@ func main() {
 			v.BindPFlag("cluster-api.gin-mode", cmd.Flags().Lookup("gin-mode"))
 
 			// Init config
-			cfg, err := capicfg.NewConfig(v, cli.Config)
+			cfg, err := config.NewConfig(cli.Config, v)
 			if err != nil {
 				zlog.Fatal().Caller().Err(err).Send()
 			}

--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -29,9 +29,10 @@ import (
 
 	grpcdispatcher "github.com/kubetail-org/grpc-dispatcher-go"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
+
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 // Represents Server
@@ -46,7 +47,7 @@ type Server struct {
 var allowedSecFetchSite = []string{"same-origin"}
 
 // Create new Server instance
-func NewServer(appConfig *capicfg.Config, cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.Dispatcher, allowedNamespaces []string) *Server {
+func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.Dispatcher, allowedNamespaces []string) *Server {
 	// Init resolver
 	r := &Resolver{cm, grpcDispatcher, allowedNamespaces}
 
@@ -74,7 +75,7 @@ func NewServer(appConfig *capicfg.Config, cm k8shelpers.ConnectionManager, grpcD
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				// Allow all if CSRF protection is disabled
-				if !appConfig.CSRF.Enabled {
+				if !cfg.CSRF.Enabled {
 					return true
 				}
 

--- a/modules/cluster-api/graph/server_test.go
+++ b/modules/cluster-api/graph/server_test.go
@@ -22,8 +22,9 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
+
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 func TestServer(t *testing.T) {
@@ -73,7 +74,7 @@ func TestServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := capicfg.DefaultConfig()
+			cfg := config.DefaultConfig()
 			cfg.CSRF.Enabled = tt.setCsrfEnabled
 
 			graphqlServer := NewServer(cfg, nil, nil, []string{})

--- a/modules/cluster-api/internal/app/app.go
+++ b/modules/cluster-api/internal/app/app.go
@@ -27,7 +27,6 @@ import (
 
 	grpcdispatcher "github.com/kubetail-org/grpc-dispatcher-go"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/ginhelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
@@ -35,6 +34,7 @@ import (
 
 	clusterapi "github.com/kubetail-org/kubetail/modules/cluster-api"
 	"github.com/kubetail-org/kubetail/modules/cluster-api/graph"
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 type App struct {
@@ -63,7 +63,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 // Create new gin app
-func NewApp(cfg *capicfg.Config) (*App, error) {
+func NewApp(cfg *config.Config) (*App, error) {
 	// Init app
 	app := &App{Engine: gin.New()}
 

--- a/modules/cluster-api/internal/app/helpers.go
+++ b/modules/cluster-api/internal/app/helpers.go
@@ -26,11 +26,12 @@ import (
 
 	grpcdispatcher "github.com/kubetail-org/grpc-dispatcher-go"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/grpchelpers"
+
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
-func mustNewGrpcDispatcher(cfg *capicfg.Config) *grpcdispatcher.Dispatcher {
+func mustNewGrpcDispatcher(cfg *config.Config) *grpcdispatcher.Dispatcher {
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(grpchelpers.AuthUnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpchelpers.AuthStreamClientInterceptor),

--- a/modules/cluster-api/internal/app/testutils_test.go
+++ b/modules/cluster-api/internal/app/testutils_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	capicfg "github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 func init() {
@@ -27,8 +27,8 @@ func init() {
 }
 
 // Create new base config for testing
-func NewTestConfig() *capicfg.Config {
-	cfg := capicfg.DefaultConfig()
+func NewTestConfig() *config.Config {
+	cfg := config.DefaultConfig()
 	cfg.BasePath = "/"
 	cfg.Logging.AccessLog.Enabled = false
 	cfg.CSRF.Enabled = false
@@ -36,7 +36,7 @@ func NewTestConfig() *capicfg.Config {
 }
 
 // Create new app for testing
-func NewTestApp(cfg *capicfg.Config) *App {
+func NewTestApp(cfg *config.Config) *App {
 	if cfg == nil {
 		cfg = NewTestConfig()
 	}

--- a/modules/dashboard/cmd/main.go
+++ b/modules/dashboard/cmd/main.go
@@ -34,11 +34,11 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logging"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/app"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 type CLI struct {
@@ -77,7 +77,7 @@ func main() {
 			}
 
 			// Init config
-			cfg, err := dashcfg.NewConfig(v, cli.Config)
+			cfg, err := config.NewConfig(v, cli.Config)
 			if err != nil {
 				zlog.Fatal().Caller().Err(err).Send()
 			}

--- a/modules/dashboard/graph/resolver.go
+++ b/modules/dashboard/graph/resolver.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/ptr"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/graph/model"
 	clusterapi "github.com/kubetail-org/kubetail/modules/dashboard/internal/cluster-api"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 // This file will not be regenerated automatically.
@@ -41,7 +41,7 @@ import (
 //go:generate go run github.com/99designs/gqlgen generate
 
 type Resolver struct {
-	config            *dashcfg.Config
+	cfg               *config.Config
 	cm                k8shelpers.ConnectionManager
 	hm                clusterapi.HealthMonitor
 	environment       sharedcfg.Environment

--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -131,7 +131,7 @@ func (r *mutationResolver) HelmInstallLatest(ctx context.Context, kubeContext *s
 	}
 
 	// Init client
-	client := helm.NewClient(helm.WithKubeconfigPath(r.config.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
+	client := helm.NewClient(helm.WithKubeconfigPath(r.cfg.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
 
 	// Install
 	release, err := client.InstallLatest(helm.DefaultNamespace, helm.DefaultReleaseName)
@@ -532,7 +532,7 @@ func (r *queryResolver) HelmListReleases(ctx context.Context, kubeContext *strin
 	kubeContextVal := r.cm.DerefKubeContext(kubeContext)
 
 	// Init client
-	client := helm.NewClient(helm.WithKubeconfigPath(r.config.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
+	client := helm.NewClient(helm.WithKubeconfigPath(r.cfg.KubeconfigPath), helm.WithKubeContext(kubeContextVal))
 
 	// Get list
 	releases, err := client.ListReleases()

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -27,11 +27,11 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/vektah/gqlparser/v2/ast"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 
 	clusterapi "github.com/kubetail-org/kubetail/modules/dashboard/internal/cluster-api"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 // Represents Server
@@ -47,17 +47,17 @@ type Server struct {
 var allowedSecFetchSite = []string{"same-origin"}
 
 // Create new Server instance
-func NewServer(appConfig *dashcfg.Config, cm k8shelpers.ConnectionManager) *Server {
+func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 	// Init health monitor
-	hm := clusterapi.NewHealthMonitor(appConfig, cm)
+	hm := clusterapi.NewHealthMonitor(cfg, cm)
 
 	// Init resolver
 	r := &Resolver{
-		config:            appConfig,
+		cfg:               cfg,
 		cm:                cm,
 		hm:                hm,
-		environment:       appConfig.Environment,
-		allowedNamespaces: appConfig.AllowedNamespaces,
+		environment:       cfg.Environment,
+		allowedNamespaces: cfg.AllowedNamespaces,
 	}
 
 	// Init config
@@ -84,7 +84,7 @@ func NewServer(appConfig *dashcfg.Config, cm k8shelpers.ConnectionManager) *Serv
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				// Allow all if CSRF protection is disabled
-				if !appConfig.CSRF.Enabled {
+				if !cfg.CSRF.Enabled {
 					return true
 				}
 

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -22,9 +22,10 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
+
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 func TestServer(t *testing.T) {
@@ -74,7 +75,7 @@ func TestServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := dashcfg.DefaultConfig()
+			cfg := config.DefaultConfig()
 			cfg.Environment = sharedcfg.EnvironmentCluster
 			cfg.CSRF.Enabled = tt.setCsrfEnabled
 

--- a/modules/dashboard/internal/cluster-api/health-monitor.go
+++ b/modules/dashboard/internal/cluster-api/health-monitor.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/util"
@@ -55,7 +55,7 @@ type HealthMonitor interface {
 }
 
 // Create new HealthMonitor instance
-func NewHealthMonitor(cfg *dashcfg.Config, cm k8shelpers.ConnectionManager) HealthMonitor {
+func NewHealthMonitor(cfg *config.Config, cm k8shelpers.ConnectionManager) HealthMonitor {
 	switch cfg.Environment {
 	case sharedcfg.EnvironmentDesktop:
 		return NewDesktopHealthMonitor(cm)

--- a/modules/dashboard/internal/cluster-api/health-monitor_test.go
+++ b/modules/dashboard/internal/cluster-api/health-monitor_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	k8shelpersmock "github.com/kubetail-org/kubetail/modules/shared/k8shelpers/mock"
 	"github.com/stretchr/testify/assert"
@@ -110,7 +110,7 @@ func TestNewHealthMonitor(t *testing.T) {
 			cm := &k8shelpersmock.MockConnectionManager{}
 
 			// create config
-			cfg := dashcfg.DefaultConfig()
+			cfg := config.DefaultConfig()
 			cfg.Environment = tt.environment
 			if tt.endpoint != "" {
 				cfg.ClusterAPIEndpoint = tt.endpoint
@@ -135,7 +135,7 @@ func TestNewHealthMonitor_InvalidEnvironment(t *testing.T) {
 	cm := &k8shelpersmock.MockConnectionManager{}
 
 	// create config
-	cfg := dashcfg.DefaultConfig()
+	cfg := config.DefaultConfig()
 	cfg.Environment = "invalid"
 
 	// Assert panic

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/ginhelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/middleware"
@@ -41,7 +41,7 @@ import (
 
 type App struct {
 	*gin.Engine
-	config          *dashcfg.Config
+	config          *config.Config
 	cm              k8shelpers.ConnectionManager
 	graphqlServer   *graph.Server
 	clusterAPIProxy clusterapi.Proxy
@@ -64,7 +64,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 // Create new gin app
-func NewApp(cfg *dashcfg.Config) (*App, error) {
+func NewApp(cfg *config.Config) (*App, error) {
 	// Init app
 	app := &App{Engine: gin.New(), config: cfg}
 

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,7 +108,7 @@ func TestSessionCookieOptions(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		setCfg *dashcfg.Config
+		setCfg *config.Config
 	}{
 		{"Path", cfg1},
 		{"Domain", cfg2},

--- a/modules/dashboard/pkg/app/auth.go
+++ b/modules/dashboard/pkg/app/auth.go
@@ -21,9 +21,8 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
-
 	"github.com/kubetail-org/kubetail/modules/dashboard/internal/formerrors"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 // Represents login form
@@ -104,9 +103,9 @@ func (app *authHandlers) SessionGET(c *gin.Context) {
 	}
 
 	switch authMode {
-	case dashcfg.AuthModeAuto:
+	case config.AuthModeAuto:
 		response["user"] = string(authMode)
-	case dashcfg.AuthModeToken:
+	case config.AuthModeToken:
 		token := c.GetString(k8sTokenGinKey)
 
 		// Handle no token found

--- a/modules/dashboard/pkg/app/auth_test.go
+++ b/modules/dashboard/pkg/app/auth_test.go
@@ -26,7 +26,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/utils/ptr"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 )
 
@@ -154,12 +154,12 @@ func (suite *authTestSuite) TestSessionGET() {
 
 	tests := []struct {
 		name              string
-		setAuthMode       dashcfg.AuthMode
+		setAuthMode       config.AuthMode
 		wantLoggedOutUser *string
 		wantLoggedInUser  *string
 	}{
-		{"auto", dashcfg.AuthModeAuto, ptr.To("auto"), ptr.To("auto")},
-		{"token", dashcfg.AuthModeToken, nil, ptr.To("user-xxx")},
+		{"auto", config.AuthModeAuto, ptr.To("auto"), ptr.To("auto")},
+		{"token", config.AuthModeToken, nil, ptr.To("user-xxx")},
 	}
 
 	for _, tt := range tests {

--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -21,7 +21,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 
@@ -33,7 +33,7 @@ const k8sTokenSessionKey = "k8sToken"
 const k8sTokenGinKey = "k8sToken"
 
 // newClusterAPIProxy
-func newClusterAPIProxy(cfg *dashcfg.Config, cm k8shelpers.ConnectionManager, pathPrefix string) (clusterapi.Proxy, error) {
+func newClusterAPIProxy(cfg *config.Config, cm k8shelpers.ConnectionManager, pathPrefix string) (clusterapi.Proxy, error) {
 	// Initialize new ClusterAPI proxy depending on environment
 	switch cfg.Environment {
 	case sharedcfg.EnvironmentDesktop:

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -22,16 +22,16 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
-func authenticationMiddleware(mode dashcfg.AuthMode) gin.HandlerFunc {
+func authenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 
 		// Use cookie session in "token" mode
-		if mode == dashcfg.AuthModeToken {
+		if mode == config.AuthModeToken {
 			session := sessions.Default(c)
 			if val, ok := session.Get(k8sTokenSessionKey).(string); ok {
 				token = val
@@ -55,7 +55,7 @@ func authenticationMiddleware(mode dashcfg.AuthMode) gin.HandlerFunc {
 	}
 }
 
-func k8sAuthenticationMiddleware(mode dashcfg.AuthMode) gin.HandlerFunc {
+func k8sAuthenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// set "Cache-Control: no-store" so that pages aren't stored in the users browser cache
 		c.Header("Cache-Control", "no-store")
@@ -64,7 +64,7 @@ func k8sAuthenticationMiddleware(mode dashcfg.AuthMode) gin.HandlerFunc {
 		token := c.GetString(k8sTokenGinKey)
 
 		// Reject unauthenticated requests if auth-mode: token
-		if mode == dashcfg.AuthModeToken && token == "" {
+		if mode == config.AuthModeToken && token == "" {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -24,25 +24,25 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
 func TestAuthenticationMiddleware(t *testing.T) {
 	tests := []struct {
 		name                string
-		mode                dashcfg.AuthMode
+		mode                config.AuthMode
 		hasSessionToken     bool
 		hasBearerToken      bool
 		wantContextHasToken bool
 	}{
-		{"auto-mode without tokens", dashcfg.AuthModeAuto, false, false, false},
-		{"auto-mode with session token", dashcfg.AuthModeAuto, true, false, false},
-		{"auto-mode with bearer token", dashcfg.AuthModeAuto, false, true, true},
-		{"auto-mode with both tokens", dashcfg.AuthModeAuto, true, true, true},
-		{"token-mode without tokens", dashcfg.AuthModeToken, false, false, false},
-		{"token-mode with session token", dashcfg.AuthModeToken, true, false, true},
-		{"token-mode with bearer token", dashcfg.AuthModeToken, false, true, true},
-		{"token-mode with both tokens", dashcfg.AuthModeToken, false, true, true},
+		{"auto-mode without tokens", config.AuthModeAuto, false, false, false},
+		{"auto-mode with session token", config.AuthModeAuto, true, false, false},
+		{"auto-mode with bearer token", config.AuthModeAuto, false, true, true},
+		{"auto-mode with both tokens", config.AuthModeAuto, true, true, true},
+		{"token-mode without tokens", config.AuthModeToken, false, false, false},
+		{"token-mode with session token", config.AuthModeToken, true, false, true},
+		{"token-mode with bearer token", config.AuthModeToken, false, true, true},
+		{"token-mode with both tokens", config.AuthModeToken, false, true, true},
 	}
 
 	for _, tt := range tests {
@@ -105,14 +105,14 @@ func TestAuthenticationMiddleware(t *testing.T) {
 func TestK8sTokenRequiredMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string
-		setMode        dashcfg.AuthMode
+		setMode        config.AuthMode
 		setHasToken    bool
 		wantStatusCode int
 	}{
-		{"auto-mode with session token", dashcfg.AuthModeAuto, true, http.StatusOK},
-		{"auto-mode without session token", dashcfg.AuthModeAuto, false, http.StatusOK},
-		{"token-mode with session token", dashcfg.AuthModeToken, true, http.StatusOK},
-		{"token-mode without session token", dashcfg.AuthModeToken, false, http.StatusUnauthorized},
+		{"auto-mode with session token", config.AuthModeAuto, true, http.StatusOK},
+		{"auto-mode without session token", config.AuthModeAuto, false, http.StatusOK},
+		{"token-mode with session token", config.AuthModeToken, true, http.StatusOK},
+		{"token-mode without session token", config.AuthModeToken, false, http.StatusUnauthorized},
 	}
 
 	for _, tt := range tests {

--- a/modules/dashboard/pkg/app/testutils_test.go
+++ b/modules/dashboard/pkg/app/testutils_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	authv1 "k8s.io/api/authentication/v1"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 )
 
@@ -31,8 +31,8 @@ func init() {
 }
 
 // Create new base config for testing
-func newTestConfig() *dashcfg.Config {
-	cfg := dashcfg.DefaultConfig()
+func newTestConfig() *config.Config {
+	cfg := config.DefaultConfig()
 	cfg.BasePath = "/"
 	cfg.Environment = sharedcfg.EnvironmentCluster
 	cfg.Logging.AccessLog.Enabled = false
@@ -43,7 +43,7 @@ func newTestConfig() *dashcfg.Config {
 }
 
 // Create new app for testing
-func newTestApp(cfg *dashcfg.Config) *App {
+func newTestApp(cfg *config.Config) *App {
 	if cfg == nil {
 		cfg = newTestConfig()
 	}

--- a/modules/dashboard/pkg/app/website.go
+++ b/modules/dashboard/pkg/app/website.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	zlog "github.com/rs/zerolog/log"
 
-	dashcfg "github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/middleware"
 )
 
@@ -47,7 +47,7 @@ func (app *websiteHandlers) InitStaticHandlers(root *gin.RouterGroup) {
 	}
 }
 
-func (app *websiteHandlers) EndpointHandler(cfg *dashcfg.Config) gin.HandlerFunc {
+func (app *websiteHandlers) EndpointHandler(cfg *config.Config) gin.HandlerFunc {
 	// read manifest file
 	manifestFile, err := app.websiteFS.Open(".vite/manifest.json")
 	if err != nil {

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -38,11 +38,7 @@ const (
 	AuthModeToken AuthMode = "token"
 )
 
-// Config is the Dashboard-specific application configuration.
-//
-// Note: the loader supports BOTH layouts:
-// - Monolithic: dashboard.* keys live under a "dashboard" parent.
-// - Component-specific: dashboard.* keys are at the root of the file.
+// Represents the Dashboard configuration
 type Config struct {
 	// Shared/common options (currently used by multiple components)
 	AllowedNamespaces []string `mapstructure:"allowed-namespaces"`
@@ -233,19 +229,12 @@ func NewConfig(v *viper.Viper, configPath string) (*Config, error) {
 	)
 	decodeOpt := viper.DecodeHook(hookFunc)
 
-	// unmarshal common/root options (e.g., allowed-namespaces, kubeconfig)
+	// Unmarshal
 	if err := v.Unmarshal(cfg, decodeOpt); err != nil {
 		return nil, err
 	}
 
-	// unmarshal dashboard section if present (monolithic config layout)
-	if vd := v.Sub("dashboard"); vd != nil {
-		if err := vd.Unmarshal(cfg, decodeOpt); err != nil {
-			return nil, err
-		}
-	}
-
-	// validate config
+	// Validate config
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This PR makes some improvements on top of the previous commit that broke up the monolithic config into component-specific configs.

## Changes

* Use `config` for module names when referring to a component's own config module
* Add docs to default template files

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
