### PR TITLE
🐋 Add support for default columns to Dashboard

### DIFF
--- a/config/default/dashboard.yaml
+++ b/config/default/dashboard.yaml
@@ -263,3 +263,15 @@ ui:
   # Default value: true
   #
   cluster-api-enabled: true
+
+  ## columns ##
+  #
+  # The default columns to display in the log viewer.
+  # Valid values: timestamp, dot, pod-container, region, zone, os, arch, node
+  # Note: The "message" column is always included automatically.
+  #
+  # Default value: ["timestamp", "dot"]
+  #
+  columns:
+    - timestamp
+    - dot

--- a/modules/dashboard/pkg/app/website.go
+++ b/modules/dashboard/pkg/app/website.go
@@ -74,6 +74,7 @@ func (app *websiteHandlers) EndpointHandler(cfg *config.Config) gin.HandlerFunc 
 		"environment":        cfg.Environment,
 		"clusterAPIEnabled":  cfg.UI.ClusterAPIEnabled,
 		"clusterAPIEndpoint": cfg.ClusterAPIEndpoint,
+		"columns":            cfg.UI.Columns,
 	}
 
 	runtimeConfigBytes, err := json.Marshal(runtimeConfig)

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -95,7 +95,8 @@ type Config struct {
 
 	// UI options
 	UI struct {
-		ClusterAPIEnabled bool `mapstructure:"cluster-api-enabled"`
+		ClusterAPIEnabled bool     `mapstructure:"cluster-api-enabled"`
+		Columns           []string `mapstructure:"columns"`
 	}
 }
 
@@ -133,6 +134,7 @@ func DefaultConfig() *Config {
 	cfg.TLS.CertFile = ""
 	cfg.TLS.KeyFile = ""
 	cfg.UI.ClusterAPIEnabled = true
+	cfg.UI.Columns = []string{"timestamp", "dot"}
 
 	return cfg
 }


### PR DESCRIPTION
Fixes #980 

## Summary

This PR adds support for configuring default columns in the Dashboard UI through the backend configuration. This allows users to customize which columns are displaeyd by default in the log viewer when using the in-cluster installation.

## Changes

- Added 'Columns []string' field to the UI struct in 'modules/dashboard/pkg/config/config.go' with default value '["timestamp", "dot"]'

- Added 'columns' to the 'runtimeConfig' map in 'modules/dashboard/pkg/app/website.go' to pass the configuration to the frontend

- Added documentation for the new 'columns' configuration option in 'config/default/dashboard.yaml'

  - Valid values: timestamp, dot, pod-container, region, zone, os, arch, node
  - Note: The 'message' column is always included automatically


## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit