### PR TITLE
🐋 Add user-agent string generator for outgoing requests

### DIFF
--- a/modules/shared/util/useragent.go
+++ b/modules/shared/util/useragent.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// UserAgent generates a user-agent string for outgoing HTTP requests following the format:
+//
+//	<product>/<version> (<os>; <arch>) Go/<go-version>
+func UserAgent(product, version string) string {
+	osName := strings.ToUpper(runtime.GOOS[:1]) + runtime.GOOS[1:]
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+
+	return fmt.Sprintf("%s/%s (%s; %s) Go/%s",
+		product, version, osName, runtime.GOARCH, goVersion,
+	)
+}

--- a/modules/shared/util/useragent_test.go
+++ b/modules/shared/util/useragent_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAgent(t *testing.T) {
+	ua := UserAgent("kubetail", "0.11.1")
+
+	osName := strings.ToUpper(runtime.GOOS[:1]) + runtime.GOOS[1:]
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+
+	assert.Contains(t, ua, "kubetail/0.11.1")
+	assert.Contains(t, ua, osName)
+	assert.Contains(t, ua, runtime.GOARCH)
+	assert.Contains(t, ua, "Go/"+goVersion)
+}
+
+func TestUserAgent_Format(t *testing.T) {
+	osName := strings.ToUpper(runtime.GOOS[:1]) + runtime.GOOS[1:]
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+
+	tests := []struct {
+		name     string
+		product  string
+		version  string
+		expected string
+	}{
+		{
+			"cli",
+			"kubetail", "0.11.1",
+			fmt.Sprintf("kubetail/0.11.1 (%s; %s) Go/%s", osName, runtime.GOARCH, goVersion),
+		},
+		{
+			"dashboard",
+			"kubetail-dashboard", "0.9.1",
+			fmt.Sprintf("kubetail-dashboard/0.9.1 (%s; %s) Go/%s", osName, runtime.GOARCH, goVersion),
+		},
+		{
+			"cluster-api",
+			"kubetail-cluster-api", "0.5.1",
+			fmt.Sprintf("kubetail-cluster-api/0.5.1 (%s; %s) Go/%s", osName, runtime.GOARCH, goVersion),
+		},
+		{
+			"cluster-agent",
+			"kubetail-cluster-agent", "0.6.1",
+			fmt.Sprintf("kubetail-cluster-agent/0.6.1 (%s; %s) Go/%s", osName, runtime.GOARCH, goVersion),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ua := UserAgent(tt.product, tt.version)
+			assert.Equal(t, tt.expected, ua)
+		})
+	}
+}

--- a/modules/shared/versioncheck/versioncheck.go
+++ b/modules/shared/versioncheck/versioncheck.go
@@ -45,6 +45,12 @@ func WithHTTPClient(client *http.Client) CheckerOption {
 	}
 }
 
+func WithUserAgent(userAgent string) CheckerOption {
+	return func(c *checker) {
+		c.githubClient.userAgent = userAgent
+	}
+}
+
 func NewChecker(options ...CheckerOption) Checker {
 	c := &checker{
 		githubClient: &githubClient{

--- a/modules/shared/versioncheck/versioncheck_test.go
+++ b/modules/shared/versioncheck/versioncheck_test.go
@@ -84,8 +84,15 @@ func TestWithOptions(t *testing.T) {
 		assert.Equal(t, customClient, c.githubClient.httpClient)
 	})
 
+	t.Run("WithUserAgent", func(t *testing.T) {
+		customUA := "custom-agent/1.0"
+		c := NewChecker(WithUserAgent(customUA)).(*checker)
+		assert.Equal(t, customUA, c.githubClient.userAgent)
+	})
+
 	t.Run("DefaultValues", func(t *testing.T) {
 		c := NewChecker().(*checker)
 		assert.NotNil(t, c.githubClient.httpClient)
+		assert.Equal(t, "kubetail-version-checker", c.githubClient.userAgent)
 	})
 }


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
-  New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #956 

## Summary
Add a reusable user-agent string generator to the shared util package so outgoing HTTP requests include structured metadata following the format: kubetail/X.Y.Z (<component>; env=<env>; <os>; <arch>) Go/<go-version>.

## Changes

- Add UserAgent(version, component, env) function to `modules/shared/util` that auto-detects OS, architecture, and Go version from the runtime
- Add WithUserAgent option to `versioncheck.NewChecker` for custom override
- Update NewChecker signature to accept version, component, and env params, replacing the hardcoded "kubetail-version-checker" string
- Add unit tests for UserAgent and the new WithUserAgent option

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
