### PR TITLE
🐋 Add support for new Ubuntu architectures to package-healthcheck

### DIFF
--- a/.github/workflows/package-healthcheck.yml
+++ b/.github/workflows/package-healthcheck.yml
@@ -258,86 +258,78 @@ jobs:
           mkdir -p /tmp/results
           echo "${cli_ver}" > "/tmp/results/${{ env.TRIPLET }}.txt"
 
-       - *upload_step
+      - *upload_step
 
-   linux-apt-emulated:
-     if: github.repository == 'kubetail-org/kubetail'
-     strategy:
-       fail-fast: false
-       matrix:
-         include:
-           # --- jammy (22.04) ---
-           - series: jammy
-             distro: ubuntu22.04
-             arch: armv7
-             ubuntu_arch: armhf
-           # --- noble (24.04) ---
-           - series: noble
-             distro: ubuntu24.04
-             arch: armv7
-             ubuntu_arch: armhf
-           # --- questing (25.10) ---
-           - series: questing
-             distro: ubuntu24.04
-             arch: armv7
-             ubuntu_arch: armhf
-           - series: questing
-             distro: ubuntu24.04
-             arch: ppc64le
-             ubuntu_arch: ppc64el
-           - series: questing
-             distro: ubuntu24.04
-             arch: riscv64
-             ubuntu_arch: riscv64
-           - series: questing
-             distro: ubuntu24.04
-             arch: s390x
-             ubuntu_arch: s390x
-           # --- resolute (26.04) ---
-           - series: resolute
-             distro: ubuntu24.04
-             arch: armv7
-             ubuntu_arch: armhf
-           - series: resolute
-             distro: ubuntu24.04
-             arch: ppc64le
-             ubuntu_arch: ppc64el
-           - series: resolute
-             distro: ubuntu24.04
-             arch: riscv64
-             ubuntu_arch: riscv64
-           - series: resolute
-             distro: ubuntu24.04
-             arch: s390x
-             ubuntu_arch: s390x
-     runs-on: ubuntu-24.04
-     env:
-       TRIPLET: apt_${{ matrix.series }}_${{ matrix.ubuntu_arch }}
-     steps:
-       - name: Test on ${{ matrix.arch }}
-         uses: uraimo/run-on-arch-action@v3
-         with:
-           arch: ${{ matrix.arch }}
-           distro: ${{ matrix.distro }}
-           githubToken: ${{ github.token }}
-           install: |
-             apt-get update
-             apt-get install -y software-properties-common curl jq
-           run: |
-             set -euxo pipefail
-             add-apt-repository -y ppa:kubetail/kubetail
-             apt-get update
-             apt-get install -y kubetail-cli
+  linux-apt-emulated:
+    if: github.repository == 'kubetail-org/kubetail'
+    strategy:
+      fail-fast: false
+      matrix:
+        series:
+          - jammy
+          - noble
+          - questing
+          - resolute
+        arch:
+          - armv7
+          - ppc64le
+          - riscv64
+          - s390x
+        include:
+          - series: jammy
+            distro: ubuntu22.04
+          - series: noble
+            distro: ubuntu24.04
+          - series: questing
+            distro: ubuntu_rolling
+          - series: resolute
+            distro: ubuntu_devel
+        exclude:
+          - series: jammy
+            arch: ppc64le
+          - series: jammy
+            arch: riscv64
+          - series: jammy
+            arch: s390x
+          - series: noble
+            arch: ppc64le
+          - series: noble
+            arch: riscv64
+          - series: noble
+            arch: s390x
+    runs-on: ubuntu-24.04
+    env:
+      TRIPLET: apt_${{ matrix.series }}_${{ matrix.arch }}
+    steps:
+      - name: Test on ${{ matrix.arch }}
+        uses: uraimo/run-on-arch-action@v3
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y software-properties-common curl jq
+          run: |
+            set -euxo pipefail
+            add-apt-repository -y ppa:kubetail/kubetail
+            apt-get update
+            apt-get install -y kubetail-cli
 
-             cli_ver="$(kubetail --version)"
+            cli_ver="$(kubetail --version)"
 
-             # Save result for summary table
-             mkdir -p /tmp/results
-             echo "${cli_ver}" > "/tmp/results/${{ env.TRIPLET }}.txt"
+            # Save result for summary table
+            mkdir -p "${GITHUB_WORKSPACE}/results"
+            echo "${cli_ver}" > "${GITHUB_WORKSPACE}/results/${{ env.TRIPLET }}.txt"
 
-       - *upload_step
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-${{ env.TRIPLET }}
+          path: results/*.txt
+          retention-days: 1
 
-   linux-copr:
+  linux-copr:
     if: github.repository == 'kubetail-org/kubetail'
     strategy:
       fail-fast: false
@@ -827,9 +819,9 @@ jobs:
     needs:
       - linux
       - linux-apk
-       - linux-apt
-       - linux-apt-emulated
-       - linux-copr
+      - linux-apt
+      - linux-apt-emulated
+      - linux-copr
       - linux-dnf
       - linux-snap
       - linux-zypper


### PR DESCRIPTION
Fixes #947

## Summary

Add support for testing additional Ubuntu architectures (armhf, ppc64el, riscv64, s390x) in the package-healthcheck workflow using run-on-arch-action.

## Changes

- Remove plucky from linux-apt job (not published to Launchpad)
- Add linux-apt-emulated job for testing non-native architectures:
  - jammy: armhf
  - noble: armhf
  - questing: armhf, ppc64el, riscv64, s390x
  - resolute: armhf, ppc64el, riscv64, s390x
- Update summary job to include linux-apt-emulated