### PR TITLE
✨ Remove CGO_ENABLED=0 from copr, macports, obs, guru publish workflows

### DIFF
--- a/.github/ci-config/copr/kubetail.spec.tmpl
+++ b/.github/ci-config/copr/kubetail.spec.tmpl
@@ -25,7 +25,6 @@ timeline, delivered to a browser or terminal.
 %build
 cd modules/cli && \
   GOWORK=off \
-  CGO_ENABLED=0 \
   go build \
     -mod=vendor \
     -ldflags="-s -w -X github.com/kubetail-org/kubetail/modules/cli/cmd.version=%{version}" \

--- a/.github/ci-config/guru/kubetail.ebuild
+++ b/.github/ci-config/guru/kubetail.ebuild
@@ -24,7 +24,6 @@ BDEPEND=">=dev-lang/go-1.24.7"
 src_compile() {
 	(
 		GOWORK=off \
-		CGO_ENABLED=0 \
 		ego build \
 			-mod=vendor \
 			-ldflags "-X github.com/kubetail-org/kubetail/modules/cli/cmd.version=${PV}" \

--- a/.github/ci-config/macports/Portfile.tmpl
+++ b/.github/ci-config/macports/Portfile.tmpl
@@ -28,8 +28,7 @@ checksums           ${distname}${extract.suffix} \
                     size    ${SIZE}
 
 build.env-append GO111MODULE=on \
-                 GOWORK=off \
-                 CGO_ENABLED=0
+                 GOWORK=off
 build.dir ${worksrcpath}/modules/cli
 build.args-append \
     -mod=vendor \

--- a/.github/ci-config/obs/kubetail-cli.spec.tmpl
+++ b/.github/ci-config/obs/kubetail-cli.spec.tmpl
@@ -25,7 +25,6 @@ timeline, delivered to a browser or terminal.
 %build
 cd modules/cli && \
   GOWORK=off \
-  CGO_ENABLED=0 \
   go build \
     -mod=vendor \
     -ldflags="-s -w -X github.com/kubetail-org/kubetail/modules/cli/cmd.version=%{version}" \


### PR DESCRIPTION
## Summary

This PR removes `CGO_ENABLED=0` from the remaining publish workflows that produce platform-specific builds (copr, macports, obs, guru).

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
