### PR TITLE
✨ Update krew-release-bot to v0.0.51 and add release tag

### DIFF
--- a/.github/workflows/publish-krew.yml
+++ b/.github/workflows/publish-krew.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Update new version in krew-index
         if: ${{ steps.config.outputs.dry_run != 'true' }}
-        uses: rajatjindal/krew-release-bot@v0.0.47
+        uses: rajatjindal/krew-release-bot@v0.0.51
         with:
           krew_template_file: krew.yaml
+          krew_plugin_release_tag: cli/v${{ steps.config.outputs.version }}


### PR DESCRIPTION
## Summary

Update the `krew-release-bot` GitHub Action from v0.0.47 to v0.0.51 and configure it to use the correct release tag format for the CLI plugin.

## Key Changes

- Bump `rajatjindal/krew-release-bot` from v0.0.47 to v0.0.51
- Add `krew_plugin_release_tag` input to specify the `cli/v<version>` tag format

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused