### PR TITLE
✨ Update Ubuntu series in GHA workflows

### DIFF
--- a/.github/workflows/package-healthcheck.yml
+++ b/.github/workflows/package-healthcheck.yml
@@ -209,6 +209,8 @@ jobs:
           - jammy
           - noble
           - plucky
+          - questing
+          - resolute
         arch:
           - amd64
           - arm64
@@ -225,6 +227,10 @@ jobs:
             image: ubuntu:24.04
           - series: plucky
             image: ubuntu:25.04
+          - series: questing
+            image: ubuntu:25.10
+          - series: resolute
+            image: ubuntu:26.04
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -14,6 +14,11 @@ on:
         description: "Version to release"
         required: true
         type: string
+      series:
+        description: "Ubuntu series to publish"
+        required: false
+        type: string
+        default: "jammy noble questing resolute"
       dry_run:
         description: "Dry run"
         required: false
@@ -30,9 +35,11 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
+            echo "series=${{ github.event.inputs.series }}" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
             echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "series=jammy noble questing resolute" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout this repo
@@ -108,7 +115,7 @@ jobs:
           DEBEMAIL: ${{ vars.KUBETAIL_BOT_EMAIL }}
         run: |
           FIRST_SERIES=true
-          for SERIES in jammy noble plucky; do
+          for SERIES in ${{ steps.config.outputs.series }}; do
             export PKG_VERSION="${VERSION}-1~${SERIES}1"
 
             if [ "${FIRST_SERIES}" = "true" ]; then 


### PR DESCRIPTION
## Summary

This PR removes `plucky` from the `publish-launchpad` workflow and adds `questing` and `resolute` to `publish-launchpad` and `package-healthcheck`.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
