### PR TITLE
🎣 Fix result writer in linux-apk job in package-healthcheck workflow

### DIFF
--- a/.github/workflows/package-healthcheck.yml
+++ b/.github/workflows/package-healthcheck.yml
@@ -190,10 +190,15 @@ jobs:
           set -euxo pipefail
           cli_ver="$(kubetail --version)"
 
-          mkdir -p /tmp/results
-          echo "${cli_ver}" > "/tmp/results/${{ env.TRIPLET }}.txt"
+          mkdir -p "$GITHUB_WORKSPACE/results"
+          echo "${cli_ver}" > "$GITHUB_WORKSPACE/results/${{ env.TRIPLET }}.txt"
 
-      - *upload_step
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-${{ env.TRIPLET }}
+          path: results/*.txt
+          retention-days: 1
 
   linux-apt:
     if: github.repository == 'kubetail-org/kubetail'
@@ -741,6 +746,7 @@ jobs:
   summary:
     needs:
       - linux
+      - linux-apk
       - linux-apt
       - linux-copr
       - linux-dnf


### PR DESCRIPTION
## Summary

This PR fixes an issue with the `linux-apk` job in the `package-healthcheck` workflow that was trying to write results to the alpine chroot instead of the host filesystem.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
