### PR TITLE
🎣 Add apt update to publish-launchpad workflow

### DIFF
--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             devscripts \
             debhelper-compat
 


### PR DESCRIPTION
## Summary

This PR adds a `apt-get update` call before `apt-get install` in the `publish-launchpad` workflow to dependency 404 issue.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
