### PR TITLE
✨ Add `debian_revision` option to `publish-launchpad` workflow

### DIFF
--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: "jammy noble questing resolute"
+      debian_revision:
+        description: "Debian revision number"
+        required: false
+        type: string
+        default: "1"
       dry_run:
         description: "Dry run"
         required: false
@@ -36,10 +41,12 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             echo "dry_run=${{ github.event.inputs.dry_run }}" >> $GITHUB_OUTPUT
             echo "series=${{ github.event.inputs.series }}" >> $GITHUB_OUTPUT
+            echo "debian_revision=${{ github.event.inputs.debian_revision }}" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/cli/v}" >> $GITHUB_OUTPUT
             echo "dry_run=false" >> $GITHUB_OUTPUT
             echo "series=jammy noble questing resolute" >> $GITHUB_OUTPUT
+            echo "debian_revision=1" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout this repo
@@ -116,7 +123,7 @@ jobs:
         run: |
           FIRST_SERIES=true
           for SERIES in ${{ steps.config.outputs.series }}; do
-            export PKG_VERSION="${VERSION}-1~${SERIES}1"
+            export PKG_VERSION="${VERSION}-${{ steps.config.outputs.debian_revision }}~${SERIES}1"
 
             if [ "${FIRST_SERIES}" = "true" ]; then 
               DCH_FLAGS="--create --package kubetail-cli"


### PR DESCRIPTION
## Summary

This PR makes the debian revision number configurable when calling the `publish-launchpad` workflow using workflow dispatch.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
