### PR TITLE
🐋Add cluster upgrade notifications in server status and bell popover

### DIFF
--- a/dashboard-ui/src/components/layouts/AppLayout.tsx
+++ b/dashboard-ui/src/components/layouts/AppLayout.tsx
@@ -14,10 +14,10 @@
 
 import Footer from '@/components/widgets/Footer';
 import UpdateBanner from '@/components/widgets/UpdateBanner';
-import { useUpdateNotification } from '@/lib/update-notifications';
+import { useCLIUpdateNotification } from '@/lib/update-notifications';
 
 export default function AppLayout({ children }: React.PropsWithChildren) {
-  const { showBanner, currentVersion, latestVersion, dismiss, dontRemindMe } = useUpdateNotification();
+  const { showBanner, currentVersion, latestVersion, dismiss, dontRemindMe } = useCLIUpdateNotification();
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">

--- a/dashboard-ui/src/components/widgets/KubeContextPicker.tsx
+++ b/dashboard-ui/src/components/widgets/KubeContextPicker.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useSubscription } from '@apollo/client/react';
 import { useEffect } from 'react';
 
 import {
@@ -25,7 +24,7 @@ import {
   SelectValue,
 } from '@kubetail/ui/elements/select';
 
-import { KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
+import { useKubeConfig } from '@/lib/kubeconfig';
 
 /**
  * KubeContextPicker component
@@ -38,14 +37,16 @@ type KubeContextPickerProps = {
 };
 
 const KubeContextPicker = ({ className, value, setValue }: KubeContextPickerProps) => {
-  const { loading, data } = useSubscription(KUBE_CONFIG_WATCH);
-  const kubeConfig = data?.kubeConfigWatch?.object;
+  const { data, loading } = useKubeConfig();
+  const names = data?.contexts?.map((c) => c.name) ?? [];
+  const currentContext = data?.currentContext ?? null;
 
-  // Set default value
+  // Default to the kubeconfig's currentContext (falling back to the first name) once data arrives.
   useEffect(() => {
-    const kubeContext = kubeConfig?.currentContext;
-    if (kubeContext !== undefined) setValue(kubeContext);
-  }, [kubeConfig !== undefined]);
+    if (value !== null) return;
+    if (currentContext) setValue(currentContext);
+    else if (names.length > 0) setValue(names[0]);
+  }, [value, currentContext, names, setValue]);
 
   return (
     <Select value={value || ''} onValueChange={(v) => setValue(v)} disabled={loading}>
@@ -55,12 +56,11 @@ const KubeContextPicker = ({ className, value, setValue }: KubeContextPickerProp
       <SelectContent>
         <SelectGroup>
           <SelectLabel>Clusters</SelectLabel>
-          {kubeConfig &&
-            kubeConfig.contexts.map((context) => (
-              <SelectItem key={context.name} value={context.name}>
-                {context.name}
-              </SelectItem>
-            ))}
+          {names.map((name) => (
+            <SelectItem key={name} value={name}>
+              {name}
+            </SelectItem>
+          ))}
         </SelectGroup>
       </SelectContent>
     </Select>

--- a/dashboard-ui/src/components/widgets/KubeContextPicker.tsx
+++ b/dashboard-ui/src/components/widgets/KubeContextPicker.tsx
@@ -38,8 +38,12 @@ type KubeContextPickerProps = {
 
 const KubeContextPicker = ({ className, value, setValue }: KubeContextPickerProps) => {
   const { data, loading } = useKubeConfig();
-  const names = data?.contexts?.map((c) => c.name) ?? [];
   const currentContext = data?.currentContext ?? null;
+  const names = (() => {
+    const all = data?.contexts?.map((c) => c.name) ?? [];
+    if (!currentContext || !all.includes(currentContext)) return all;
+    return [currentContext, ...all.filter((n) => n !== currentContext)];
+  })();
 
   // Default to the kubeconfig's currentContext (falling back to the first name) once data arrives.
   useEffect(() => {

--- a/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
@@ -12,39 +12,70 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useSubscription } from '@apollo/client/react';
 import { ArrowUpCircle } from 'lucide-react';
 import { useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@kubetail/ui/elements/popover';
 
-import { useUpdateNotification } from '@/lib/update-notifications';
+import appConfig from '@/app-config';
+import * as dashboardOps from '@/lib/graphql/dashboard/ops';
+import { useCLIUpdateNotification, useClusterUpdateNotification } from '@/lib/update-notifications';
+
+const ClusterUpdateEntry = ({ kubeContext }: { kubeContext: string }) => {
+  const { updateAvailable, currentVersion, latestVersion } = useClusterUpdateNotification(kubeContext);
+
+  if (!updateAvailable || !latestVersion) return null;
+
+  return (
+    <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
+      <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
+      <p>
+        Cluster update: {currentVersion} → {latestVersion}
+      </p>
+    </div>
+  );
+};
+
+const useActiveKubeContext = (): string | null => {
+  const { data } = useSubscription(dashboardOps.KUBE_CONFIG_WATCH, {
+    skip: appConfig.environment !== 'desktop',
+  });
+  return data?.kubeConfigWatch?.object?.currentContext ?? null;
+};
 
 export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { updateAvailable, currentVersion, latestVersion } = useUpdateNotification();
+  const { updateAvailable, currentVersion, latestVersion } = useCLIUpdateNotification();
+  const activeKubeContext = useActiveKubeContext();
+  const { updateAvailable: clusterUpdateAvailable } = useClusterUpdateNotification(activeKubeContext ?? '');
+
+  const hasCliUpdate = updateAvailable && !!latestVersion;
+  const hasClusterUpdate = appConfig.environment === 'desktop' && !!activeKubeContext && clusterUpdateAvailable;
+  const hasNotifications = hasCliUpdate || hasClusterUpdate;
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <div className="relative h-full">
           {children}
-          {updateAvailable && <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-blue-500" />}
+          {hasNotifications && <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-blue-500" />}
         </div>
       </PopoverTrigger>
       {isOpen && (
         <PopoverContent side="top" className="w-80 mr-1">
           <div className="space-y-2">
             <p className="text-sm font-medium">Notifications</p>
-            {updateAvailable && latestVersion ? (
+            {hasCliUpdate && (
               <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
                 <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
                 <p>
                   CLI update: {currentVersion} → {latestVersion}
                 </p>
               </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">No new notifications</p>
             )}
+            {hasClusterUpdate && <ClusterUpdateEntry kubeContext={activeKubeContext} />}
+            {!hasNotifications && <p className="text-sm text-muted-foreground">No new notifications</p>}
           </div>
         </PopoverContent>
       )}

--- a/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
@@ -26,9 +26,16 @@ type ClusterUpdateInfo = {
   latestVersion: string | null;
 };
 
+const UpdateNotice = ({ children }: React.PropsWithChildren) => (
+  <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
+    <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
+    <p>{children}</p>
+  </div>
+);
+
 type ClusterUpdateSubscriberProps = {
   kubeContext: string;
-  onChange: (kubeContext: string, info: ClusterUpdateInfo) => void;
+  onChange: (kubeContext: string, info: ClusterUpdateInfo | null) => void;
 };
 
 /**
@@ -42,7 +49,7 @@ const ClusterUpdateSubscriber = ({ kubeContext, onChange }: ClusterUpdateSubscri
 
   useEffect(() => {
     onChange(kubeContext, { hasUpdate, currentVersion, latestVersion });
-    return () => onChange(kubeContext, { hasUpdate: false, currentVersion: null, latestVersion: null });
+    return () => onChange(kubeContext, null);
   }, [kubeContext, hasUpdate, currentVersion, latestVersion, onChange]);
 
   return null;
@@ -55,8 +62,14 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
 
   // Aggregated cluster update state by kubeContext, populated by long-lived subscribers below.
   const [clusterUpdates, setClusterUpdates] = useState<Record<string, ClusterUpdateInfo>>({});
-  const handleClusterUpdateChange = useCallback((kubeContext: string, info: ClusterUpdateInfo) => {
+  const handleClusterUpdateChange = useCallback((kubeContext: string, info: ClusterUpdateInfo | null) => {
     setClusterUpdates((prev) => {
+      if (info === null) {
+        if (!(kubeContext in prev)) return prev;
+        const next = { ...prev };
+        delete next[kubeContext];
+        return next;
+      }
       const cur = prev[kubeContext];
       if (
         cur &&
@@ -94,25 +107,16 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
           <div className="space-y-2">
             <p className="text-sm font-medium">Notifications</p>
             {hasCliUpdate && (
-              <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
-                <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                <p>
-                  CLI update: {currentVersion} → {latestVersion}
-                </p>
-              </div>
+              <UpdateNotice>
+                CLI update: {currentVersion} → {latestVersion}
+              </UpdateNotice>
             )}
             {clustersWithUpdates.map((ctx) => {
               const info = clusterUpdates[ctx];
               return (
-                <div
-                  key={ctx}
-                  className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100"
-                >
-                  <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                  <p>
-                    Cluster update ({ctx}): {info.currentVersion} → {info.latestVersion}
-                  </p>
-                </div>
+                <UpdateNotice key={ctx}>
+                  Cluster update ({ctx}): {info.currentVersion} → {info.latestVersion}
+                </UpdateNotice>
               );
             })}
             {!hasNotifications && <p className="text-sm text-muted-foreground">No new notifications</p>}

--- a/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useSubscription } from '@apollo/client/react';
 import { ArrowUpCircle } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@kubetail/ui/elements/popover';
 
 import appConfig from '@/app-config';
-import * as dashboardOps from '@/lib/graphql/dashboard/ops';
-import { useCLIUpdateNotification, useClusterUpdateNotification } from '@/lib/update-notifications';
+import { useCLIUpdateNotification, useClusterUpdateNotification, useKubeContexts } from '@/lib/update-notifications';
 
 type ClusterUpdateInfo = {
   hasUpdate: boolean;
@@ -48,13 +46,6 @@ const ClusterUpdateSubscriber = ({ kubeContext, onChange }: ClusterUpdateSubscri
   }, [kubeContext, hasUpdate, currentVersion, latestVersion, onChange]);
 
   return null;
-};
-
-const useKubeContexts = (): string[] => {
-  const { data } = useSubscription(dashboardOps.KUBE_CONFIG_WATCH, {
-    skip: appConfig.environment !== 'desktop',
-  });
-  return data?.kubeConfigWatch?.object?.contexts?.map((c) => c.name) ?? [];
 };
 
 export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {

--- a/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
@@ -13,18 +13,12 @@
 // limitations under the License.
 
 import { ArrowUpCircle } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@kubetail/ui/elements/popover';
 
 import appConfig from '@/app-config';
-import { useCLIUpdateNotification, useClusterUpdateNotification, useKubeContexts } from '@/lib/update-notifications';
-
-type ClusterUpdateInfo = {
-  hasUpdate: boolean;
-  currentVersion: string | null;
-  latestVersion: string | null;
-};
+import { useAllClusterUpdateViews, useCLIUpdateNotification, useHasAnyClusterUpdate } from '@/lib/update-notifications';
 
 const UpdateNotice = ({ children }: React.PropsWithChildren) => (
   <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
@@ -33,60 +27,14 @@ const UpdateNotice = ({ children }: React.PropsWithChildren) => (
   </div>
 );
 
-type ClusterUpdateSubscriberProps = {
-  kubeContext: string;
-  onChange: (kubeContext: string, info: ClusterUpdateInfo | null) => void;
-};
-
-/**
- * Invisible: reads cluster update state for one kubeContext and lifts it to the parent. Mounted
- * outside `PopoverContent` so the subscription survives the popover opening/closing — otherwise
- * the trigger dot would only reflect contexts evaluated since the last open.
- */
-const ClusterUpdateSubscriber = ({ kubeContext, onChange }: ClusterUpdateSubscriberProps) => {
-  const { updateAvailable, currentVersion, latestVersion } = useClusterUpdateNotification(kubeContext);
-  const hasUpdate = updateAvailable && !!latestVersion;
-
-  useEffect(() => {
-    onChange(kubeContext, { hasUpdate, currentVersion, latestVersion });
-    return () => onChange(kubeContext, null);
-  }, [kubeContext, hasUpdate, currentVersion, latestVersion, onChange]);
-
-  return null;
-};
-
 export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState(false);
   const { updateAvailable, currentVersion, latestVersion } = useCLIUpdateNotification();
-  const kubeContexts = useKubeContexts();
-
-  // Aggregated cluster update state by kubeContext, populated by long-lived subscribers below.
-  const [clusterUpdates, setClusterUpdates] = useState<Record<string, ClusterUpdateInfo>>({});
-  const handleClusterUpdateChange = useCallback((kubeContext: string, info: ClusterUpdateInfo | null) => {
-    setClusterUpdates((prev) => {
-      if (info === null) {
-        if (!(kubeContext in prev)) return prev;
-        const next = { ...prev };
-        delete next[kubeContext];
-        return next;
-      }
-      const cur = prev[kubeContext];
-      if (
-        cur &&
-        cur.hasUpdate === info.hasUpdate &&
-        cur.currentVersion === info.currentVersion &&
-        cur.latestVersion === info.latestVersion
-      ) {
-        return prev;
-      }
-      return { ...prev, [kubeContext]: info };
-    });
-  }, []);
+  const hasClusterUpdate = useHasAnyClusterUpdate();
+  const clusterViews = useAllClusterUpdateViews();
 
   const hasCliUpdate = updateAvailable && !!latestVersion;
-  const clustersWithUpdates =
-    appConfig.environment === 'desktop' ? kubeContexts.filter((ctx) => clusterUpdates[ctx]?.hasUpdate) : [];
-  const hasNotifications = hasCliUpdate || clustersWithUpdates.length > 0;
+  const hasNotifications = hasCliUpdate || (appConfig.environment === 'desktop' && hasClusterUpdate);
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -96,12 +44,6 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
           {hasNotifications && <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-blue-500" />}
         </div>
       </PopoverTrigger>
-      {/* Subscribers live outside PopoverContent so they stay mounted when the popover is closed,
-          keeping the trigger dot accurate across all kubeContexts at all times. */}
-      {appConfig.environment === 'desktop' &&
-        kubeContexts.map((ctx) => (
-          <ClusterUpdateSubscriber key={ctx} kubeContext={ctx} onChange={handleClusterUpdateChange} />
-        ))}
       {isOpen && (
         <PopoverContent side="top" className="w-80 mr-1">
           <div className="space-y-2">
@@ -111,14 +53,14 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
                 CLI update: {currentVersion} → {latestVersion}
               </UpdateNotice>
             )}
-            {clustersWithUpdates.map((ctx) => {
-              const info = clusterUpdates[ctx];
-              return (
-                <UpdateNotice key={ctx}>
-                  Cluster update ({ctx}): {info.currentVersion} → {info.latestVersion}
-                </UpdateNotice>
-              );
-            })}
+            {appConfig.environment === 'desktop' &&
+              clusterViews
+                .filter(({ view }) => view.updateAvailable && view.latestVersion)
+                .map(({ kubeContext, view }) => (
+                  <UpdateNotice key={kubeContext}>
+                    Cluster update ({kubeContext}): {view.currentVersion} → {view.latestVersion}
+                  </UpdateNotice>
+                ))}
             {!hasNotifications && <p className="text-sm text-muted-foreground">No new notifications</p>}
           </div>
         </PopoverContent>

--- a/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/NotificationsPopover.tsx
@@ -14,7 +14,7 @@
 
 import { useSubscription } from '@apollo/client/react';
 import { ArrowUpCircle } from 'lucide-react';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@kubetail/ui/elements/popover';
 
@@ -22,37 +22,67 @@ import appConfig from '@/app-config';
 import * as dashboardOps from '@/lib/graphql/dashboard/ops';
 import { useCLIUpdateNotification, useClusterUpdateNotification } from '@/lib/update-notifications';
 
-const ClusterUpdateEntry = ({ kubeContext }: { kubeContext: string }) => {
-  const { updateAvailable, currentVersion, latestVersion } = useClusterUpdateNotification(kubeContext);
-
-  if (!updateAvailable || !latestVersion) return null;
-
-  return (
-    <div className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
-      <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
-      <p>
-        Cluster update: {currentVersion} → {latestVersion}
-      </p>
-    </div>
-  );
+type ClusterUpdateInfo = {
+  hasUpdate: boolean;
+  currentVersion: string | null;
+  latestVersion: string | null;
 };
 
-const useActiveKubeContext = (): string | null => {
+type ClusterUpdateSubscriberProps = {
+  kubeContext: string;
+  onChange: (kubeContext: string, info: ClusterUpdateInfo) => void;
+};
+
+/**
+ * Invisible: reads cluster update state for one kubeContext and lifts it to the parent. Mounted
+ * outside `PopoverContent` so the subscription survives the popover opening/closing — otherwise
+ * the trigger dot would only reflect contexts evaluated since the last open.
+ */
+const ClusterUpdateSubscriber = ({ kubeContext, onChange }: ClusterUpdateSubscriberProps) => {
+  const { updateAvailable, currentVersion, latestVersion } = useClusterUpdateNotification(kubeContext);
+  const hasUpdate = updateAvailable && !!latestVersion;
+
+  useEffect(() => {
+    onChange(kubeContext, { hasUpdate, currentVersion, latestVersion });
+    return () => onChange(kubeContext, { hasUpdate: false, currentVersion: null, latestVersion: null });
+  }, [kubeContext, hasUpdate, currentVersion, latestVersion, onChange]);
+
+  return null;
+};
+
+const useKubeContexts = (): string[] => {
   const { data } = useSubscription(dashboardOps.KUBE_CONFIG_WATCH, {
     skip: appConfig.environment !== 'desktop',
   });
-  return data?.kubeConfigWatch?.object?.currentContext ?? null;
+  return data?.kubeConfigWatch?.object?.contexts?.map((c) => c.name) ?? [];
 };
 
 export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState(false);
   const { updateAvailable, currentVersion, latestVersion } = useCLIUpdateNotification();
-  const activeKubeContext = useActiveKubeContext();
-  const { updateAvailable: clusterUpdateAvailable } = useClusterUpdateNotification(activeKubeContext ?? '');
+  const kubeContexts = useKubeContexts();
+
+  // Aggregated cluster update state by kubeContext, populated by long-lived subscribers below.
+  const [clusterUpdates, setClusterUpdates] = useState<Record<string, ClusterUpdateInfo>>({});
+  const handleClusterUpdateChange = useCallback((kubeContext: string, info: ClusterUpdateInfo) => {
+    setClusterUpdates((prev) => {
+      const cur = prev[kubeContext];
+      if (
+        cur &&
+        cur.hasUpdate === info.hasUpdate &&
+        cur.currentVersion === info.currentVersion &&
+        cur.latestVersion === info.latestVersion
+      ) {
+        return prev;
+      }
+      return { ...prev, [kubeContext]: info };
+    });
+  }, []);
 
   const hasCliUpdate = updateAvailable && !!latestVersion;
-  const hasClusterUpdate = appConfig.environment === 'desktop' && !!activeKubeContext && clusterUpdateAvailable;
-  const hasNotifications = hasCliUpdate || hasClusterUpdate;
+  const clustersWithUpdates =
+    appConfig.environment === 'desktop' ? kubeContexts.filter((ctx) => clusterUpdates[ctx]?.hasUpdate) : [];
+  const hasNotifications = hasCliUpdate || clustersWithUpdates.length > 0;
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -62,6 +92,12 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
           {hasNotifications && <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-blue-500" />}
         </div>
       </PopoverTrigger>
+      {/* Subscribers live outside PopoverContent so they stay mounted when the popover is closed,
+          keeping the trigger dot accurate across all kubeContexts at all times. */}
+      {appConfig.environment === 'desktop' &&
+        kubeContexts.map((ctx) => (
+          <ClusterUpdateSubscriber key={ctx} kubeContext={ctx} onChange={handleClusterUpdateChange} />
+        ))}
       {isOpen && (
         <PopoverContent side="top" className="w-80 mr-1">
           <div className="space-y-2">
@@ -74,7 +110,20 @@ export const NotificationsPopover = ({ children }: React.PropsWithChildren) => {
                 </p>
               </div>
             )}
-            {hasClusterUpdate && <ClusterUpdateEntry kubeContext={activeKubeContext} />}
+            {clustersWithUpdates.map((ctx) => {
+              const info = clusterUpdates[ctx];
+              return (
+                <div
+                  key={ctx}
+                  className="flex items-start gap-2 rounded border border-blue-200 bg-blue-50 p-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100"
+                >
+                  <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>
+                    Cluster update ({ctx}): {info.currentVersion} → {info.latestVersion}
+                  </p>
+                </div>
+              );
+            })}
             {!hasNotifications && <p className="text-sm text-muted-foreground">No new notifications</p>}
           </div>
         </PopoverContent>

--- a/dashboard-ui/src/components/widgets/ServerStatus.tsx
+++ b/dashboard-ui/src/components/widgets/ServerStatus.tsx
@@ -20,7 +20,6 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } 
 import { Table, TableBody, TableCell, TableRow } from '@kubetail/ui/elements/table';
 
 import appConfig from '@/app-config';
-import ClusterAPIInstallButton from '@/components/widgets/ClusterAPIInstallButton';
 import * as dashboardOps from '@/lib/graphql/dashboard/ops';
 import {
   ServerStatus,
@@ -29,6 +28,7 @@ import {
   useKubernetesAPIServerStatus,
   useClusterAPIServerStatus,
 } from '@/lib/server-status';
+import { useClusterUpdateNotification } from '@/lib/update-notifications';
 import { cn } from '@/lib/util';
 
 const kubernetesAPIServerStatusMapState = atom(new Map<string, ServerStatus>());
@@ -56,6 +56,9 @@ const HealthDot = ({ className, status }: { className?: string; status: Status }
     case Status.Unknown:
       color = 'chrome';
       break;
+    case Status.UpdateAvailable:
+      color = 'blue';
+      break;
     default:
       throw new Error('not implemented');
   }
@@ -67,6 +70,7 @@ const HealthDot = ({ className, status }: { className?: string; status: Status }
         'bg-red-500': color === 'red',
         'bg-green-500': color === 'green',
         'bg-yellow-500': color === 'yellow',
+        'bg-blue-500': color === 'blue',
       })}
     />
   );
@@ -170,6 +174,9 @@ const KubernetesAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: Se
 const ClusterAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: ServerStatusRowProps) => {
   const serverStatusMap = useAtomValue(clusterAPIServerStatusMapState);
   const serverStatus = serverStatusMap.get(kubeContext) || new ServerStatus();
+  const { updateAvailable } = useClusterUpdateNotification(appConfig.environment === 'desktop' ? kubeContext : '');
+
+  const showClusterUpdate = appConfig.environment === 'desktop' && updateAvailable;
 
   return (
     <TableRow>
@@ -179,13 +186,10 @@ const ClusterAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: Serve
       ) : (
         <>
           <TableCell className="w-px">
-            <HealthDot status={serverStatus.status} />
+            <HealthDot status={showClusterUpdate ? Status.UpdateAvailable : serverStatus.status} />
           </TableCell>
-          <TableCell className="whitespace-normal flex justify-between items-center">
-            {statusMessage(serverStatus, 'Uknown')}
-            {appConfig.environment === 'desktop' && serverStatus.status === Status.NotFound && (
-              <ClusterAPIInstallButton kubeContext={kubeContext} />
-            )}
+          <TableCell className="whitespace-normal">
+            {showClusterUpdate ? 'Update available' : statusMessage(serverStatus, 'Uknown')}
           </TableCell>
         </>
       )}

--- a/dashboard-ui/src/components/widgets/ServerStatus.tsx
+++ b/dashboard-ui/src/components/widgets/ServerStatus.tsx
@@ -26,7 +26,8 @@ import {
   useKubernetesAPIServerStatus,
   useClusterAPIServerStatus,
 } from '@/lib/server-status';
-import { useClusterUpdateNotification, useKubeContexts } from '@/lib/update-notifications';
+import { useKubeConfig } from '@/lib/kubeconfig';
+import { useClusterUpdateNotification } from '@/lib/update-notifications';
 import { cn } from '@/lib/util';
 
 const kubernetesAPIServerStatusMapState = atom(new Map<string, ServerStatus>());
@@ -223,7 +224,8 @@ type ServerStatusWidgetProps = {
 };
 
 const ServerStatusWidget = ({ className, healthDotClassName }: ServerStatusWidgetProps) => {
-  const kubeContexts = useKubeContexts();
+  const { data } = useKubeConfig();
+  const kubeContexts = appConfig.environment !== 'desktop' ? [''] : (data?.contexts?.map((c) => c.name) ?? []);
 
   const dashboardServerStatus = useDashboardServerStatus();
   const kubernetesAPIServertatusMap = useAtomValue(kubernetesAPIServerStatusMapState);

--- a/dashboard-ui/src/components/widgets/ServerStatus.tsx
+++ b/dashboard-ui/src/components/widgets/ServerStatus.tsx
@@ -56,9 +56,6 @@ const HealthDot = ({ className, status }: { className?: string; status: Status }
     case Status.Unknown:
       color = 'chrome';
       break;
-    case Status.UpdateAvailable:
-      color = 'blue';
-      break;
     default:
       throw new Error('not implemented');
   }
@@ -70,7 +67,6 @@ const HealthDot = ({ className, status }: { className?: string; status: Status }
         'bg-red-500': color === 'red',
         'bg-green-500': color === 'green',
         'bg-yellow-500': color === 'yellow',
-        'bg-blue-500': color === 'blue',
       })}
     />
   );
@@ -176,7 +172,8 @@ const ClusterAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: Serve
   const serverStatus = serverStatusMap.get(kubeContext) || new ServerStatus();
   const { updateAvailable } = useClusterUpdateNotification(appConfig.environment === 'desktop' ? kubeContext : '');
 
-  const showClusterUpdate = appConfig.environment === 'desktop' && updateAvailable;
+  const isInstalled = serverStatus.status !== Status.NotFound && serverStatus.status !== Status.Unknown;
+  const showClusterUpdate = appConfig.environment === 'desktop' && updateAvailable && isInstalled;
 
   return (
     <TableRow>
@@ -186,10 +183,27 @@ const ClusterAPIServerStatusRow = ({ kubeContext, dashboardServerStatus }: Serve
       ) : (
         <>
           <TableCell className="w-px">
-            <HealthDot status={showClusterUpdate ? Status.UpdateAvailable : serverStatus.status} />
+            <HealthDot status={serverStatus.status} />
           </TableCell>
           <TableCell className="whitespace-normal">
-            {showClusterUpdate ? 'Update available' : statusMessage(serverStatus, 'Uknown')}
+            <div className="flex flex-wrap items-center gap-2">
+              <span>{statusMessage(serverStatus, 'Uknown')}</span>
+              {appConfig.environment === 'desktop' && serverStatus.status === Status.NotFound && (
+                <a
+                  href="https://docs.kubetail.com/guides/cluster/installation"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="rounded border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs text-blue-900 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100 dark:hover:bg-blue-900"
+                >
+                  Install
+                </a>
+              )}
+              {showClusterUpdate && (
+                <span className="rounded border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">
+                  Update available
+                </span>
+              )}
+            </div>
           </TableCell>
         </>
       )}

--- a/dashboard-ui/src/components/widgets/ServerStatus.tsx
+++ b/dashboard-ui/src/components/widgets/ServerStatus.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useSubscription } from '@apollo/client/react';
 import { Fragment, useEffect } from 'react';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 
