### PR TITLE
✨Remove unnecessary explicit WorkloadItem type annotations

### DIFF
--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -77,7 +77,6 @@ import {
   workloadIsFetchingAtomFamilies,
   filteredWorkloadItemsAtomFamilies,
 } from './state';
-import type { WorkloadItem } from './shared';
 import { useLogFileInfo } from './util';
 import { WorkloadDataProvider } from './workload-data-provider';
 
@@ -321,13 +320,13 @@ const DisplayWorkloadItems = memo(({ kind }: DisplayWorkloadItemsProps) => {
   const isFetching = useAtomValue(workloadIsFetchingAtomFamilies[kind](kubeContext));
   const items = useAtomValue(filteredWorkloadItemsAtomFamilies[kind](kubeContext));
 
-  const itemIDs: string[] = useMemo(() => items.map((item: WorkloadItem) => item.metadata.uid), [items]);
+  const itemIDs = useMemo(() => items.map((item) => item.metadata.uid), [items]);
 
   const logFileInfo = useLogFileInfo(kubeContext, itemIDs);
 
   const data = useMemo(
     () =>
-      items.map((item: WorkloadItem) => {
+      items.map((item) => {
         const fileInfo = logFileInfo.get(item.metadata.uid);
         return {
           id: item.metadata.uid,


### PR DESCRIPTION
## Summary

Remove unnecessary explicit `WorkloadItem` type annotations in `home/index.tsx`, as TypeScript can infer the types from the atom families.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [ ] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
