### PR TITLE
✨ Revert publish workflow runners from ubuntu-slim to ubuntu-24.04

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -24,7 +24,7 @@ jobs:
   update-kubetail-bin:
     name: Update AUR kubetail-bin repo
     environment: production
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - name: Config
         id: config
@@ -126,7 +126,7 @@ jobs:
   update-kubetail-cli:
     name: Update AUR kubetail-cli repo
     environment: production
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - name: Config
         id: config

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   generate-nuspec:
     name: Generate nuspec
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - name: Config
         id: config

--- a/.github/workflows/publish-copr.yml
+++ b/.github/workflows/publish-copr.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - id: config

--- a/.github/workflows/publish-krew.yml
+++ b/.github/workflows/publish-krew.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   update-krew-index-repo:
     name: Update krew-index repo
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - name: Config
         id: config

--- a/.github/workflows/publish-obs.yml
+++ b/.github/workflows/publish-obs.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - id: config

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -24,7 +24,7 @@ jobs:
   winget-release:
     name: Release on winget
     environment: production
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     env:
       UPSTREAM_REPO: microsoft/winget-pkgs
       FORK_REPO: kubetail-org/winget-pkgs


### PR DESCRIPTION
## Summary

Reverts the GitHub Actions runners for all publish workflows from `ubuntu-slim` back to `ubuntu-24.04`.

## Key Changes

- Changed `runs-on` from `ubuntu-slim` to `ubuntu-24.04` in publish-aur, publish-chocolatey, publish-copr, publish-krew, publish-obs, and publish-winget workflows

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused