### PR TITLE
🐋 Add kubeContext support to ClusterVersionStatus

### DIFF
--- a/modules/dashboard/graph/schema.helpers.go
+++ b/modules/dashboard/graph/schema.helpers.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	gqlerrors "github.com/kubetail-org/kubetail/modules/shared/graphql/errors"
+	"github.com/kubetail-org/kubetail/modules/shared/helm"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/graph/model"
 	clusterapi "github.com/kubetail-org/kubetail/modules/dashboard/internal/cluster-api"
@@ -48,7 +49,18 @@ import (
 
 // helmReleaseGetter is an interface for getting a Helm release by name and namespace.
 type helmReleaseGetter interface {
-	GetRelease(namespace, releaseName string) (*release.Release, error)
+	GetReleaseForContext(kubeContext, namespace, releaseName string) (*release.Release, error)
+}
+
+// defaultHelmReleaseGetter implements helmReleaseGetter by creating a new
+// helm client per request, scoped to the given kubeContext.
+type defaultHelmReleaseGetter struct {
+	kubeconfigPath string
+}
+
+func (g *defaultHelmReleaseGetter) GetReleaseForContext(kubeContext, namespace, releaseName string) (*release.Release, error) {
+	client := helm.NewClient(helm.WithKubeconfigPath(g.kubeconfigPath), helm.WithKubeContext(kubeContext))
+	return client.GetRelease(namespace, releaseName)
 }
 
 // Represents response from fetchListResource()

--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -565,8 +565,9 @@ func (r *queryResolver) ClusterVersionStatus(ctx context.Context, kubeContext *s
 	var currentVersion string
 
 	if r.environment == sharedcfg.EnvironmentDesktop {
-		// Desktop mode: get the kubetail release from kubetail-system namespace
-		rel, err := r.helmReleaseGetter.GetRelease(helm.DefaultNamespace, helm.DefaultReleaseName)
+		// Desktop mode: get the kubetail release from kubetail-system namespace for the active kubeContext
+		kubeContextVal := r.cm.DerefKubeContext(kubeContext)
+		rel, err := r.helmReleaseGetter.GetReleaseForContext(kubeContextVal, helm.DefaultNamespace, helm.DefaultReleaseName)
 		if err != nil || rel == nil {
 			return nil, nil
 		}

--- a/modules/dashboard/graph/schema.resolvers_test.go
+++ b/modules/dashboard/graph/schema.resolvers_test.go
@@ -34,14 +34,20 @@ import (
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
-// mockHelmReleaseGetter implements helmReleaseGetter for testing.
-type mockHelmReleaseGetter struct {
-	release *release.Release
-	err     error
+// MockHelmReleaseGetter implements helmReleaseGetter for testing.
+type MockHelmReleaseGetter struct {
+	mock.Mock
 }
 
-func (m *mockHelmReleaseGetter) GetRelease(namespace, releaseName string) (*release.Release, error) {
-	return m.release, m.err
+func (m *MockHelmReleaseGetter) GetReleaseForContext(kubeContext, namespace, releaseName string) (*release.Release, error) {
+	ret := m.Called(kubeContext, namespace, releaseName)
+
+	var r0 *release.Release
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*release.Release)
+	}
+
+	return r0, ret.Error(1)
 }
 
 func makeRelease(name, version string) *release.Release {
@@ -389,14 +395,18 @@ func TestClusterVersionStatus_DesktopMode(t *testing.T) {
 				vc.On("GetLatestHelmChartVersion").Return(&versioncheck.VersionInfo{Version: tt.latestVersion}, nil)
 			}
 
+			cm := &k8shelpersmock.MockConnectionManager{}
+			cm.On("DerefKubeContext", mock.Anything).Return("")
+
+			hg := &MockHelmReleaseGetter{}
+			hg.On("GetReleaseForContext", mock.Anything, mock.Anything, mock.Anything).Return(tt.release, tt.getErr)
+
 			r := &queryResolver{&Resolver{
-				cfg:            &config.Config{},
-				environment:    sharedcfg.EnvironmentDesktop,
-				versionChecker: vc,
-				helmReleaseGetter: &mockHelmReleaseGetter{
-					release: tt.release,
-					err:     tt.getErr,
-				},
+				cfg:               &config.Config{},
+				cm:                cm,
+				environment:       sharedcfg.EnvironmentDesktop,
+				versionChecker:    vc,
+				helmReleaseGetter: hg,
 			}}
 
 			result, err := r.ClusterVersionStatus(context.Background(), nil)

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
-	"github.com/kubetail-org/kubetail/modules/shared/helm"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/versioncheck"
 
@@ -61,7 +60,7 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 		environment:       cfg.Environment,
 		allowedNamespaces: cfg.AllowedNamespaces,
 		versionChecker:    versioncheck.NewChecker(),
-		helmReleaseGetter: helm.NewClient(helm.WithKubeconfigPath(cfg.KubeconfigPath)),
+		helmReleaseGetter: &defaultHelmReleaseGetter{kubeconfigPath: cfg.KubeconfigPath},
 	}
 
 	// Init config


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes #1002 (backend dependency)

## Summary

Add kubeContext support to `ClusterVersionStatus()` in the dashboard backend so the GraphQL API returns the Helm chart version for the cluster associated with the active kubeContext. This is required for the frontend PR that will show cluster upgrade notifications in the health status indicator and bell popover (per-cluster information in desktop mode).

## Changes

* Extend `helmReleaseGetter` interface with `GetReleaseForContext(kubeContext, namespace, releaseName string)` instead of `GetRelease(namespace, releaseName string)`
* Add `GetReleaseForContext` to `helm.Client`: creates a context-scoped client when `kubeContext` is non-empty, otherwise uses the default context
* Update `ClusterVersionStatus` resolver to resolve the active context via `r.cm.DerefKubeContext(kubeContext)` and pass it to the getter
* Update mock and tests for the new interface and add `ConnectionManager` mock to the Desktop mode tests

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
