### PR TITLE
ci: add RISC-V runners to modules-test and cli-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         arch:
           - amd64
           - arm64
+          - riscv64
         include:
           - os: linux
             arch: amd64
@@ -148,6 +149,9 @@ jobs:
           - os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+          - os: linux
+            arch: riscv64
+            runner: ubuntu-24.04-riscv
           - os: macos-15
             arch: amd64
             runner: macos-15-intel
@@ -166,6 +170,12 @@ jobs:
         exclude:
           - os: macos-26
             arch: amd64
+          - os: macos-15
+            arch: riscv64
+          - os: macos-26
+            arch: riscv64
+          - os: windows
+            arch: riscv64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -301,6 +311,7 @@ jobs:
         arch:
           - amd64
           - arm64
+          - riscv64
         include:
           - os: linux
             arch: amd64
@@ -310,6 +321,10 @@ jobs:
             arch: arm64
             runner: ubuntu-24.04-arm
             platform: linux-arm64
+          - os: linux
+            arch: riscv64
+            runner: ubuntu-24.04-riscv
+            platform: linux-riscv64
           - os: macos-15
             arch: amd64
             runner: macos-15-intel
@@ -333,6 +348,12 @@ jobs:
         exclude:
           - os: macos-26
             arch: amd64
+          - os: macos-15
+            arch: riscv64
+          - os: macos-26
+            arch: riscv64
+          - os: windows
+            arch: riscv64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Fixes #1019

Following the recent RISE project announcement, this PR adds the `ubuntu-24.04-riscv` GitHub runner to the `modules-test` and `cli-builds` matrices in `.github/workflows/ci.yml`.

Included tests for compatibility and excluded macOS/Windows combinations for RISC-V.