@@ -20,7 +19,6 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } 
 import { Table, TableBody, TableCell, TableRow } from '@kubetail/ui/elements/table';
 
 import appConfig from '@/app-config';
-import * as dashboardOps from '@/lib/graphql/dashboard/ops';
 import {
   ServerStatus,
   Status,
@@ -28,7 +26,7 @@ import {
   useKubernetesAPIServerStatus,
   useClusterAPIServerStatus,
 } from '@/lib/server-status';
-import { useClusterUpdateNotification } from '@/lib/update-notifications';
+import { useClusterUpdateNotification, useKubeContexts } from '@/lib/update-notifications';
 import { cn } from '@/lib/util';
 
 const kubernetesAPIServerStatusMapState = atom(new Map<string, ServerStatus>());
@@ -225,14 +223,7 @@ type ServerStatusWidgetProps = {
 };
 
 const ServerStatusWidget = ({ className, healthDotClassName }: ServerStatusWidgetProps) => {
-  const { data } = useSubscription(dashboardOps.KUBE_CONFIG_WATCH, { skip: appConfig.environment === 'cluster' });
-
-  const kubeContexts = new Array<string>();
-  if (appConfig.environment === 'cluster') {
-    kubeContexts.push('');
-  } else {
-    data?.kubeConfigWatch?.object?.contexts.map((context) => kubeContexts.push(context.name));
-  }
+  const kubeContexts = useKubeContexts();
 
   const dashboardServerStatus = useDashboardServerStatus();
   const kubernetesAPIServertatusMap = useAtomValue(kubernetesAPIServerStatusMapState);

--- a/dashboard-ui/src/lib/kubeconfig.tsx
+++ b/dashboard-ui/src/lib/kubeconfig.tsx
@@ -1,0 +1,44 @@
+// Copyright 2024-2025 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useSubscription } from '@apollo/client/react';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+import appConfig from '@/app-config';
+import { KubeConfigFragmentFragment } from '@/lib/graphql/dashboard/__generated__/graphql';
+import { KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
+
+const IS_DESKTOP = appConfig.environment === 'desktop';
+
+type KubeConfigState = { data: KubeConfigFragmentFragment | null; loading: boolean };
+
+export const kubeConfigAtom = atom<KubeConfigState>({ data: null, loading: IS_DESKTOP });
+
+/** Mounts once at the app root. Owns the single KUBE_CONFIG_WATCH subscription. */
+export function KubeConfigEffect() {
+  const setState = useSetAtom(kubeConfigAtom);
+  const { data, loading } = useSubscription(KUBE_CONFIG_WATCH, { skip: !IS_DESKTOP });
+
+  useEffect(() => {
+    const nextData = data?.kubeConfigWatch?.object ?? null;
+    setState((prev) => (prev.data === nextData && prev.loading === loading ? prev : { data: nextData, loading }));
+  }, [data, loading, setState]);
+
+  return null;
+}
+
+export function useKubeConfig(): KubeConfigState {
+  return useAtomValue(kubeConfigAtom);
+}

--- a/dashboard-ui/src/lib/server-status.ts
+++ b/dashboard-ui/src/lib/server-status.ts
@@ -27,6 +27,7 @@ export const enum Status {
   Degraded = 'DEGRADED',
   Unknown = 'UNKNOWN',
   NotFound = 'NOTFOUND',
+  UpdateAvailable = 'UPDATE_AVAILABLE',
 }
 
 export class ServerStatus {

--- a/dashboard-ui/src/lib/server-status.ts
+++ b/dashboard-ui/src/lib/server-status.ts
@@ -27,7 +27,6 @@ export const enum Status {
   Degraded = 'DEGRADED',
   Unknown = 'UNKNOWN',
   NotFound = 'NOTFOUND',
-  UpdateAvailable = 'UPDATE_AVAILABLE',
 }
 
 export class ServerStatus {

--- a/dashboard-ui/src/lib/update-notifications.test.tsx
+++ b/dashboard-ui/src/lib/update-notifications.test.tsx
@@ -16,15 +16,39 @@ import type { MockedResponse } from '@apollo/client/testing';
 import { act, screen, waitFor } from '@testing-library/react';
 
 import appConfig from '@/app-config';
-import { CLI_LATEST_VERSION } from '@/lib/graphql/dashboard/ops';
+import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
 import { renderElement } from '@/test-utils';
 
-import { UpdateNotificationProvider, useUpdateNotification, compareSemver } from './update-notifications';
+import {
+  compareSemver,
+  UpdateNotificationProvider,
+  useCLIUpdateNotification,
+  useClusterUpdateNotification,
+} from './update-notifications';
 
 const STORAGE_KEY = 'kubetail:updates:cli';
 
+/** Satisfies KUBE_CONFIG_WATCH inside UpdateNotificationProvider for CLI-only tests. */
+const notificationProviderKubeMock: MockedResponse = {
+  request: { query: KUBE_CONFIG_WATCH },
+  maxUsageCount: 20,
+  result: {
+    data: {
+      kubeConfigWatch: {
+        __typename: 'KubeConfigWatchEvent',
+        type: 'ADDED',
+        object: {
+          __typename: 'KubeConfig',
+          currentContext: '',
+          contexts: [],
+        },
+      },
+    },
+  },
+};
+
 function TestConsumer() {
-  const { showBanner, updateAvailable, latestVersion } = useUpdateNotification();
+  const { showBanner, updateAvailable, latestVersion } = useCLIUpdateNotification();
   return (
     <div>
       {showBanner && <span data-testid="banner-visible">visible</span>}
@@ -38,7 +62,7 @@ function renderWithProvider(mocks: MockedResponse[]) {
     <UpdateNotificationProvider>
       <TestConsumer />
     </UpdateNotificationProvider>,
-    mocks,
+    [notificationProviderKubeMock, ...mocks],
   );
 }
 
@@ -81,7 +105,7 @@ describe('compareSemver', () => {
   });
 });
 
-describe('useUpdateNotification', () => {
+describe('useCLIUpdateNotification', () => {
   it('does not show banner immediately (respects delay)', () => {
     renderWithProvider([latestVersionMock]);
     expect(screen.queryByTestId('banner-visible')).not.toBeInTheDocument();
@@ -161,6 +185,204 @@ describe('useUpdateNotification', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('banner-visible')).not.toBeInTheDocument();
+    });
+  });
+});
+
+const CLUSTER_STORAGE_PREFIX = 'kubetail:updates:cluster:';
+const KUBE_CONTEXT = 'test-cluster';
+
+/** Keeps CLI query satisfied while cluster tests run under UpdateNotificationProvider. */
+const clusterTestCliMock: MockedResponse = {
+  request: { query: CLI_LATEST_VERSION },
+  result: { data: { cliLatestVersion: '0.9.0' } },
+};
+
+function kubeConfigWatchMock(contextNames: string[], currentContext?: string): MockedResponse {
+  return {
+    request: { query: KUBE_CONFIG_WATCH },
+    result: {
+      data: {
+        kubeConfigWatch: {
+          type: 'ADDED',
+          object: {
+            currentContext: currentContext ?? contextNames[0] ?? '',
+            contexts: contextNames.map((name) => ({ name, cluster: 'c', namespace: 'default' })),
+          },
+        },
+      },
+    },
+  };
+}
+
+function ClusterTestConsumer({ kubeContext = KUBE_CONTEXT }: { kubeContext?: string }) {
+  const { updateAvailable, currentVersion, latestVersion } = useClusterUpdateNotification(kubeContext);
+  return (
+    <div>
+      {updateAvailable && <span data-testid="cluster-update">{latestVersion}</span>}
+      {currentVersion && <span data-testid="current-version">{currentVersion}</span>}
+    </div>
+  );
+}
+
+function renderClusterWithMocks(
+  mocks: MockedResponse[],
+  kubeContext?: string,
+  kubeContextNames: string[] = [KUBE_CONTEXT],
+) {
+  return renderElement(
+    <UpdateNotificationProvider>
+      <ClusterTestConsumer kubeContext={kubeContext} />
+    </UpdateNotificationProvider>,
+    [clusterTestCliMock, kubeConfigWatchMock(kubeContextNames), ...mocks],
+  );
+}
+
+const clusterUpdateAvailableMock: MockedResponse = {
+  request: { query: CLUSTER_VERSION_STATUS, variables: { kubeContext: KUBE_CONTEXT } },
+  result: {
+    data: { clusterVersionStatus: { currentVersion: '0.9.0', latestVersion: '1.0.0', updateAvailable: true } },
+  },
+};
+
+const clusterNoUpdateMock: MockedResponse = {
+  request: { query: CLUSTER_VERSION_STATUS, variables: { kubeContext: KUBE_CONTEXT } },
+  result: {
+    data: { clusterVersionStatus: { currentVersion: '1.0.0', latestVersion: '1.0.0', updateAvailable: false } },
+  },
+};
+
+const clusterNullResultMock: MockedResponse = {
+  request: { query: CLUSTER_VERSION_STATUS, variables: { kubeContext: KUBE_CONTEXT } },
+  result: { data: { clusterVersionStatus: null } },
+};
+
+const clusterErrorMock: MockedResponse = {
+  request: { query: CLUSTER_VERSION_STATUS, variables: { kubeContext: KUBE_CONTEXT } },
+  error: new Error('Internal Server Error'),
+};
+
+describe('useClusterUpdateNotification', () => {
+  it('shows update notification when updateAvailable is true', async () => {
+    renderClusterWithMocks([clusterUpdateAvailableMock]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cluster-update')).toBeInTheDocument();
+      expect(screen.getByTestId('cluster-update')).toHaveTextContent('1.0.0');
+    });
+  });
+
+  it('does not show update notification when updateAvailable is false', async () => {
+    renderClusterWithMocks([clusterNoUpdateMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show notification when dismissed less than 24h ago', async () => {
+    localStorage.setItem(`${CLUSTER_STORAGE_PREFIX}${KUBE_CONTEXT}`, JSON.stringify({ dismissedAt: Date.now() }));
+    renderClusterWithMocks([clusterUpdateAvailableMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show notification when version is in skipped list', async () => {
+    localStorage.setItem(`${CLUSTER_STORAGE_PREFIX}${KUBE_CONTEXT}`, JSON.stringify({ skippedVersions: ['1.0.0'] }));
+    renderClusterWithMocks([clusterUpdateAvailableMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('fails silently when query returns null', async () => {
+    renderClusterWithMocks([clusterNullResultMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('fails silently when query errors', async () => {
+    renderClusterWithMocks([clusterErrorMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('uses cached data when cache is fresh', async () => {
+    localStorage.setItem(
+      `${CLUSTER_STORAGE_PREFIX}${KUBE_CONTEXT}`,
+      JSON.stringify({
+        currentVersion: '0.9.0',
+        latestVersion: '0.9.0',
+        fetchedAt: Date.now(),
+      }),
+    );
+
+    renderClusterWithMocks([]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('skips query when environment is not desktop', async () => {
+    Object.defineProperty(appConfig, 'environment', { value: 'cluster', writable: true });
+    renderClusterWithMocks([clusterUpdateAvailableMock]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keys state per kubeContext', async () => {
+    const context2 = 'other-cluster';
+    const mock2: MockedResponse = {
+      request: { query: CLUSTER_VERSION_STATUS, variables: { kubeContext: context2 } },
+      result: {
+        data: { clusterVersionStatus: { currentVersion: '0.8.0', latestVersion: '1.0.0', updateAvailable: true } },
+      },
+    };
+
+    localStorage.setItem(`${CLUSTER_STORAGE_PREFIX}${KUBE_CONTEXT}`, JSON.stringify({ dismissedAt: Date.now() }));
+
+    renderClusterWithMocks([clusterUpdateAvailableMock, mock2], context2, [KUBE_CONTEXT, context2]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cluster-update')).toHaveTextContent('1.0.0');
     });
   });
 });

--- a/dashboard-ui/src/lib/update-notifications.test.tsx
+++ b/dashboard-ui/src/lib/update-notifications.test.tsx
@@ -17,7 +17,7 @@ import { act, screen, waitFor } from '@testing-library/react';
 
 import appConfig from '@/app-config';
 import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
-import { renderElement } from '@/test-utils';
+import { renderElement, withAppConfig } from '@/test-utils';
 
 import {
   compareSemver,
@@ -356,15 +356,16 @@ describe('useClusterUpdateNotification', () => {
   });
 
   it('skips query when environment is not desktop', async () => {
-    Object.defineProperty(appConfig, 'environment', { value: 'cluster', writable: true });
-    renderClusterWithMocks([clusterUpdateAvailableMock]);
+    await withAppConfig({ environment: 'cluster' }, async () => {
+      renderClusterWithMocks([clusterUpdateAvailableMock]);
 
-    await act(async () => {
-      vi.advanceTimersByTime(1000);
-    });
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId('cluster-update')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useQuery } from '@apollo/client/react';
+import { useQuery, useSubscription } from '@apollo/client/react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import appConfig from '@/app-config';
-import { CLI_LATEST_VERSION } from '@/lib/graphql/dashboard/ops';
+import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
 
-const STORAGE_KEY = 'kubetail:updates:cli';
+/**
+ * CLI vs cluster update hints: localStorage + Apollo, exposed via separate React contexts.
+ *
+ * Layout:
+ * - Persistence + cache helpers (this file, top)
+ * - `ClusterVersionSubscriber`: one `CLUSTER_VERSION_STATUS` query per kubeContext on desktop
+ * - `UpdateNotificationProvider`: wires CLI + cluster subscribers and context providers
+ * - `useCLIUpdateNotification` / `useClusterUpdateNotification`: read-only hooks for UI
+ */
+
+const STORAGE_KEY_CLI = 'kubetail:updates:cli';
+const CLUSTER_STORAGE_PREFIX = 'kubetail:updates:cluster:';
 
 const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 const DISMISS_TTL_MS = 24 * 60 * 60 * 1000;
@@ -29,6 +40,62 @@ interface UpdateState {
   fetchedAt?: number;
   dismissedAt?: number;
   skippedVersions?: string[];
+}
+
+interface ClusterUpdateState extends UpdateState {
+  currentVersion?: string;
+}
+
+// --- localStorage (CLI key + one blob per kubeContext)
+function clusterStorageKey(kubeContext: string): string {
+  return `${CLUSTER_STORAGE_PREFIX}${kubeContext}`;
+}
+
+function readPersisted<T extends object>(storageKey: string): T {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return {} as T;
+    return JSON.parse(raw) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
+function writePersisted(storageKey: string, state: object) {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(state));
+  } catch {
+    // fail silently
+  }
+}
+
+function patchPersisted<T extends object>(storageKey: string, patch: Partial<T>) {
+  writePersisted(storageKey, { ...readPersisted<T>(storageKey), ...patch });
+}
+
+function readCLIState(): UpdateState {
+  return readPersisted<UpdateState>(STORAGE_KEY_CLI);
+}
+
+function readClusterState(kubeContext: string): ClusterUpdateState {
+  return readPersisted<ClusterUpdateState>(clusterStorageKey(kubeContext));
+}
+
+function patchCLIState(patch: Partial<UpdateState>) {
+  patchPersisted(STORAGE_KEY_CLI, patch);
+}
+
+function patchClusterState(kubeContext: string, patch: Partial<ClusterUpdateState>) {
+  patchPersisted(clusterStorageKey(kubeContext), patch);
+}
+
+// Cache TTL (avoid hammering the network; still respect dismiss/skip in the view builders)
+function isCLICacheValid(state: UpdateState): boolean {
+  return !!state.latestVersion && !!state.fetchedAt && Date.now() - state.fetchedAt < CACHE_TTL_MS;
+}
+
+function isClusterCacheValid(state: ClusterUpdateState): boolean {
+  return state.fetchedAt !== undefined && Date.now() - state.fetchedAt < CACHE_TTL_MS;
 }
 
 export function compareSemver(a: string, b: string): number {
@@ -42,100 +109,317 @@ export function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-function readState(): UpdateState {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    return JSON.parse(raw);
-  } catch {
-    return {};
-  }
-}
-
-function writeState(state: UpdateState) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    // fail silently
-  }
-}
-
-function patchState(patch: Partial<UpdateState>) {
-  writeState({ ...readState(), ...patch });
-}
-
-function isCacheValid(state: UpdateState): boolean {
-  return !!state.latestVersion && !!state.fetchedAt && Date.now() - state.fetchedAt < CACHE_TTL_MS;
-}
-
-export interface UpdateNotificationState {
-  showBanner: boolean;
-  currentVersion: string;
+// Public shapes for hooks
+interface BaseUpdateNotificationState {
   latestVersion: string | null;
-  updateAvailable: boolean;
   dismiss: () => void;
   dontRemindMe: () => void;
 }
 
-const UpdateNotificationContext = createContext({} as UpdateNotificationState);
+export interface UpdateNotificationState extends BaseUpdateNotificationState {
+  showBanner: boolean;
+  currentVersion: string;
+  updateAvailable: boolean;
+}
 
+export interface ClusterUpdateNotificationState extends BaseUpdateNotificationState {
+  updateAvailable: boolean;
+  currentVersion: string | null;
+}
+
+type ClusterVersionQuerySnapshot = {
+  data?: {
+    clusterVersionStatus?: {
+      currentVersion?: string | null;
+      latestVersion?: string | null;
+      updateAvailable: boolean;
+    } | null;
+  } | null;
+  error?: Error;
+  loading: boolean;
+};
+
+type ClusterNotificationsRegistry = {
+  querySnapshots: Record<string, ClusterVersionQuerySnapshot>;
+};
+
+// CLI value vs cluster registry are split so CLI-only UI does not subscribe to cluster updates.
+const CLIUpdateNotificationContext = createContext({} as UpdateNotificationState);
+const ClusterNotificationsContext = createContext<ClusterNotificationsRegistry | null>(null);
+const ClusterNotificationsInvalidateContext = createContext<(() => void) | null>(null);
+
+/** Derive what to show for one kubeContext from persisted state + latest Apollo snapshot. */
+function buildClusterNotificationView(
+  kubeContext: string,
+  snapshot: ClusterVersionQuerySnapshot | undefined,
+  dismiss: () => void,
+  dontRemindMe: () => void,
+): ClusterUpdateNotificationState {
+  const persisted = readClusterState(kubeContext);
+  const cacheValid = isClusterCacheValid(persisted);
+  const data = snapshot?.data;
+
+  const currentVersion = cacheValid
+    ? (persisted.currentVersion ?? null)
+    : (data?.clusterVersionStatus?.currentVersion ?? null);
+
+  const latestVersion = cacheValid
+    ? (persisted.latestVersion ?? null)
+    : (data?.clusterVersionStatus?.latestVersion ?? null);
+
+  const queryUpdateAvailable = cacheValid
+    ? currentVersion !== null && latestVersion !== null && currentVersion !== latestVersion
+    : (data?.clusterVersionStatus?.updateAvailable ?? false);
+
+  const dismissed = persisted.dismissedAt !== undefined && Date.now() - persisted.dismissedAt < DISMISS_TTL_MS;
+  const skipped = latestVersion !== null && (persisted.skippedVersions ?? []).includes(latestVersion);
+  const updateAvailable = queryUpdateAvailable && !dismissed && !skipped;
+
+  return {
+    updateAvailable,
+    currentVersion,
+    latestVersion,
+    dismiss,
+    dontRemindMe,
+  };
+}
+
+/**
+ * Invisible per-context worker: runs `CLUSTER_VERSION_STATUS`, mirrors results into `querySnapshots`,
+ * and refreshes localStorage after a successful fetch (or error) so the cache stays coherent.
+ */
+function ClusterVersionSubscriber({
+  kubeContext,
+  bumpCluster,
+  setSnapshot,
+}: {
+  kubeContext: string;
+  bumpCluster: () => void;
+  setSnapshot: (ctx: string, snap: ClusterVersionQuerySnapshot) => void;
+}) {
+  const isDesktop = appConfig.environment === 'desktop';
+  const [persisted, setPersisted] = useState(() => readClusterState(kubeContext));
+
+  useEffect(() => {
+    setPersisted(readClusterState(kubeContext));
+  }, [kubeContext]);
+
+  const cacheValid = isClusterCacheValid(persisted);
+
+  // Skip while we already have a fresh persisted row (see patch effect below).
+  const { data, error, loading } = useQuery(CLUSTER_VERSION_STATUS, {
+    skip: !isDesktop || !kubeContext || cacheValid,
+    variables: { kubeContext },
+    fetchPolicy: 'network-only',
+  });
+
+  useEffect(() => {
+    setSnapshot(kubeContext, { data, error, loading });
+  }, [kubeContext, data, error, loading, setSnapshot]);
+
+  // After load: persist versions (or mark fetch time on failure), then refresh registry (see bumpCluster).
+  useEffect(() => {
+    if (!isDesktop || !kubeContext || cacheValid) return;
+    if (loading) return;
+
+    if (error) {
+      patchClusterState(kubeContext, {
+        fetchedAt: Date.now(),
+        currentVersion: undefined,
+        latestVersion: undefined,
+      });
+      setPersisted(readClusterState(kubeContext));
+      bumpCluster();
+      return;
+    }
+
+    if (data === undefined) return;
+
+    const result = data.clusterVersionStatus;
+    if (result) {
+      patchClusterState(kubeContext, {
+        currentVersion: result.currentVersion,
+        latestVersion: result.latestVersion,
+        fetchedAt: Date.now(),
+      });
+    } else {
+      patchClusterState(kubeContext, {
+        fetchedAt: Date.now(),
+        currentVersion: undefined,
+        latestVersion: undefined,
+      });
+    }
+    setPersisted(readClusterState(kubeContext));
+    bumpCluster();
+  }, [data, error, loading, isDesktop, kubeContext, cacheValid, bumpCluster]);
+
+  return null;
+}
+
+/**
+ * Root provider: CLI banner state + one `ClusterVersionSubscriber` per kubeContext (desktop).
+ * Children render after subscribers so snapshots exist before hooks in descendants run.
+ */
 export function UpdateNotificationProvider({ children }: React.PropsWithChildren) {
   const isDesktop = appConfig.environment === 'desktop';
-  const currentVersion = appConfig.cliVersion;
+  const currentVersionCLI = appConfig.cliVersion;
   const [ready, setReady] = useState(false);
-  const [state, setState] = useState(() => readState());
-  const [now] = useState(() => Date.now());
+  const [cliPersisted, setCLIPersisted] = useState(() => readCLIState());
+  const [mountedAt] = useState(() => Date.now());
 
-  const cacheValid = isCacheValid(state);
+  const cliCacheValid = isCLICacheValid(cliPersisted);
 
+  // Desktop: watch kubeconfig so we know which contexts exist (cluster mode uses a single synthetic context).
+  const { data: kubeData } = useSubscription(KUBE_CONFIG_WATCH, {
+    skip: appConfig.environment !== 'desktop',
+  });
+
+  const kubeContexts = useMemo(() => {
+    if (appConfig.environment === 'cluster') return [''];
+    const contexts = kubeData?.kubeConfigWatch?.object?.contexts;
+    return contexts?.map((c) => c.name) ?? [];
+  }, [kubeData]);
+
+  // Cluster registry: Apollo snapshots per kubeContext; `bumpCluster` shallow-copies the map to invalidate
+  // consumers when only localStorage changed (dismiss/skip) or after persist without a new Apollo payload.
+  const [querySnapshots, setQuerySnapshots] = useState<Record<string, ClusterVersionQuerySnapshot>>({});
+
+  const bumpCluster = useCallback(() => {
+    setQuerySnapshots((prev) => ({ ...prev }));
+  }, []);
+
+  const setSnapshot = useCallback((kubeContext: string, snap: ClusterVersionQuerySnapshot) => {
+    setQuerySnapshots((prev) => {
+      const cur = prev[kubeContext];
+      if (cur && cur.data === snap.data && cur.error === snap.error && cur.loading === snap.loading) {
+        return prev;
+      }
+      return { ...prev, [kubeContext]: snap };
+    });
+  }, []);
+
+  const clusterRegistry = useMemo(() => ({ querySnapshots }), [querySnapshots]);
+
+  // Delay showing the CLI banner so it does not flash on cold load.
   useEffect(() => {
     const timer = setTimeout(() => setReady(true), SHOW_DELAY_MS);
     return () => clearTimeout(timer);
   }, []);
 
-  const { data } = useQuery(CLI_LATEST_VERSION, {
-    skip: !isDesktop || !currentVersion || cacheValid,
+  const { data: cliQueryData } = useQuery(CLI_LATEST_VERSION, {
+    skip: !isDesktop || !currentVersionCLI || cliCacheValid,
     fetchPolicy: 'network-only',
   });
 
   useEffect(() => {
-    const version = data?.cliLatestVersion;
-    if (version) patchState({ latestVersion: version, fetchedAt: Date.now() });
-  }, [data]);
+    const version = cliQueryData?.cliLatestVersion;
+    if (version) patchCLIState({ latestVersion: version, fetchedAt: Date.now() });
+  }, [cliQueryData]);
 
-  const latestVersion = cacheValid ? state.latestVersion! : (data?.cliLatestVersion ?? null);
+  const latestVersionCLI = cliCacheValid ? cliPersisted.latestVersion! : (cliQueryData?.cliLatestVersion ?? null);
 
-  const updateAvailable =
-    currentVersion !== '' && latestVersion !== null && compareSemver(latestVersion, currentVersion) > 0;
+  const cliUpdateAvailable =
+    currentVersionCLI !== '' && latestVersionCLI !== null && compareSemver(latestVersionCLI, currentVersionCLI) > 0;
 
-  const dismissed = state.dismissedAt !== undefined && now - state.dismissedAt < DISMISS_TTL_MS;
-  const skipped = latestVersion !== null && (state.skippedVersions ?? []).includes(latestVersion);
-  const hasUpdate = updateAvailable && !skipped;
+  // `mountedAt` is fixed at provider mount so dismiss TTL is stable for this session (matches prior behavior).
+  const cliDismissed = cliPersisted.dismissedAt !== undefined && mountedAt - cliPersisted.dismissedAt < DISMISS_TTL_MS;
+  const cliSkipped = latestVersionCLI !== null && (cliPersisted.skippedVersions ?? []).includes(latestVersionCLI);
+  const cliHasUpdate = cliUpdateAvailable && !cliSkipped;
 
-  const showBanner = ready && !dismissed && hasUpdate;
+  const showBanner = ready && !cliDismissed && cliHasUpdate;
 
-  const dismiss = useCallback(() => {
-    patchState({ dismissedAt: Date.now() });
-    setState(readState());
+  const dismissCLI = useCallback(() => {
+    patchCLIState({ dismissedAt: Date.now() });
+    setCLIPersisted(readCLIState());
   }, []);
 
-  const dontRemindMe = useCallback(() => {
-    const { skippedVersions = [] } = readState();
-    if (latestVersion && !skippedVersions.includes(latestVersion)) {
-      skippedVersions.push(latestVersion);
+  const dontRemindCLI = useCallback(() => {
+    const { skippedVersions = [] } = readCLIState();
+    if (latestVersionCLI && !skippedVersions.includes(latestVersionCLI)) {
+      skippedVersions.push(latestVersionCLI);
     }
-    patchState({ skippedVersions, dismissedAt: Date.now() });
-    setState(readState());
-  }, [latestVersion]);
+    patchCLIState({ skippedVersions, dismissedAt: Date.now() });
+    setCLIPersisted(readCLIState());
+  }, [latestVersionCLI]);
 
-  const value = useMemo(
-    () => ({ showBanner, currentVersion, latestVersion, updateAvailable, dismiss, dontRemindMe }),
-    [showBanner, currentVersion, latestVersion, updateAvailable, dismiss, dontRemindMe],
+  const cliValue = useMemo(
+    () => ({
+      showBanner,
+      currentVersion: currentVersionCLI,
+      latestVersion: latestVersionCLI,
+      updateAvailable: cliUpdateAvailable,
+      dismiss: dismissCLI,
+      dontRemindMe: dontRemindCLI,
+    }),
+    [showBanner, currentVersionCLI, latestVersionCLI, cliUpdateAvailable, dismissCLI, dontRemindCLI],
   );
 
-  return <UpdateNotificationContext.Provider value={value}>{children}</UpdateNotificationContext.Provider>;
+  return (
+    <CLIUpdateNotificationContext.Provider value={cliValue}>
+      {/* Invalidate is separate from registry data: dismiss/remind only needs the callback, not the snapshot map. */}
+      <ClusterNotificationsInvalidateContext.Provider value={bumpCluster}>
+        <ClusterNotificationsContext.Provider value={clusterRegistry}>
+          {kubeContexts.map((ctx) => (
+            <ClusterVersionSubscriber
+              key={ctx || '__default__'}
+              kubeContext={ctx}
+              bumpCluster={bumpCluster}
+              setSnapshot={setSnapshot}
+            />
+          ))}
+          {children}
+        </ClusterNotificationsContext.Provider>
+      </ClusterNotificationsInvalidateContext.Provider>
+    </CLIUpdateNotificationContext.Provider>
+  );
 }
 
-export function useUpdateNotification(): UpdateNotificationState {
-  return useContext(UpdateNotificationContext);
+/** Latest CLI update banner state (no cluster context subscription). */
+export function useCLIUpdateNotification(): UpdateNotificationState {
+  return useContext(CLIUpdateNotificationContext);
+}
+
+/** Per-kubeContext cluster update row; reads shared registry + bumps via invalidate after mutations. */
+export function useClusterUpdateNotification(kubeContext: string): ClusterUpdateNotificationState {
+  const clusterRegistry = useContext(ClusterNotificationsContext);
+  const invalidateClusterNotifications = useContext(ClusterNotificationsInvalidateContext);
+
+  const dismissCluster = useCallback(() => {
+    if (!clusterRegistry || !invalidateClusterNotifications) return;
+    patchClusterState(kubeContext, { dismissedAt: Date.now() });
+    invalidateClusterNotifications();
+  }, [kubeContext, clusterRegistry, invalidateClusterNotifications]);
+
+  const dontRemindCluster = useCallback(() => {
+    if (!clusterRegistry || !invalidateClusterNotifications) return;
+    const persisted = readClusterState(kubeContext);
+    const valid = isClusterCacheValid(persisted);
+    const snap = clusterRegistry.querySnapshots[kubeContext];
+    const lv = valid ? (persisted.latestVersion ?? null) : (snap?.data?.clusterVersionStatus?.latestVersion ?? null);
+    const { skippedVersions = [] } = persisted;
+    if (lv && !skippedVersions.includes(lv)) {
+      skippedVersions.push(lv);
+    }
+    patchClusterState(kubeContext, { skippedVersions, dismissedAt: Date.now() });
+    invalidateClusterNotifications();
+  }, [kubeContext, clusterRegistry, invalidateClusterNotifications]);
+
+  const clusterView = useMemo(() => {
+    if (!clusterRegistry) {
+      return {
+        updateAvailable: false,
+        currentVersion: null,
+        latestVersion: null,
+        dismiss: dismissCluster,
+        dontRemindMe: dontRemindCluster,
+      } as ClusterUpdateNotificationState;
+    }
+    return buildClusterNotificationView(
+      kubeContext,
+      clusterRegistry.querySnapshots[kubeContext],
+      dismissCluster,
+      dontRemindCluster,
+    );
+  }, [kubeContext, clusterRegistry, dismissCluster, dontRemindCluster]);
+  return clusterView;
 }

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -18,16 +18,6 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import appConfig from '@/app-config';
 import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
 
-/**
- * CLI vs cluster update hints: localStorage + Apollo, exposed via separate React contexts.
- *
- * Layout:
- * - Persistence + cache helpers (this file, top)
- * - `ClusterVersionSubscriber`: one `CLUSTER_VERSION_STATUS` query per kubeContext on desktop
- * - `UpdateNotificationProvider`: wires CLI + cluster subscribers and context providers
- * - `useCLIUpdateNotification` / `useClusterUpdateNotification`: read-only hooks for UI
- */
-
 const STORAGE_KEY_CLI = 'kubetail:updates:cli';
 const CLUSTER_STORAGE_PREFIX = 'kubetail:updates:cluster:';
 
@@ -46,7 +36,6 @@ interface ClusterUpdateState extends UpdateState {
   currentVersion?: string;
 }
 
-// --- localStorage (CLI key + one blob per kubeContext)
 function clusterStorageKey(kubeContext: string): string {
   return `${CLUSTER_STORAGE_PREFIX}${kubeContext}`;
 }
@@ -89,7 +78,6 @@ function patchClusterState(kubeContext: string, patch: Partial<ClusterUpdateStat
   patchPersisted(clusterStorageKey(kubeContext), patch);
 }
 
-// Cache TTL (avoid hammering the network; still respect dismiss/skip in the view builders)
 function isCLICacheValid(state: UpdateState): boolean {
   return !!state.latestVersion && !!state.fetchedAt && Date.now() - state.fetchedAt < CACHE_TTL_MS;
 }
@@ -109,7 +97,6 @@ export function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-// Public shapes for hooks
 interface BaseUpdateNotificationState {
   latestVersion: string | null;
   dismiss: () => void;

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useQuery, useSubscription } from '@apollo/client/react';
+import { useQuery } from '@apollo/client/react';
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { atomFamily } from 'jotai-family';
 import { useEffect, useMemo } from 'react';
 
 import appConfig from '@/app-config';
-import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
+import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS } from '@/lib/graphql/dashboard/ops';
+import { kubeConfigAtom, useKubeConfig } from '@/lib/kubeconfig';
 
 const STORAGE_KEY_CLI = 'kubetail:updates:cli';
 const CLUSTER_STORAGE_PREFIX = 'kubetail:updates:cluster:';
@@ -84,7 +85,6 @@ const clusterPersistedAtomFamily = atomFamily((kubeContext: string) =>
   atomWithStorage<ClusterUpdateState>(`${CLUSTER_STORAGE_PREFIX}${kubeContext}`, {}),
 );
 
-const kubeContextsAtom = atom<string[]>([]);
 const readyAtom = atom(false);
 
 // --- Derived view atoms
@@ -131,12 +131,11 @@ const clusterViewAtomFamily = atomFamily((kubeContext: string) =>
   }),
 );
 
-const allClusterViewsAtom = atom((get) =>
-  get(kubeContextsAtom).map((kubeContext) => ({
-    kubeContext,
-    view: get(clusterViewAtomFamily(kubeContext)),
-  })),
-);
+const allClusterViewsAtom = atom((get) => {
+  const cfg = get(kubeConfigAtom);
+  const names = appConfig.environment !== 'desktop' ? [''] : (cfg.data?.contexts?.map((c) => c.name) ?? []);
+  return names.map((kubeContext) => ({ kubeContext, view: get(clusterViewAtomFamily(kubeContext)) }));
+});
 
 const hasAnyClusterUpdateAtom = atom((get) => get(allClusterViewsAtom).some(({ view }) => view.updateAvailable));
 
@@ -188,28 +187,14 @@ function ClusterVersionFetcher({ kubeContext }: { kubeContext: string }) {
 }
 
 /**
- * Wires CLI + per-kubeContext fetchers, mirrors kubeconfig contexts into `kubeContextsAtom`, and
- * schedules the show-delay timer. All state lives in atoms; this component only runs side effects.
+ * Mounts the kubeconfig subscriber, the CLI fetcher, and one cluster fetcher per kubeContext.
+ * All shared state lives in atoms; this component only runs side effects.
  */
 export function UpdateNotificationProvider({ children }: React.PropsWithChildren) {
   const isDesktop = appConfig.environment === 'desktop';
-  const setKubeContexts = useSetAtom(kubeContextsAtom);
   const setReady = useSetAtom(readyAtom);
-  const kubeContexts = useAtomValue(kubeContextsAtom);
-
-  const { data: kubeData } = useSubscription(KUBE_CONFIG_WATCH, { skip: !isDesktop });
-
-  const nextKubeContexts = useMemo(() => {
-    if (!isDesktop) return [''];
-    return kubeData?.kubeConfigWatch?.object?.contexts?.map((c) => c.name) ?? [];
-  }, [kubeData, isDesktop]);
-
-  useEffect(() => {
-    setKubeContexts((prev) => {
-      if (prev.length === nextKubeContexts.length && prev.every((v, i) => v === nextKubeContexts[i])) return prev;
-      return nextKubeContexts;
-    });
-  }, [nextKubeContexts, setKubeContexts]);
+  const { data } = useKubeConfig();
+  const kubeContexts = isDesktop ? (data?.contexts?.map((c) => c.name) ?? []) : [''];
 
   // Delay showing the CLI banner so it does not flash on cold load.
   useEffect(() => {
@@ -255,10 +240,6 @@ export function useClusterUpdateNotification(kubeContext: string): ClusterUpdate
   const view = useAtomValue(clusterViewAtomFamily(kubeContext));
   const setPersisted = useSetAtom(clusterPersistedAtomFamily(kubeContext));
   return useMemo(() => ({ ...view, ...buildDismissHandlers(setPersisted, view.latestVersion) }), [view, setPersisted]);
-}
-
-export function useKubeContexts(): string[] {
-  return useAtomValue(kubeContextsAtom);
 }
 
 export function useHasAnyClusterUpdate(): boolean {

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -144,12 +144,12 @@ type ClusterNotificationsRegistry = {
   // Bumped when localStorage changes (dismiss/skip) without an accompanying snapshot update.
   // Snapshot changes alone don't bump it — they already invalidate via querySnapshots identity.
   localStorageVersion: number;
+  invalidate: () => void;
 };
 
 // CLI value vs cluster registry are split so CLI-only UI does not subscribe to cluster updates.
 const CLIUpdateNotificationContext = createContext({} as UpdateNotificationState);
 const ClusterNotificationsContext = createContext<ClusterNotificationsRegistry | null>(null);
-const ClusterNotificationsInvalidateContext = createContext<(() => void) | null>(null);
 
 // Exposed so consumers (e.g. NotificationsPopover) can iterate kubeContexts without opening a
 // second KUBE_CONFIG_WATCH subscription. `null` distinguishes "outside the provider" from "no
@@ -199,17 +199,17 @@ function buildClusterNotificationView(
 function ClusterVersionSubscriber({
   kubeContext,
   setSnapshot,
+  invalidate,
 }: {
   kubeContext: string;
   setSnapshot: (ctx: string, snap: ClusterVersionQuerySnapshot) => void;
+  invalidate: () => void;
 }) {
   const isDesktop = appConfig.environment === 'desktop';
-  const [persisted, setPersisted] = useState(() => readClusterState(kubeContext));
-
-  useEffect(() => {
-    setPersisted(readClusterState(kubeContext));
-  }, [kubeContext]);
-
+  // Derive persisted state during render rather than mirroring it into useState — the only writer
+  // is this component's own effect (and the dismiss/skip handlers via `invalidate`), and both
+  // bump the provider's localStorageVersion which re-renders us.
+  const persisted = readClusterState(kubeContext);
   const cacheValid = isClusterCacheValid(persisted);
 
   // Skip while we already have a fresh persisted row (see patch effect below).
@@ -223,8 +223,9 @@ function ClusterVersionSubscriber({
     setSnapshot(kubeContext, { data, error, loading });
   }, [kubeContext, data, error, loading, setSnapshot]);
 
-  // After load: persist versions (or mark fetch time on failure). Consumers re-derive automatically
-  // because `setSnapshot` (called in the effect above) changes the registry's `querySnapshots` identity.
+  // After load: persist versions (or mark fetch time on failure), then bump the provider's
+  // localStorageVersion so we (and any consumer) re-render and pick up the fresh persisted row.
+  // `setSnapshot` already drives consumer re-derivation for the snapshot half of the registry.
   useEffect(() => {
     if (!isDesktop || !kubeContext || cacheValid) return;
     if (loading) return;
@@ -235,7 +236,7 @@ function ClusterVersionSubscriber({
         currentVersion: undefined,
         latestVersion: undefined,
       });
-      setPersisted(readClusterState(kubeContext));
+      invalidate();
       return;
     }
 
@@ -255,8 +256,8 @@ function ClusterVersionSubscriber({
         latestVersion: undefined,
       });
     }
-    setPersisted(readClusterState(kubeContext));
-  }, [data, error, loading, isDesktop, kubeContext, cacheValid]);
+    invalidate();
+  }, [data, error, loading, isDesktop, kubeContext, cacheValid, invalidate]);
 
   return null;
 }
@@ -305,9 +306,9 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
     });
   }, []);
 
-  const clusterRegistry = useMemo(
-    () => ({ querySnapshots, localStorageVersion }),
-    [querySnapshots, localStorageVersion],
+  const clusterRegistry = useMemo<ClusterNotificationsRegistry>(
+    () => ({ querySnapshots, localStorageVersion, invalidate: invalidateLocalStorage }),
+    [querySnapshots, localStorageVersion, invalidateLocalStorage],
   );
 
   // Delay showing the CLI banner so it does not flash on cold load.
@@ -366,17 +367,19 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
 
   return (
     <CLIUpdateNotificationContext.Provider value={cliValue}>
-      {/* Invalidate is separate from registry data: dismiss/remind only needs the callback. */}
-      <ClusterNotificationsInvalidateContext.Provider value={invalidateLocalStorage}>
-        <ClusterNotificationsContext.Provider value={clusterRegistry}>
-          <KubeContextsContext.Provider value={kubeContexts}>
-            {kubeContexts.map((ctx) => (
-              <ClusterVersionSubscriber key={ctx || '__default__'} kubeContext={ctx} setSnapshot={setSnapshot} />
-            ))}
-            {children}
-          </KubeContextsContext.Provider>
-        </ClusterNotificationsContext.Provider>
-      </ClusterNotificationsInvalidateContext.Provider>
+      <ClusterNotificationsContext.Provider value={clusterRegistry}>
+        <KubeContextsContext.Provider value={kubeContexts}>
+          {kubeContexts.map((ctx) => (
+            <ClusterVersionSubscriber
+              key={ctx || '__default__'}
+              kubeContext={ctx}
+              setSnapshot={setSnapshot}
+              invalidate={invalidateLocalStorage}
+            />
+          ))}
+          {children}
+        </KubeContextsContext.Provider>
+      </ClusterNotificationsContext.Provider>
     </CLIUpdateNotificationContext.Provider>
   );
 }
@@ -398,16 +401,15 @@ export function useKubeContexts(): string[] {
 /** Per-kubeContext cluster update row; reads shared registry + bumps via invalidate after mutations. */
 export function useClusterUpdateNotification(kubeContext: string): ClusterUpdateNotificationState {
   const clusterRegistry = useContext(ClusterNotificationsContext);
-  const invalidateClusterNotifications = useContext(ClusterNotificationsInvalidateContext);
 
   const dismissCluster = useCallback(() => {
-    if (!clusterRegistry || !invalidateClusterNotifications) return;
+    if (!clusterRegistry) return;
     patchClusterState(kubeContext, { dismissedAt: Date.now() });
-    invalidateClusterNotifications();
-  }, [kubeContext, clusterRegistry, invalidateClusterNotifications]);
+    clusterRegistry.invalidate();
+  }, [kubeContext, clusterRegistry]);
 
   const dontRemindCluster = useCallback(() => {
-    if (!clusterRegistry || !invalidateClusterNotifications) return;
+    if (!clusterRegistry) return;
     const persisted = readClusterState(kubeContext);
     const valid = isClusterCacheValid(persisted);
     const snap = clusterRegistry.querySnapshots[kubeContext];
@@ -417,8 +419,8 @@ export function useClusterUpdateNotification(kubeContext: string): ClusterUpdate
       skippedVersions.push(lv);
     }
     patchClusterState(kubeContext, { skippedVersions, dismissedAt: Date.now() });
-    invalidateClusterNotifications();
-  }, [kubeContext, clusterRegistry, invalidateClusterNotifications]);
+    clusterRegistry.invalidate();
+  }, [kubeContext, clusterRegistry]);
 
   const clusterView = useMemo(() => {
     if (!clusterRegistry) {

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -115,8 +115,9 @@ type ClusterView = Omit<ClusterUpdateNotificationState, 'dismiss' | 'dontRemindM
 const clusterViewAtomFamily = atomFamily((kubeContext: string) =>
   atom<ClusterView>((get) => {
     const persisted = get(clusterPersistedAtomFamily(kubeContext));
-    const currentVersion = persisted.currentVersion ?? null;
-    const latestVersion = persisted.latestVersion ?? null;
+    const cacheValid = isClusterCacheValid(persisted);
+    const currentVersion = cacheValid ? (persisted.currentVersion ?? null) : null;
+    const latestVersion = cacheValid ? (persisted.latestVersion ?? null) : null;
 
     const updateAvailable =
       currentVersion !== null && latestVersion !== null && compareSemver(latestVersion, currentVersion) > 0;

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -141,6 +141,9 @@ type ClusterVersionQuerySnapshot = {
 
 type ClusterNotificationsRegistry = {
   querySnapshots: Record<string, ClusterVersionQuerySnapshot>;
+  // Bumped when localStorage changes (dismiss/skip) without an accompanying snapshot update.
+  // Snapshot changes alone don't bump it — they already invalidate via querySnapshots identity.
+  localStorageVersion: number;
 };
 
 // CLI value vs cluster registry are split so CLI-only UI does not subscribe to cluster updates.
@@ -190,11 +193,9 @@ function buildClusterNotificationView(
  */
 function ClusterVersionSubscriber({
   kubeContext,
-  bumpCluster,
   setSnapshot,
 }: {
   kubeContext: string;
-  bumpCluster: () => void;
   setSnapshot: (ctx: string, snap: ClusterVersionQuerySnapshot) => void;
 }) {
   const isDesktop = appConfig.environment === 'desktop';
@@ -217,7 +218,8 @@ function ClusterVersionSubscriber({
     setSnapshot(kubeContext, { data, error, loading });
   }, [kubeContext, data, error, loading, setSnapshot]);
 
-  // After load: persist versions (or mark fetch time on failure), then refresh registry (see bumpCluster).
+  // After load: persist versions (or mark fetch time on failure). Consumers re-derive automatically
+  // because `setSnapshot` (called in the effect above) changes the registry's `querySnapshots` identity.
   useEffect(() => {
     if (!isDesktop || !kubeContext || cacheValid) return;
     if (loading) return;
@@ -229,7 +231,6 @@ function ClusterVersionSubscriber({
         latestVersion: undefined,
       });
       setPersisted(readClusterState(kubeContext));
-      bumpCluster();
       return;
     }
 
@@ -250,8 +251,7 @@ function ClusterVersionSubscriber({
       });
     }
     setPersisted(readClusterState(kubeContext));
-    bumpCluster();
-  }, [data, error, loading, isDesktop, kubeContext, cacheValid, bumpCluster]);
+  }, [data, error, loading, isDesktop, kubeContext, cacheValid]);
 
   return null;
 }
@@ -280,12 +280,14 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
     return contexts?.map((c) => c.name) ?? [];
   }, [kubeData]);
 
-  // Cluster registry: Apollo snapshots per kubeContext; `bumpCluster` shallow-copies the map to invalidate
-  // consumers when only localStorage changed (dismiss/skip) or after persist without a new Apollo payload.
+  // Cluster registry: Apollo snapshots per kubeContext (changes drive consumer re-renders directly)
+  // plus a separate version counter that consumers also subscribe to, bumped only by localStorage
+  // mutations (dismiss / dontRemindMe) where no snapshot change occurs.
   const [querySnapshots, setQuerySnapshots] = useState<Record<string, ClusterVersionQuerySnapshot>>({});
+  const [localStorageVersion, setLocalStorageVersion] = useState(0);
 
-  const bumpCluster = useCallback(() => {
-    setQuerySnapshots((prev) => ({ ...prev }));
+  const invalidateLocalStorage = useCallback(() => {
+    setLocalStorageVersion((v) => v + 1);
   }, []);
 
   const setSnapshot = useCallback((kubeContext: string, snap: ClusterVersionQuerySnapshot) => {
@@ -298,7 +300,10 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
     });
   }, []);
 
-  const clusterRegistry = useMemo(() => ({ querySnapshots }), [querySnapshots]);
+  const clusterRegistry = useMemo(
+    () => ({ querySnapshots, localStorageVersion }),
+    [querySnapshots, localStorageVersion],
+  );
 
   // Delay showing the CLI banner so it does not flash on cold load.
   useEffect(() => {
@@ -356,16 +361,11 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
 
   return (
     <CLIUpdateNotificationContext.Provider value={cliValue}>
-      {/* Invalidate is separate from registry data: dismiss/remind only needs the callback, not the snapshot map. */}
-      <ClusterNotificationsInvalidateContext.Provider value={bumpCluster}>
+      {/* Invalidate is separate from registry data: dismiss/remind only needs the callback. */}
+      <ClusterNotificationsInvalidateContext.Provider value={invalidateLocalStorage}>
         <ClusterNotificationsContext.Provider value={clusterRegistry}>
           {kubeContexts.map((ctx) => (
-            <ClusterVersionSubscriber
-              key={ctx || '__default__'}
-              kubeContext={ctx}
-              bumpCluster={bumpCluster}
-              setSnapshot={setSnapshot}
-            />
+            <ClusterVersionSubscriber key={ctx || '__default__'} kubeContext={ctx} setSnapshot={setSnapshot} />
           ))}
           {children}
         </ClusterNotificationsContext.Provider>

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import { useQuery, useSubscription } from '@apollo/client/react';
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+import { atomFamily } from 'jotai-family';
+import { useEffect, useMemo } from 'react';
 
 import appConfig from '@/app-config';
 import { CLI_LATEST_VERSION, CLUSTER_VERSION_STATUS, KUBE_CONFIG_WATCH } from '@/lib/graphql/dashboard/ops';
@@ -34,48 +37,6 @@ interface UpdateState {
 
 interface ClusterUpdateState extends UpdateState {
   currentVersion?: string;
-}
-
-function clusterStorageKey(kubeContext: string): string {
-  return `${CLUSTER_STORAGE_PREFIX}${kubeContext}`;
-}
-
-function readPersisted<T extends object>(storageKey: string): T {
-  try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) return {} as T;
-    return JSON.parse(raw) as T;
-  } catch {
-    return {} as T;
-  }
-}
-
-function writePersisted(storageKey: string, state: object) {
-  try {
-    localStorage.setItem(storageKey, JSON.stringify(state));
-  } catch {
-    // fail silently
-  }
-}
-
-function patchPersisted<T extends object>(storageKey: string, patch: Partial<T>) {
-  writePersisted(storageKey, { ...readPersisted<T>(storageKey), ...patch });
-}
-
-function readCLIState(): UpdateState {
-  return readPersisted<UpdateState>(STORAGE_KEY_CLI);
-}
-
-function readClusterState(kubeContext: string): ClusterUpdateState {
-  return readPersisted<ClusterUpdateState>(clusterStorageKey(kubeContext));
-}
-
-function patchCLIState(patch: Partial<UpdateState>) {
-  patchPersisted(STORAGE_KEY_CLI, patch);
-}
-
-function patchClusterState(kubeContext: string, patch: Partial<ClusterUpdateState>) {
-  patchPersisted(clusterStorageKey(kubeContext), patch);
 }
 
 function isCLICacheValid(state: UpdateState): boolean {
@@ -114,337 +75,196 @@ export interface ClusterUpdateNotificationState extends BaseUpdateNotificationSt
   currentVersion: string | null;
 }
 
-type ClusterVersionQuerySnapshot = {
-  data?: {
-    clusterVersionStatus?: {
-      currentVersion?: string | null;
-      latestVersion?: string | null;
-      updateAvailable: boolean;
-    } | null;
-  } | null;
-  error?: Error;
-  loading: boolean;
-};
+// --- Atoms (single source of truth)
 
-type ClusterNotificationsRegistry = {
-  querySnapshots: Record<string, ClusterVersionQuerySnapshot>;
-  // Bumped when localStorage changes (dismiss/skip) without an accompanying snapshot update.
-  // Snapshot changes alone don't bump it — they already invalidate via querySnapshots identity.
-  localStorageVersion: number;
-  invalidate: () => void;
-};
+// atomWithStorage handles localStorage read/write AND cross-tab sync via the storage event.
+const cliPersistedAtom = atomWithStorage<UpdateState>(STORAGE_KEY_CLI, {});
 
-// CLI value vs cluster registry are split so CLI-only UI does not subscribe to cluster updates.
-const CLIUpdateNotificationContext = createContext({} as UpdateNotificationState);
-const ClusterNotificationsContext = createContext<ClusterNotificationsRegistry | null>(null);
+const clusterPersistedAtomFamily = atomFamily((kubeContext: string) =>
+  atomWithStorage<ClusterUpdateState>(`${CLUSTER_STORAGE_PREFIX}${kubeContext}`, {}),
+);
 
-// Exposed so consumers (e.g. NotificationsPopover) can iterate kubeContexts without opening a
-// second KUBE_CONFIG_WATCH subscription. `null` distinguishes "outside the provider" from "no
-// contexts yet"; an empty array is a valid in-provider state.
-const KubeContextsContext = createContext<string[] | null>(null);
+const kubeContextsAtom = atom<string[]>([]);
+const readyAtom = atom(false);
 
-/** Derive what to show for one kubeContext from persisted state + latest Apollo snapshot. */
-function buildClusterNotificationView(
-  kubeContext: string,
-  snapshot: ClusterVersionQuerySnapshot | undefined,
-  dismiss: () => void,
-  dontRemindMe: () => void,
-): ClusterUpdateNotificationState {
-  const persisted = readClusterState(kubeContext);
-  const cacheValid = isClusterCacheValid(persisted);
-  const data = snapshot?.data;
+// --- Derived view atoms
 
-  const currentVersion = cacheValid
-    ? (persisted.currentVersion ?? null)
-    : (data?.clusterVersionStatus?.currentVersion ?? null);
+const cliViewAtom = atom<Omit<UpdateNotificationState, 'dismiss' | 'dontRemindMe'>>((get) => {
+  const persisted = get(cliPersistedAtom);
+  const ready = get(readyAtom);
+  const currentVersion = appConfig.cliVersion;
 
-  const latestVersion = cacheValid
-    ? (persisted.latestVersion ?? null)
-    : (data?.clusterVersionStatus?.latestVersion ?? null);
+  const cacheValid = isCLICacheValid(persisted);
+  const latestVersion = cacheValid ? persisted.latestVersion! : null;
 
-  const queryUpdateAvailable = cacheValid
-    ? currentVersion !== null && latestVersion !== null && currentVersion !== latestVersion
-    : (data?.clusterVersionStatus?.updateAvailable ?? false);
-
+  const updateAvailable =
+    currentVersion !== '' && latestVersion !== null && compareSemver(latestVersion, currentVersion) > 0;
   const dismissed = persisted.dismissedAt !== undefined && Date.now() - persisted.dismissedAt < DISMISS_TTL_MS;
   const skipped = latestVersion !== null && (persisted.skippedVersions ?? []).includes(latestVersion);
-  const updateAvailable = queryUpdateAvailable && !dismissed && !skipped;
 
   return {
-    updateAvailable,
+    showBanner: ready && !dismissed && updateAvailable && !skipped,
     currentVersion,
     latestVersion,
-    dismiss,
-    dontRemindMe,
+    updateAvailable,
   };
+});
+
+type ClusterView = Omit<ClusterUpdateNotificationState, 'dismiss' | 'dontRemindMe'>;
+
+const clusterViewAtomFamily = atomFamily((kubeContext: string) =>
+  atom<ClusterView>((get) => {
+    const persisted = get(clusterPersistedAtomFamily(kubeContext));
+    const currentVersion = persisted.currentVersion ?? null;
+    const latestVersion = persisted.latestVersion ?? null;
+
+    const updateAvailable =
+      currentVersion !== null && latestVersion !== null && compareSemver(latestVersion, currentVersion) > 0;
+    const dismissed = persisted.dismissedAt !== undefined && Date.now() - persisted.dismissedAt < DISMISS_TTL_MS;
+    const skipped = latestVersion !== null && (persisted.skippedVersions ?? []).includes(latestVersion);
+
+    return {
+      updateAvailable: updateAvailable && !dismissed && !skipped,
+      currentVersion,
+      latestVersion,
+    };
+  }),
+);
+
+const allClusterViewsAtom = atom((get) =>
+  get(kubeContextsAtom).map((kubeContext) => ({
+    kubeContext,
+    view: get(clusterViewAtomFamily(kubeContext)),
+  })),
+);
+
+const hasAnyClusterUpdateAtom = atom((get) => get(allClusterViewsAtom).some(({ view }) => view.updateAvailable));
+
+// --- Side-effect components mounted by the provider
+
+function CLIFetcher() {
+  const [persisted, setPersisted] = useAtom(cliPersistedAtom);
+  const cacheValid = isCLICacheValid(persisted);
+
+  const { data } = useQuery(CLI_LATEST_VERSION, {
+    skip: !appConfig.cliVersion || cacheValid,
+    fetchPolicy: 'network-only',
+  });
+
+  useEffect(() => {
+    const version = data?.cliLatestVersion;
+    if (!version) return;
+    setPersisted((prev) => ({ ...prev, latestVersion: version, fetchedAt: Date.now() }));
+  }, [data, setPersisted]);
+
+  return null;
 }
 
-/**
- * Invisible per-context worker: runs `CLUSTER_VERSION_STATUS`, mirrors results into `querySnapshots`,
- * and refreshes localStorage after a successful fetch (or error) so the cache stays coherent.
- */
-function ClusterVersionSubscriber({
-  kubeContext,
-  setSnapshot,
-  invalidate,
-}: {
-  kubeContext: string;
-  setSnapshot: (ctx: string, snap: ClusterVersionQuerySnapshot) => void;
-  invalidate: () => void;
-}) {
-  const isDesktop = appConfig.environment === 'desktop';
-  // Derive persisted state during render rather than mirroring it into useState — the only writer
-  // is this component's own effect (and the dismiss/skip handlers via `invalidate`), and both
-  // bump the provider's localStorageVersion which re-renders us.
-  const persisted = readClusterState(kubeContext);
+function ClusterVersionFetcher({ kubeContext }: { kubeContext: string }) {
+  const [persisted, setPersisted] = useAtom(clusterPersistedAtomFamily(kubeContext));
   const cacheValid = isClusterCacheValid(persisted);
 
-  // Skip while we already have a fresh persisted row (see patch effect below).
   const { data, error, loading } = useQuery(CLUSTER_VERSION_STATUS, {
-    skip: !isDesktop || !kubeContext || cacheValid,
+    skip: !kubeContext || cacheValid,
     variables: { kubeContext },
     fetchPolicy: 'network-only',
   });
 
   useEffect(() => {
-    setSnapshot(kubeContext, { data, error, loading });
-  }, [kubeContext, data, error, loading, setSnapshot]);
-
-  // After load: persist versions (or mark fetch time on failure), then bump the provider's
-  // localStorageVersion so we (and any consumer) re-render and pick up the fresh persisted row.
-  // `setSnapshot` already drives consumer re-derivation for the snapshot half of the registry.
-  useEffect(() => {
-    if (!isDesktop || !kubeContext || cacheValid) return;
-    if (loading) return;
-
-    if (error) {
-      patchClusterState(kubeContext, {
-        fetchedAt: Date.now(),
-        currentVersion: undefined,
-        latestVersion: undefined,
-      });
-      invalidate();
-      return;
-    }
-
+    if (!kubeContext || cacheValid) return;
+    if (loading || error) return;
     if (data === undefined) return;
 
     const result = data.clusterVersionStatus;
-    if (result) {
-      patchClusterState(kubeContext, {
-        currentVersion: result.currentVersion,
-        latestVersion: result.latestVersion,
-        fetchedAt: Date.now(),
-      });
-    } else {
-      patchClusterState(kubeContext, {
-        fetchedAt: Date.now(),
-        currentVersion: undefined,
-        latestVersion: undefined,
-      });
-    }
-    invalidate();
-  }, [data, error, loading, isDesktop, kubeContext, cacheValid, invalidate]);
+    setPersisted((prev) => ({
+      ...prev,
+      currentVersion: result?.currentVersion ?? undefined,
+      latestVersion: result?.latestVersion ?? undefined,
+      fetchedAt: Date.now(),
+    }));
+  }, [data, error, loading, kubeContext, cacheValid, setPersisted]);
 
   return null;
 }
 
 /**
- * Root provider: CLI banner state + one `ClusterVersionSubscriber` per kubeContext (desktop).
- * Children render after subscribers so snapshots exist before hooks in descendants run.
+ * Wires CLI + per-kubeContext fetchers, mirrors kubeconfig contexts into `kubeContextsAtom`, and
+ * schedules the show-delay timer. All state lives in atoms; this component only runs side effects.
  */
 export function UpdateNotificationProvider({ children }: React.PropsWithChildren) {
   const isDesktop = appConfig.environment === 'desktop';
-  const currentVersionCLI = appConfig.cliVersion;
-  const [ready, setReady] = useState(false);
-  const [mountedAt] = useState(() => Date.now());
+  const setKubeContexts = useSetAtom(kubeContextsAtom);
+  const setReady = useSetAtom(readyAtom);
+  const kubeContexts = useAtomValue(kubeContextsAtom);
 
-  // Desktop: watch kubeconfig so we know which contexts exist (cluster mode uses a single synthetic context).
-  const { data: kubeData } = useSubscription(KUBE_CONFIG_WATCH, {
-    skip: appConfig.environment !== 'desktop',
-  });
+  const { data: kubeData } = useSubscription(KUBE_CONFIG_WATCH, { skip: !isDesktop });
 
-  const kubeContexts = useMemo(() => {
-    if (appConfig.environment === 'cluster') return [''];
-    const contexts = kubeData?.kubeConfigWatch?.object?.contexts;
-    return contexts?.map((c) => c.name) ?? [];
-  }, [kubeData]);
+  const nextKubeContexts = useMemo(() => {
+    if (!isDesktop) return [''];
+    return kubeData?.kubeConfigWatch?.object?.contexts?.map((c) => c.name) ?? [];
+  }, [kubeData, isDesktop]);
 
-  // Cluster registry: Apollo snapshots per kubeContext (changes drive consumer re-renders directly)
-  // plus a separate version counter that consumers also subscribe to, bumped only by localStorage
-  // mutations (dismiss / dontRemindMe) where no snapshot change occurs.
-  const [querySnapshots, setQuerySnapshots] = useState<Record<string, ClusterVersionQuerySnapshot>>({});
-  const [localStorageVersion, setLocalStorageVersion] = useState(0);
-
-  const invalidateLocalStorage = useCallback(() => {
-    setLocalStorageVersion((v) => v + 1);
-  }, []);
-
-  const setSnapshot = useCallback((kubeContext: string, snap: ClusterVersionQuerySnapshot) => {
-    setQuerySnapshots((prev) => {
-      const cur = prev[kubeContext];
-      if (cur && cur.data === snap.data && cur.error === snap.error && cur.loading === snap.loading) {
-        return prev;
-      }
-      return { ...prev, [kubeContext]: snap };
+  useEffect(() => {
+    setKubeContexts((prev) => {
+      if (prev.length === nextKubeContexts.length && prev.every((v, i) => v === nextKubeContexts[i])) return prev;
+      return nextKubeContexts;
     });
-  }, []);
-
-  const clusterRegistry = useMemo<ClusterNotificationsRegistry>(
-    () => ({ querySnapshots, localStorageVersion, invalidate: invalidateLocalStorage }),
-    [querySnapshots, localStorageVersion, invalidateLocalStorage],
-  );
+  }, [nextKubeContexts, setKubeContexts]);
 
   // Delay showing the CLI banner so it does not flash on cold load.
   useEffect(() => {
     const timer = setTimeout(() => setReady(true), SHOW_DELAY_MS);
     return () => clearTimeout(timer);
-  }, []);
-
-  // Cross-tab sync: when another tab fetches a fresh CLI/cluster version or the user dismisses
-  // a notification, the storage event lets this tab pick up the change without refetching.
-  // The event only fires in *other* tabs, so there's no self-write loop.
-  useEffect(() => {
-    const handler = (ev: StorageEvent) => {
-      // ev.key === null fires when another tab calls localStorage.clear(); refresh either way
-      // since we cannot tell which key (if any) was relevant.
-      if (ev.key === null || ev.key === STORAGE_KEY_CLI || ev.key.startsWith(CLUSTER_STORAGE_PREFIX)) {
-        invalidateLocalStorage();
-      }
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, [invalidateLocalStorage]);
-
-  // Derive CLI persisted state during render (re-reads on every localStorageVersion bump).
-  const cliPersisted = readCLIState();
-  const cliCacheValid = isCLICacheValid(cliPersisted);
-
-  const { data: cliQueryData } = useQuery(CLI_LATEST_VERSION, {
-    skip: !isDesktop || !currentVersionCLI || cliCacheValid,
-    fetchPolicy: 'network-only',
-  });
-
-  // `cliQueryData` arriving triggers a re-render, which re-reads localStorage during render and
-  // flips `cliCacheValid` to true on the next render. No invalidate() is needed (and calling it
-  // inside an effect would be a setState-in-effect lint violation).
-  useEffect(() => {
-    const version = cliQueryData?.cliLatestVersion;
-    if (!version) return;
-    patchCLIState({ latestVersion: version, fetchedAt: Date.now() });
-  }, [cliQueryData]);
-
-  const latestVersionCLI = cliCacheValid ? cliPersisted.latestVersion! : (cliQueryData?.cliLatestVersion ?? null);
-
-  const cliUpdateAvailable =
-    currentVersionCLI !== '' && latestVersionCLI !== null && compareSemver(latestVersionCLI, currentVersionCLI) > 0;
-
-  // `mountedAt` is fixed at provider mount so dismiss TTL is stable for this session (matches prior behavior).
-  const cliDismissed = cliPersisted.dismissedAt !== undefined && mountedAt - cliPersisted.dismissedAt < DISMISS_TTL_MS;
-  const cliSkipped = latestVersionCLI !== null && (cliPersisted.skippedVersions ?? []).includes(latestVersionCLI);
-  const cliHasUpdate = cliUpdateAvailable && !cliSkipped;
-
-  const showBanner = ready && !cliDismissed && cliHasUpdate;
-
-  const dismissCLI = useCallback(() => {
-    patchCLIState({ dismissedAt: Date.now() });
-    invalidateLocalStorage();
-  }, [invalidateLocalStorage]);
-
-  const dontRemindCLI = useCallback(() => {
-    const { skippedVersions = [] } = readCLIState();
-    if (latestVersionCLI && !skippedVersions.includes(latestVersionCLI)) {
-      skippedVersions.push(latestVersionCLI);
-    }
-    patchCLIState({ skippedVersions, dismissedAt: Date.now() });
-    invalidateLocalStorage();
-  }, [latestVersionCLI, invalidateLocalStorage]);
-
-  const cliValue = useMemo(
-    () => ({
-      showBanner,
-      currentVersion: currentVersionCLI,
-      latestVersion: latestVersionCLI,
-      updateAvailable: cliUpdateAvailable,
-      dismiss: dismissCLI,
-      dontRemindMe: dontRemindCLI,
-    }),
-    [showBanner, currentVersionCLI, latestVersionCLI, cliUpdateAvailable, dismissCLI, dontRemindCLI],
-  );
+  }, [setReady]);
 
   return (
-    <CLIUpdateNotificationContext.Provider value={cliValue}>
-      <ClusterNotificationsContext.Provider value={clusterRegistry}>
-        <KubeContextsContext.Provider value={kubeContexts}>
-          {kubeContexts.map((ctx) => (
-            <ClusterVersionSubscriber
-              key={ctx || '__default__'}
-              kubeContext={ctx}
-              setSnapshot={setSnapshot}
-              invalidate={invalidateLocalStorage}
-            />
-          ))}
-          {children}
-        </KubeContextsContext.Provider>
-      </ClusterNotificationsContext.Provider>
-    </CLIUpdateNotificationContext.Provider>
+    <>
+      {isDesktop && <CLIFetcher />}
+      {kubeContexts.map((ctx) => (
+        <ClusterVersionFetcher key={ctx || '__default__'} kubeContext={ctx} />
+      ))}
+      {children}
+    </>
   );
 }
 
-/** Latest CLI update banner state (no cluster context subscription). */
+// --- Public hooks
+
+function buildDismissHandlers<T extends UpdateState>(
+  setPersisted: (updater: (prev: T) => T) => void,
+  latestVersion: string | null,
+): { dismiss: () => void; dontRemindMe: () => void } {
+  return {
+    dismiss: () => setPersisted((prev) => ({ ...prev, dismissedAt: Date.now() })),
+    dontRemindMe: () =>
+      setPersisted((prev) => {
+        const skipped = prev.skippedVersions ?? [];
+        const next = latestVersion && !skipped.includes(latestVersion) ? [...skipped, latestVersion] : skipped;
+        return { ...prev, skippedVersions: next, dismissedAt: Date.now() };
+      }),
+  };
+}
+
 export function useCLIUpdateNotification(): UpdateNotificationState {
-  return useContext(CLIUpdateNotificationContext);
+  const view = useAtomValue(cliViewAtom);
+  const setPersisted = useSetAtom(cliPersistedAtom);
+  return useMemo(() => ({ ...view, ...buildDismissHandlers(setPersisted, view.latestVersion) }), [view, setPersisted]);
 }
 
-/**
- * List of kubeContexts visible to the provider. Returns `[]` when used outside the provider or
- * before the kubeconfig subscription has produced data. On non-desktop environments this is the
- * synthetic `['']` context the provider uses to drive a single cluster subscriber.
- */
-export function useKubeContexts(): string[] {
-  return useContext(KubeContextsContext) ?? [];
-}
-
-/** Per-kubeContext cluster update row; reads shared registry + bumps via invalidate after mutations. */
 export function useClusterUpdateNotification(kubeContext: string): ClusterUpdateNotificationState {
-  const clusterRegistry = useContext(ClusterNotificationsContext);
+  const view = useAtomValue(clusterViewAtomFamily(kubeContext));
+  const setPersisted = useSetAtom(clusterPersistedAtomFamily(kubeContext));
+  return useMemo(() => ({ ...view, ...buildDismissHandlers(setPersisted, view.latestVersion) }), [view, setPersisted]);
+}
 
-  const dismissCluster = useCallback(() => {
-    if (!clusterRegistry) return;
-    patchClusterState(kubeContext, { dismissedAt: Date.now() });
-    clusterRegistry.invalidate();
-  }, [kubeContext, clusterRegistry]);
+export function useKubeContexts(): string[] {
+  return useAtomValue(kubeContextsAtom);
+}
 
-  const dontRemindCluster = useCallback(() => {
-    if (!clusterRegistry) return;
-    const persisted = readClusterState(kubeContext);
-    const valid = isClusterCacheValid(persisted);
-    const snap = clusterRegistry.querySnapshots[kubeContext];
-    const lv = valid ? (persisted.latestVersion ?? null) : (snap?.data?.clusterVersionStatus?.latestVersion ?? null);
-    const { skippedVersions = [] } = persisted;
-    if (lv && !skippedVersions.includes(lv)) {
-      skippedVersions.push(lv);
-    }
-    patchClusterState(kubeContext, { skippedVersions, dismissedAt: Date.now() });
-    clusterRegistry.invalidate();
-  }, [kubeContext, clusterRegistry]);
+export function useHasAnyClusterUpdate(): boolean {
+  return useAtomValue(hasAnyClusterUpdateAtom);
+}
 
-  const clusterView = useMemo(() => {
-    if (!clusterRegistry) {
-      return {
-        updateAvailable: false,
-        currentVersion: null,
-        latestVersion: null,
-        dismiss: dismissCluster,
-        dontRemindMe: dontRemindCluster,
-      } as ClusterUpdateNotificationState;
-    }
-    return buildClusterNotificationView(
-      kubeContext,
-      clusterRegistry.querySnapshots[kubeContext],
-      dismissCluster,
-      dontRemindCluster,
-    );
-  }, [kubeContext, clusterRegistry, dismissCluster, dontRemindCluster]);
-  return clusterView;
+export function useAllClusterUpdateViews(): { kubeContext: string; view: ClusterView }[] {
+  return useAtomValue(allClusterViewsAtom);
 }

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -257,10 +257,7 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
   const isDesktop = appConfig.environment === 'desktop';
   const currentVersionCLI = appConfig.cliVersion;
   const [ready, setReady] = useState(false);
-  const [cliPersisted, setCLIPersisted] = useState(() => readCLIState());
   const [mountedAt] = useState(() => Date.now());
-
-  const cliCacheValid = isCLICacheValid(cliPersisted);
 
   // Desktop: watch kubeconfig so we know which contexts exist (cluster mode uses a single synthetic context).
   const { data: kubeData } = useSubscription(KUBE_CONFIG_WATCH, {
@@ -304,14 +301,37 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
     return () => clearTimeout(timer);
   }, []);
 
+  // Cross-tab sync: when another tab fetches a fresh CLI/cluster version or the user dismisses
+  // a notification, the storage event lets this tab pick up the change without refetching.
+  // The event only fires in *other* tabs, so there's no self-write loop.
+  useEffect(() => {
+    const handler = (ev: StorageEvent) => {
+      // ev.key === null fires when another tab calls localStorage.clear(); refresh either way
+      // since we cannot tell which key (if any) was relevant.
+      if (ev.key === null || ev.key === STORAGE_KEY_CLI || ev.key.startsWith(CLUSTER_STORAGE_PREFIX)) {
+        invalidateLocalStorage();
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [invalidateLocalStorage]);
+
+  // Derive CLI persisted state during render (re-reads on every localStorageVersion bump).
+  const cliPersisted = readCLIState();
+  const cliCacheValid = isCLICacheValid(cliPersisted);
+
   const { data: cliQueryData } = useQuery(CLI_LATEST_VERSION, {
     skip: !isDesktop || !currentVersionCLI || cliCacheValid,
     fetchPolicy: 'network-only',
   });
 
+  // `cliQueryData` arriving triggers a re-render, which re-reads localStorage during render and
+  // flips `cliCacheValid` to true on the next render. No invalidate() is needed (and calling it
+  // inside an effect would be a setState-in-effect lint violation).
   useEffect(() => {
     const version = cliQueryData?.cliLatestVersion;
-    if (version) patchCLIState({ latestVersion: version, fetchedAt: Date.now() });
+    if (!version) return;
+    patchCLIState({ latestVersion: version, fetchedAt: Date.now() });
   }, [cliQueryData]);
 
   const latestVersionCLI = cliCacheValid ? cliPersisted.latestVersion! : (cliQueryData?.cliLatestVersion ?? null);
@@ -328,8 +348,8 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
 
   const dismissCLI = useCallback(() => {
     patchCLIState({ dismissedAt: Date.now() });
-    setCLIPersisted(readCLIState());
-  }, []);
+    invalidateLocalStorage();
+  }, [invalidateLocalStorage]);
 
   const dontRemindCLI = useCallback(() => {
     const { skippedVersions = [] } = readCLIState();
@@ -337,8 +357,8 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
       skippedVersions.push(latestVersionCLI);
     }
     patchCLIState({ skippedVersions, dismissedAt: Date.now() });
-    setCLIPersisted(readCLIState());
-  }, [latestVersionCLI]);
+    invalidateLocalStorage();
+  }, [latestVersionCLI, invalidateLocalStorage]);
 
   const cliValue = useMemo(
     () => ({

--- a/dashboard-ui/src/lib/update-notifications.tsx
+++ b/dashboard-ui/src/lib/update-notifications.tsx
@@ -151,6 +151,11 @@ const CLIUpdateNotificationContext = createContext({} as UpdateNotificationState
 const ClusterNotificationsContext = createContext<ClusterNotificationsRegistry | null>(null);
 const ClusterNotificationsInvalidateContext = createContext<(() => void) | null>(null);
 
+// Exposed so consumers (e.g. NotificationsPopover) can iterate kubeContexts without opening a
+// second KUBE_CONFIG_WATCH subscription. `null` distinguishes "outside the provider" from "no
+// contexts yet"; an empty array is a valid in-provider state.
+const KubeContextsContext = createContext<string[] | null>(null);
+
 /** Derive what to show for one kubeContext from persisted state + latest Apollo snapshot. */
 function buildClusterNotificationView(
   kubeContext: string,
@@ -364,10 +369,12 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
       {/* Invalidate is separate from registry data: dismiss/remind only needs the callback. */}
       <ClusterNotificationsInvalidateContext.Provider value={invalidateLocalStorage}>
         <ClusterNotificationsContext.Provider value={clusterRegistry}>
-          {kubeContexts.map((ctx) => (
-            <ClusterVersionSubscriber key={ctx || '__default__'} kubeContext={ctx} setSnapshot={setSnapshot} />
-          ))}
-          {children}
+          <KubeContextsContext.Provider value={kubeContexts}>
+            {kubeContexts.map((ctx) => (
+              <ClusterVersionSubscriber key={ctx || '__default__'} kubeContext={ctx} setSnapshot={setSnapshot} />
+            ))}
+            {children}
+          </KubeContextsContext.Provider>
         </ClusterNotificationsContext.Provider>
       </ClusterNotificationsInvalidateContext.Provider>
     </CLIUpdateNotificationContext.Provider>
@@ -377,6 +384,15 @@ export function UpdateNotificationProvider({ children }: React.PropsWithChildren
 /** Latest CLI update banner state (no cluster context subscription). */
 export function useCLIUpdateNotification(): UpdateNotificationState {
   return useContext(CLIUpdateNotificationContext);
+}
+
+/**
+ * List of kubeContexts visible to the provider. Returns `[]` when used outside the provider or
+ * before the kubeconfig subscription has produced data. On non-desktop environments this is the
+ * synthetic `['']` context the provider uses to drive a single cluster subscriber.
+ */
+export function useKubeContexts(): string[] {
+  return useContext(KubeContextsContext) ?? [];
 }
 
 /** Per-kubeContext cluster update row; reads shared registry + bumps via invalidate after mutations. */

--- a/dashboard-ui/src/main.tsx
+++ b/dashboard-ui/src/main.tsx
@@ -19,6 +19,7 @@ import { createBrowserRouter, createRoutesFromElements, RouterProvider } from 'r
 
 import { dashboardClient } from '@/apollo-client';
 import { SessionProvider } from '@/lib/auth';
+import { KubeConfigEffect } from '@/lib/kubeconfig';
 import { PreferencesProvider } from '@/lib/preferences';
 import { ThemeEffect } from '@/lib/theme';
 import { UpdateNotificationProvider } from '@/lib/update-notifications';
@@ -36,6 +37,7 @@ createRoot(document.getElementById('root')!).render(
       <ApolloProvider client={dashboardClient}>
         <PreferencesProvider>
           <ThemeEffect />
+          <KubeConfigEffect />
           <UpdateNotificationProvider>
             <RouterProvider router={router} />
           </UpdateNotificationProvider>

--- a/dashboard-ui/src/test-utils.tsx
+++ b/dashboard-ui/src/test-utils.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { DashboardCustomCache } from '@/apollo-client';
+import appConfig from '@/app-config';
 
 export const renderElement = (component: React.ReactElement, mocks?: MockedResponse[]) =>
   render(
@@ -32,3 +33,24 @@ export const renderElement = (component: React.ReactElement, mocks?: MockedRespo
       <MemoryRouter>{component}</MemoryRouter>
     </MockedProvider>,
   );
+
+/**
+ * Run `fn` with the given appConfig overrides applied, then restore the previous values — even if
+ * `fn` throws. Lets tests exercise non-default config (e.g. `environment: 'cluster'`) without
+ * leaving the global `appConfig` mutated for any later test or test file.
+ */
+export async function withAppConfig<T>(overrides: Partial<typeof appConfig>, fn: () => Promise<T> | T): Promise<T> {
+  const original: Partial<typeof appConfig> = {};
+  const keys = Object.keys(overrides) as (keyof typeof appConfig)[];
+  keys.forEach((key) => {
+    original[key] = appConfig[key] as never;
+    Object.defineProperty(appConfig, key, { value: overrides[key], writable: true, configurable: true });
+  });
+  try {
+    return await fn();
+  } finally {
+    keys.forEach((key) => {
+      Object.defineProperty(appConfig, key, { value: original[key], writable: true, configurable: true });
+    });
+  }
+}

--- a/dashboard-ui/src/test-utils.tsx
+++ b/dashboard-ui/src/test-utils.tsx
@@ -15,23 +15,30 @@
 import { MockedProvider } from '@apollo/client/testing/react';
 import type { MockedResponse } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
+import { createStore, Provider as JotaiProvider } from 'jotai';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { DashboardCustomCache } from '@/apollo-client';
 import appConfig from '@/app-config';
+import { KubeConfigEffect } from '@/lib/kubeconfig';
 
 export const renderElement = (component: React.ReactElement, mocks?: MockedResponse[]) =>
   render(
-    <MockedProvider
-      mocks={mocks}
-      cache={new DashboardCustomCache()}
-      defaultOptions={{
-        watchQuery: { fetchPolicy: 'cache-first' },
-      }}
-    >
-      <MemoryRouter>{component}</MemoryRouter>
-    </MockedProvider>,
+    <JotaiProvider store={createStore()}>
+      <MockedProvider
+        mocks={mocks}
+        cache={new DashboardCustomCache()}
+        defaultOptions={{
+          watchQuery: { fetchPolicy: 'cache-first' },
+        }}
+      >
+        <MemoryRouter>
+          <KubeConfigEffect />
+          {component}
+        </MemoryRouter>
+      </MockedProvider>
+    </JotaiProvider>,
   );
 
 /**


### PR DESCRIPTION
Fixes #1011 

## Summary

Adds cluster (Helm chart) upgrade hints in desktop mode: queries `CLUSTER_VERSION_STATUS` per kube context and surfaces it in the health dialog and notifications bell.

## Changes

- `useClusterUpgradeNotification` hook with per-context cache/dismiss (12h TTL, same idea as CLI update notifications).
- Kubetail version row in ServerStatus (desktop only).
- Cluster upgrade line and blue dot on `NotificationsPopover` when a cluster or CLI update is available.
- Tests in `upgrade-notifications.test.tsx`

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
