### PR TITLE
✨ Fix intermittent race test failure

### DIFF
--- a/modules/shared/logs/helpers_test.go
+++ b/modules/shared/logs/helpers_test.go
@@ -448,9 +448,20 @@ func TestMergeLogStreamsContextCancellation(t *testing.T) {
 	// Cancel context
 	cancel()
 
+	// Wait for the channel to be closed
+	timeout := time.After(1 * time.Second)
+
 	// Verify channel is closed
-	_, ok := <-merged
-	assert.False(t, ok, "channel should be closed after context cancellation")
+	for {
+		select {
+		case _, ok := <-merged:
+			if !ok {
+				return
+			}
+		case <-timeout:
+			t.Fatal("channel should be closed after context cancellation")
+		}
+	}
 }
 
 func TestParseWorkloadType(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `modules/shared/logs/helpers_test.go` causing intermittent race test failures due a check for a closed channel without draining first.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
