### PR TITLE
🐋 Add support for extra CPU architectures to Ubuntu PPA

### DIFF
--- a/.github/ci-config/launchpad/control
+++ b/.github/ci-config/launchpad/control
@@ -12,7 +12,7 @@ Homepage: https://github.com/kubetail-org/kubetail
 Rules-Requires-Root: no
 
 Package: kubetail-cli
-Architecture: amd64 arm64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Real-time logging dashboard for Kubernetes
  Kubetail is a general-purpose logging dashboard for Kubernetes,

--- a/.github/ci-config/launchpad/rules.tmpl
+++ b/.github/ci-config/launchpad/rules.tmpl
@@ -3,7 +3,6 @@
 export PATH := /usr/lib/go-1.24/bin:$(PATH)
 export GO111MODULE := on
 export GOWORK := off
-export CGO_ENABLED := 0
 
 %:
 	dh $@


### PR DESCRIPTION
Fixes #944

## Summary

This PR updates the Launchpad PPA configuration to build the CLI for all architectures supported by Ubuntu (including `riscv64`, `s390x`, `ppc64el`, `armhf`, and `i386`), rather than limiting it to just `amd64` and `arm64`.

## Changes

- Changed `Architecture` in `control` file from `amd64 arm64` to `any`. This allows Launchpad to automatically schedule builds for all available architectures.
- Removed `export CGO_ENABLED := 0` from `rules.tmpl`.
- Verified the build locally using QEMU emulation for `riscv64` to confirm the binary is correctly built and dynamically linked.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]