### PR TITLE
✨ Replace flushSync workaround with native useFlushSync option

### DIFF
--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
@@ -369,9 +369,6 @@ export const useLoadMoreBefore = ({ client, config, refs, actions, services }: R
 
       const { scrollTop: prevScrollTop, scrollHeight: prevScrollHeight } = scrollElement;
 
-      // Hack to get around https://github.com/TanStack/virtual/issues/1094
-      services.virtualizer.isScrolling = false;
-
       const beforePaintPromise = services.beforePaint(() => {
         const nextScrollHeight = scrollElement.scrollHeight;
         scrollElement.scrollTop = prevScrollTop + (nextScrollHeight - prevScrollHeight);
@@ -400,9 +397,6 @@ export const useLoadMoreAfter = ({ client, config, actions, services }: Runtime)
 
     // Update UI
     if (result.records.length) {
-      // Hack to get around https://github.com/TanStack/virtual/issues/1094
-      services.virtualizer.isScrolling = false;
-
       services.recordStore.append(result.records);
     }
   }, [client, config.batchSizeRegular]);
@@ -487,9 +481,6 @@ export const useFollowFromEnd = ({ client, config, state, refs, services }: Runt
 
       const records = pendingRecords;
       pendingRecords = [];
-
-      // Hack to get around https://github.com/TanStack/virtual/issues/1094
-      services.virtualizer.isScrolling = false;
 
       // Scroll to bottom if auto-scroll enabled
       if (refs.isAutoScrollEnabled.current) {
@@ -700,6 +691,7 @@ export const LogViewerInner = ({
     overscan: config.overscan,
     scrollMargin: hasMoreBefore ? config.hasMoreBeforeRowHeight : 0,
     useScrollendEvent: true,
+    useFlushSync: false,
   });
 
   // Store virtualizer in ref for parent access


### PR DESCRIPTION
Fixes #1094

## Summary

The log viewer was bypassing `@tanstack/react-virtual`'s `flushSync` call by manually setting `virtualizer.isScrolling = false` as a workaround for [TanStack/virtual#1094](https://github.com/TanStack/virtual/issues/1094). TanStack Virtual now provides a native [`useFlushSync`](https://tanstack.com/virtual/latest/docs/framework/react/react-virtual#useflushsync) option to disable it. This PR switches to using the official API and removes the custom workaround code.

## Changes

- Added `useFlushSync: false` to the `useVirtualizer` options in `LogViewerInner`
- Removed 3 instances of the `services.virtualizer.isScrolling = false` hack in:
  - `useLoadMoreBefore`
  - `useLoadMoreAfter`
  - `useFollowFromEnd`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)