### PR TITLE
📜 Note Helm chart uses ghcr.io by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Our docker images are available at these registry endpoints:
 * GitHub - ghcr.io/kubetail-org/kubetail-*
 ```
 
+The Helm chart defaults to pulling images from `ghcr.io` to avoid Docker Hub rate limits.
+
 ## Minikube
 
 As of [minikube](https://minikube.sigs.k8s.io/) v1.36.0, you can install Kubetail as an addon:


### PR DESCRIPTION
Fixes #922
Related: https://github.com/kubetail-org/helm-charts/pull/164
## Summary
Note that the Helm chart defaults to pulling images from ghcr.io to avoid Docker Hub rate limits.
## Changes
- Add a short note in the Docker Registries section about the Helm chart default registry
## Submitter checklist
- [x] Add the correct emoji to the PR title
- [x] Link the issue number to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]
[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
Use title: 📜 Note Helm chart uses ghcr.io by default