### PR TITLE
📜  Fix incorrect hack/config.yaml path in CLAUDE.md Key Files section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,10 @@ Several components use code generation:
 - `dashboard-ui/package.json` - Frontend scripts and dependencies
 - `crates/rgkl/Cargo.toml` - Rust project configuration
 - `Tiltfile` - Local Kubernetes development setup
-- `modules/dashboard/hack/config.yaml` - Example configuration
+- `config/default/cli.yaml` - Default CLI configuration
+- `config/default/dashboard.yaml` - Default Dashboard configuration
+- `config/default/cluster-api.yaml` - Default ClusterAPI configuration
+- `config/default/cluster-agent.yaml` - Default ClusterAgent configuration
 - `hack/manifests/` - Test manifests
 - `hack/test-configs/` - Test configurations
 


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes # 

## Summary

In the "Key Files" section of `CLAUDE.md`, hack/config.yaml is listed as the example configuration path. However, this file does not exist.

## Changes

Updated `hack/config.yaml` to `modules/dashboard/hack/config.yaml` in the Key Files section. 

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
