### PR TITLE
🐋 Add dashboard columns config option to CLI config schema

### DIFF
--- a/config/default/cli.json
+++ b/config/default/cli.json
@@ -15,5 +15,8 @@
       "port": 7500,
       "skip-open": false
     }
+  },
+  "dashboard": {
+    "columns": ["timestamp", "dot"]
   }
 }

--- a/config/default/cli.toml
+++ b/config/default/cli.toml
@@ -33,3 +33,7 @@ port = 7500
 
 # If true, don't automatically open browser when server starts
 skip-open = false
+
+[dashboard]
+# The default columns to show when displaying log records.
+columns = ["timestamp", "dot"]

--- a/config/default/cli.yaml
+++ b/config/default/cli.yaml
@@ -99,3 +99,19 @@ commands:
     # Default value: false
     #
     skip-open: false
+
+## dashboard ##
+#
+# Settings for the web dashboard UI
+#
+dashboard:
+
+  ## columns ##
+  #
+  # The default columns to show when displaying log records.
+  #
+  # Default value: ["timestamp", "dot"]
+  #
+  columns:
+    - timestamp
+    - dot

--- a/modules/cli/assets/config.json
+++ b/modules/cli/assets/config.json
@@ -15,5 +15,8 @@
       "port": 7500,
       "skip-open": false
     }
+  },
+  "dashboard": {
+    "columns": ["timestamp", "dot"]
   }
 }

--- a/modules/cli/assets/config.toml
+++ b/modules/cli/assets/config.toml
@@ -33,3 +33,7 @@ port = 7500
 
 # If true, don't automatically open browser when server starts
 skip-open = false
+
+[dashboard]
+# The default columns to show when displaying log records.
+columns = ["timestamp", "dot"]

--- a/modules/cli/assets/config.yaml
+++ b/modules/cli/assets/config.yaml
@@ -99,3 +99,19 @@ commands:
     # Default value: false
     #
     skip-open: false
+
+## dashboard ##
+#
+# Settings for the web dashboard UI
+#
+dashboard:
+
+  ## columns ##
+  #
+  # The default columns to show when displaying log records.
+  #
+  # Default value: ["timestamp", "dot"]
+  #
+  columns:
+    - timestamp
+    - dot

--- a/modules/cli/pkg/config/config.go
+++ b/modules/cli/pkg/config/config.go
@@ -54,6 +54,11 @@ type Config struct {
 			SkipOpen bool   `mapstructure:"skip-open"`
 		} `mapstructure:"serve"`
 	} `mapstructure:"commands"`
+
+	// Dashboard settings for the web UI
+	Dashboard struct {
+		Columns []string `mapstructure:"columns"`
+	} `mapstructure:"dashboard"`
 }
 
 // Validate config
@@ -74,6 +79,8 @@ func DefaultCLIConfig() *Config {
 	cfg.Commands.Serve.SkipOpen = false
 
 	cfg.General.KubeconfigPath = ""
+
+	cfg.Dashboard.Columns = []string{"timestamp", "dot"}
 
 	return cfg
 }

--- a/modules/cli/pkg/config/config_test.go
+++ b/modules/cli/pkg/config/config_test.go
@@ -37,6 +37,8 @@ commands:
     port: 8080
     host: "0.0.0.0"
     skip-open: true
+dashboard:
+  columns: ["timestamp", "dot", "pod"]
 `
 
 var invalidCLIConfig = `
@@ -60,6 +62,7 @@ func TestDefaultCLIConfig(t *testing.T) {
 	assert.Equal(t, "localhost", cfg.Commands.Serve.Host)
 	assert.Equal(t, false, cfg.Commands.Serve.SkipOpen)
 	assert.Equal(t, "", cfg.General.KubeconfigPath)
+	assert.Equal(t, []string{"timestamp", "dot"}, cfg.Dashboard.Columns)
 }
 
 func TestNewCLIConfigSuccess(t *testing.T) {
@@ -80,6 +83,7 @@ func TestNewCLIConfigSuccess(t *testing.T) {
 		assert.Equal(t, 8080, cfg.Commands.Serve.Port)
 		assert.Equal(t, "0.0.0.0", cfg.Commands.Serve.Host)
 		assert.Equal(t, true, cfg.Commands.Serve.SkipOpen)
+		assert.Equal(t, []string{"timestamp", "dot", "pod"}, cfg.Dashboard.Columns)
 	})
 
 	t.Run("with viper override", func(t *testing.T) {


### PR DESCRIPTION
Fixes #979 

## Summary

Add a new 'dashboard' section to the CLI configuration schema that allows users to configure dashboard-specific settings through their local config file ('~/.kubetail/config.yaml'). This follows the CLI config proposal - https://github.com/kubetail-org/cli-config-proposal/blob/main/config.yaml which defines the standard structure for this configuration.

Users can now configure the dashboard columns:

```yaml
dashboard:
  columns:
    - timestamp
    - dot
```

## Changes

-  Add `Dashboard` struct with `Columns` field to the `Config` type, set default value `["timestamp", "dot"]` in `DefaultCLIConfig()`
- Add test coverage for dashboard configuration (test fixtures and assertions)
-  Add dashboard section with columns option and documentation
-  Add dashboard section with columns option
- Add dashboard section with columns option
- Regenerated embedded config files via `go generate ./...`


## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]