### PR TITLE
🎣 Clicking on checkboxes in dashboard is flaky

### DIFF
--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -363,20 +363,20 @@ const DisplayWorkloadItems = memo(({ kind }: DisplayWorkloadItemsProps) => {
 
   const handleSingleCheckboxChange = useCallback(
     (id: string) => {
-      // update individual
-      const newValue = !isChecked.get(id);
-      const newIsChecked = new Map(isChecked);
-      newIsChecked.set(id, newValue);
-      setIsChecked(newIsChecked);
+      setIsChecked((prev) => {
+        const newMap = new Map(prev);
+        newMap.set(id, !prev.get(id));
 
-      // update selectAll based on all current items
-      const allItemsChecked = itemIDs.every((itemID) => newIsChecked.get(itemID) || false);
-      const someItemsUnchecked = itemIDs.some((itemID) => !newIsChecked.get(itemID));
+        // update selectAll based on all current items
+        const allItemsChecked = itemIDs.every((itemID) => newMap.get(itemID) || false);
+        const someItemsUnchecked = itemIDs.some((itemID) => !newMap.get(itemID));
+        if (allItemsChecked) setSelectAll(true);
+        if (someItemsUnchecked) setSelectAll(false);
 
-      if (allItemsChecked) setSelectAll(true);
-      if (someItemsUnchecked) setSelectAll(false);
+        return newMap;
+      });
     },
-    [itemIDs, isChecked, setSelectAll, setIsChecked],
+    [itemIDs, setSelectAll, setIsChecked],
   );
 
   const meta = useMemo(


### PR DESCRIPTION
Fixes #988

## Summary

Fix a bug where selecting a second pod checkbox would deselect the first. The root cause was a stale closure in `handleSingleCheckboxChange` because `MemoizedDataTableRow` skips re-rendering rows whose `isChecked` prop hasn't changed, those rows hold onto an outdated version of the handler that captures an old `isChecked map`. When triggered, the stale handler overwrites state with a map missing previously selected pods.

## Changes

Rewrote `handleSingleCheckboxChange` to use functional updater, so it always operates on latest state instead of the closure-captured `isChecked` which may be outdated in memoized rows

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
