### PR TITLE
🎣 Fix Homebrew not being initialized before glab install in CI

### DIFF
--- a/.github/workflows/publish-alpine.yml
+++ b/.github/workflows/publish-alpine.yml
@@ -147,6 +147,11 @@ jobs:
           git commit -s -S -m "testing/kubetail: upgrade to $VERSION"
           git push --set-upstream origin "$BRANCH_NAME"
 
+      - name: Set up Homebrew
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+
       - name: Install GitLab CLI
         run: |
           brew install glab


### PR DESCRIPTION
## Summary

Fix a CI failure caused by Homebrew not being initialized on Ubuntu runners before attempting to install the GitLab CLI.

## Changes

- Initialize the Homebrew environment before running `brew install glab`
- Ensure `brew` is available in PATH on ubuntu-24.04 runners

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
