### PR TITLE
fix: prevent panic on closed channel in KubeConfigWatch

### DIFF
--- a/modules/dashboard/graph/schema.resolvers.go
+++ b/modules/dashboard/graph/schema.resolvers.go
@@ -1051,6 +1051,7 @@ func (r *subscriptionResolver) KubeConfigWatch(ctx context.Context) (<-chan *mod
 		}
 
 		defer sub.Drain()
+		defer sub.Unsubscribe()
 
 		// Wait for client close
 		<-ctx.Done()

--- a/modules/dashboard/internal/cluster-api/health-monitor.go
+++ b/modules/dashboard/internal/cluster-api/health-monitor.go
@@ -405,7 +405,8 @@ func (w *endpointSlicesHealthMonitorWorker) WatchHealthStatus(ctx context.Contex
 		// Wait for client to close
 		<-ctx.Done()
 
-		// Unsubscribe
+		// Stop receiving new messages, then drain pending ones
+		sub.Unsubscribe()
 		sub.Drain()
 
 		// Close output channel


### PR DESCRIPTION
## Summary
Fixes #1009.

**Root cause:** `KubeConfigWatch` calls `sub.Drain()` on context cancellation but never `sub.Unsubscribe()`. Megaphone's `deliver` keeps spawning callback goroutines that send on `outCh` after the deferred `close(outCh)` runs, causing `panic: send on closed channel`.

**Fix:** Added `defer sub.Unsubscribe()` after `defer sub.Drain()` so defers execute in LIFO order: Unsubscribe (stop new deliveries) -> Drain (wait for in-flight callbacks) -> close(outCh). Same pattern fixed in `health-monitor.go` which had the same missing `Unsubscribe` call.

## Changes
- `modules/dashboard/graph/schema.resolvers.go`: added `defer sub.Unsubscribe()` in `KubeConfigWatch`
- `modules/dashboard/internal/cluster-api/health-monitor.go`: added `sub.Unsubscribe()` before `sub.Drain()` in `SubscribeStatus`

## Testing
- Verified with `go vet`
- The cluster-api module already uses this pattern correctly (`sub.Unsubscribe()` at line 256)