### PR TITLE
🐋 Add position column to log viewer

### DIFF
--- a/dashboard-ui/src/components/widgets/log-viewer/double-tailed-array.test.ts
+++ b/dashboard-ui/src/components/widgets/log-viewer/double-tailed-array.test.ts
@@ -33,6 +33,19 @@ describe('DoubleTailedArray', () => {
       expect(arr.length).toBe(0);
       expect(arr.toArray()).toEqual([]);
     });
+
+    it('should accept a custom keyOffset', () => {
+      const arr = new DoubleTailedArray<number>([10, 20, 30], -2);
+      expect(arr.keyOffset).toBe(-2);
+      expect(arr.keyAt(0)).toBe(-2);
+      expect(arr.keyAt(1)).toBe(-1);
+      expect(arr.keyAt(2)).toBe(0);
+    });
+
+    it('should default keyOffset to 0 when not provided', () => {
+      const arr = new DoubleTailedArray<number>([10, 20, 30]);
+      expect(arr.keyOffset).toBe(0);
+    });
   });
 
   describe('length', () => {
@@ -442,29 +455,29 @@ describe('DoubleTailedArray', () => {
   });
 
   describe('key tracking', () => {
-    it('should start with firstKey 0', () => {
+    it('should start with keyOffset 0', () => {
       const arr = new DoubleTailedArray<number>([10, 20, 30]);
-      expect(arr.firstKey).toBe(0);
+      expect(arr.keyOffset).toBe(0);
     });
 
-    it('keyAt should return firstKey + index', () => {
+    it('keyAt should return keyOffset + index', () => {
       const arr = new DoubleTailedArray<number>([10, 20, 30]);
       expect(arr.keyAt(0)).toBe(0);
       expect(arr.keyAt(1)).toBe(1);
       expect(arr.keyAt(2)).toBe(2);
     });
 
-    it('indexOfKey should return key - firstKey', () => {
+    it('indexOfKey should return key - keyOffset', () => {
       const arr = new DoubleTailedArray<number>([10, 20, 30]);
       expect(arr.indexOfKey(0)).toBe(0);
       expect(arr.indexOfKey(1)).toBe(1);
       expect(arr.indexOfKey(2)).toBe(2);
     });
 
-    it('should decrement firstKey on prepend', () => {
+    it('should decrement keyOffset on prepend', () => {
       const arr = new DoubleTailedArray<number>([10, 20]);
       arr.prepend([5, 6, 7]);
-      expect(arr.firstKey).toBe(-3);
+      expect(arr.keyOffset).toBe(-3);
       expect(arr.keyAt(0)).toBe(-3); // element 5
       expect(arr.keyAt(1)).toBe(-2); // element 6
       expect(arr.keyAt(2)).toBe(-1); // element 7
@@ -472,10 +485,10 @@ describe('DoubleTailedArray', () => {
       expect(arr.keyAt(4)).toBe(1); // element 20
     });
 
-    it('should not change firstKey on append', () => {
+    it('should not change keyOffset on append', () => {
       const arr = new DoubleTailedArray<number>([10, 20]);
       arr.append([30, 40]);
-      expect(arr.firstKey).toBe(0);
+      expect(arr.keyOffset).toBe(0);
       expect(arr.keyAt(2)).toBe(2);
       expect(arr.keyAt(3)).toBe(3);
     });
@@ -489,7 +502,7 @@ describe('DoubleTailedArray', () => {
       // keys: -1=5, 0=10, 1=20, 2=30
       arr.prepend([1, 2]);
       // keys: -3=1, -2=2, -1=5, 0=10, 1=20, 2=30
-      expect(arr.firstKey).toBe(-3);
+      expect(arr.keyOffset).toBe(-3);
       expect(arr.indexOfKey(-3)).toBe(0);
       expect(arr.indexOfKey(0)).toBe(3);
       expect(arr.indexOfKey(2)).toBe(5);

--- a/dashboard-ui/src/components/widgets/log-viewer/double-tailed-array.ts
+++ b/dashboard-ui/src/components/widgets/log-viewer/double-tailed-array.ts
@@ -34,36 +34,38 @@ export class DoubleTailedArray<T> {
 
   private after: T[] = [];
 
-  private _firstKey = 0;
+  private _keyOffset = 0;
 
-  constructor(items?: T[]) {
+  constructor(items?: T[], keyOffset = 0) {
     if (items) {
       this.after = [...items];
     }
+    this._keyOffset = keyOffset;
   }
 
   /**
-   * The key of the first element. Decrements when items are prepended,
-   * stays stable when items are appended. Keys are always sequential
-   * in display order: firstKey, firstKey+1, ..., firstKey+length-1.
+   * The offset used to convert between indices and keys.
+   * Decrements when items are prepended, stays stable when items
+   * are appended. Keys are sequential: keyOffset, keyOffset+1, ...,
+   * keyOffset+length-1.
    */
-  get firstKey(): number {
-    return this._firstKey;
+  get keyOffset(): number {
+    return this._keyOffset;
   }
 
   /**
-   * Returns the key at a given index: firstKey + index. O(1).
+   * Returns the key at a given index: keyOffset + index. O(1).
    */
   keyAt(index: number): number {
-    return this._firstKey + index;
+    return this._keyOffset + index;
   }
 
   /**
-   * Returns the index for a given key: key - firstKey. O(1).
+   * Returns the index for a given key: key - keyOffset. O(1).
    * Does not bounds-check — caller should verify the result is in range.
    */
   indexOfKey(key: number): number {
-    return key - this._firstKey;
+    return key - this._keyOffset;
   }
 
   /**
@@ -121,7 +123,7 @@ export class DoubleTailedArray<T> {
    * Elements are added in order, so prepend(1, 2, 3) will add [1, 2, 3] at the start
    */
   prepend(values: T[]): void {
-    this._firstKey -= values.length;
+    this._keyOffset -= values.length;
     // Push in reverse order so they appear in correct order at the beginning
     for (let i = values.length - 1; i >= 0; i -= 1) {
       this.before.push(values[i]);

--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
@@ -137,17 +137,32 @@ describe('internal helpers', () => {
     }
 
     describe('new()', () => {
-      it('initializes new array on first call', () => {
+      it('initializes new array with last record at key 0 by default', () => {
         const { recordsRef, setCount, recordStore } = createMockRecordStore();
 
         act(() => {
-          recordStore.new(createMockRecords(2));
+          recordStore.new(createMockRecords(3));
         });
 
         expect(setCount).toHaveBeenCalledTimes(1);
-        expect(setCount).toHaveBeenCalledWith(2);
+        expect(setCount).toHaveBeenCalledWith(3);
+        expect(recordsRef.current.keyAt(0)).toBe(-2);
+        expect(recordsRef.current.keyAt(1)).toBe(-1);
+        expect(recordsRef.current.keyAt(2)).toBe(0);
+      });
+
+      it('initializes new array with first record at key 0 when zeroAt is first', () => {
+        const { recordsRef, setCount, recordStore } = createMockRecordStore();
+
+        act(() => {
+          recordStore.new(createMockRecords(3), { zeroAt: 'first' });
+        });
+
+        expect(setCount).toHaveBeenCalledTimes(1);
+        expect(setCount).toHaveBeenCalledWith(3);
         expect(recordsRef.current.keyAt(0)).toBe(0);
         expect(recordsRef.current.keyAt(1)).toBe(1);
+        expect(recordsRef.current.keyAt(2)).toBe(2);
       });
 
       it('resets array and count when called again', () => {
@@ -163,15 +178,15 @@ describe('internal helpers', () => {
         expect(setCount).toHaveBeenCalledTimes(2);
         expect(setCount).toHaveBeenCalledWith(2);
         expect(recordsRef.current.length).toBe(2);
-        expect(recordsRef.current.keyAt(0)).toBe(0);
-        expect(recordsRef.current.keyAt(1)).toBe(1);
+        expect(recordsRef.current.keyAt(0)).toBe(-1);
+        expect(recordsRef.current.keyAt(1)).toBe(0);
       });
 
       it('handles skipSetCount option', () => {
         const { recordsRef, setCount, recordStore } = createMockRecordStore();
 
         act(() => {
-          recordStore.new(createMockRecords(2), true);
+          recordStore.new(createMockRecords(2), { skipSetCount: true });
         });
 
         expect(setCount).toHaveBeenCalledTimes(0);
@@ -179,7 +194,7 @@ describe('internal helpers', () => {
       });
     });
 
-    it('append() adds keys and updates count properly', () => {
+    it('append() adds records and updates count properly', () => {
       const { recordsRef, setCount, recordStore } = createMockRecordStore();
 
       act(() => {
@@ -189,8 +204,6 @@ describe('internal helpers', () => {
       expect(setCount).toHaveBeenCalledTimes(1);
       expect(setCount).toHaveBeenCalledWith(2);
       expect(recordsRef.current.length).toBe(2);
-      expect(recordsRef.current.keyAt(0)).toBe(0);
-      expect(recordsRef.current.keyAt(1)).toBe(1);
     });
 
     it('prepend() adjusts keys and updates count properly', () => {

--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
@@ -54,7 +54,7 @@ const DEFAULT_IS_REFRESHING_ROW_HEIGHT = 0;
  */
 
 export type RecordStore = {
-  new: (records: LogRecord[], skipSetCount?: boolean) => void;
+  new: (records: LogRecord[], options?: { skipSetCount?: boolean; zeroAt?: 'first' | 'last' }) => void;
   append: (records: LogRecord[]) => void;
   prepend: (records: LogRecord[]) => void;
   first: () => LogRecord | undefined;
@@ -188,8 +188,10 @@ type RecordStoreOptions = {
 export function useRecordStore({ recordsRef, setCount }: RecordStoreOptions): RecordStore {
   return useMemo(
     () => ({
-      new: (records: LogRecord[], skipSetCount = false) => {
-        recordsRef.current = new DoubleTailedArray(records);
+      new: (records: LogRecord[], options?: { skipSetCount?: boolean; zeroAt?: 'first' | 'last' }) => {
+        const { skipSetCount = false, zeroAt = 'last' } = options ?? {};
+        const keyOffset = zeroAt === 'first' ? 0 : -(records.length - 1);
+        recordsRef.current = new DoubleTailedArray(records, keyOffset);
         if (!skipSetCount) setCount(recordsRef.current.length);
       },
       append: (records: LogRecord[]) => {
@@ -241,7 +243,7 @@ export const useInit = ({ client, config, refs, actions, services }: Runtime) =>
           // Update UI
           if (result.records.length) {
             if (result.nextCursor !== null) actions.setHasMoreAfter(true);
-            services.recordStore.new(result.records);
+            services.recordStore.new(result.records, { zeroAt: 'first' });
           }
 
           // eslint-disable-next-line react-hooks/immutability -- refs are shared via Runtime, not truly immutable args
@@ -297,7 +299,7 @@ export const useInit = ({ client, config, refs, actions, services }: Runtime) =>
             });
 
             // Combine results
-            services.recordStore.new(afterResult.records, true);
+            services.recordStore.new(afterResult.records, { skipSetCount: true });
             services.recordStore.prepend(beforeResult.records);
 
             await beforePaintPromise;

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -203,12 +203,20 @@ describe('Main', () => {
       onRowClick: vi.fn(),
     };
 
-    it('calls onRowClick when clicking the timestamp cell', () => {
+    it('calls onRowClick when clicking the pos cell', () => {
       render(<RecordRow {...defaultProps} />);
-      const timestampCell = screen.getByText(/Jun 15, 2024/);
-      fireEvent.click(timestampCell);
+      const posCell = screen.getByRole('button');
+      fireEvent.click(posCell);
       expect(defaultProps.onRowClick).toHaveBeenCalledTimes(1);
       expect(defaultProps.onRowClick).toHaveBeenCalledWith(0, expect.any(Object));
+    });
+
+    it('does not call onRowClick when clicking the timestamp cell', () => {
+      const onRowClick = vi.fn();
+      render(<RecordRow {...defaultProps} onRowClick={onRowClick} />);
+      const timestampCell = screen.getByText(/Jun 15, 2024/);
+      fireEvent.click(timestampCell);
+      expect(onRowClick).not.toHaveBeenCalled();
     });
 
     it('does not call onRowClick when clicking the message cell', () => {

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -164,7 +164,7 @@ describe('Main', () => {
       );
 
       const colIds = [...document.querySelectorAll('[data-col-id]')].map((el) => el.getAttribute('data-col-id'));
-      expect(colIds).toEqual([ViewerColumn.Pod, ViewerColumn.Timestamp, ViewerColumn.Message]);
+      expect(colIds).toEqual(['Pos', ViewerColumn.Pod, ViewerColumn.Timestamp, ViewerColumn.Message]);
     });
   });
 
@@ -225,6 +225,59 @@ describe('Main', () => {
       const row = screen.getByRole('row');
       fireEvent.click(row);
       expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('RecordRow Key column', () => {
+    const mockRow: LogViewerVirtualRow = {
+      index: 0,
+      key: 0,
+      size: 20,
+      start: 0,
+      record: {
+        timestamp: '2024-06-15T10:30:01.123Z',
+        message: 'test message',
+        cursor: 'cursor-1',
+        source: {
+          metadata: { region: 'us-east-1', zone: 'us-east-1a', os: 'linux', arch: 'amd64', node: 'node-1' },
+          namespace: 'default',
+          podName: 'my-pod',
+          containerName: 'my-container',
+        },
+      },
+    };
+
+    const defaultProps = {
+      row: mockRow,
+      gridTemplate: 'auto auto 1fr',
+      visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      isWrap: false,
+      isSelected: false,
+      isSelectionTop: false,
+      isSelectionBottom: false,
+      maxRowWidth: 500,
+      colWidths: new Map<ViewerColumn, number>(),
+      measureElement: vi.fn(),
+      measureRowElement: vi.fn(),
+      measureCellElement: vi.fn(),
+      onRowClick: vi.fn(),
+    };
+
+    it('renders "0" when row key is 0', () => {
+      render(<RecordRow {...defaultProps} row={{ ...mockRow, key: 0 }} />);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('renders "+2" when row key is positive', () => {
+      render(<RecordRow {...defaultProps} row={{ ...mockRow, key: 2 }} />);
+      expect(screen.getByText('+')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('renders "-3" when row key is negative', () => {
+      render(<RecordRow {...defaultProps} row={{ ...mockRow, key: -3 }} />);
+      expect(screen.getByText('-')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
     });
   });
 

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -413,18 +413,27 @@ export const RecordRow = memo(
   }: RecordRowProps) => {
     const els: React.ReactElement[] = [];
 
-    // Pos column (always first)
+    // Pos column (always first, acts as row selector)
     els.push(
       <div
         key="__pos__"
         data-col-id="Pos"
+        role="button"
+        tabIndex={0}
         className={cn(
           isSelected && 'bg-blue-500/10 dark:bg-blue-500/15',
           !isSelected && row.index % 2 !== 0 && 'bg-chrome-100',
           row.key === 0 && 'border-l-2 border-green-500 font-extrabold',
           row.key !== 0 && 'text-chrome-800',
-          'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5',
+          'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5 cursor-pointer select-none outline-none',
         )}
+        onClick={(e) => onRowClick(row.key, e)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onRowClick(row.key, e as unknown as React.MouseEvent);
+          }
+        }}
       >
         {row.key !== 0 && <span className="text-chrome-300 text-[0.9rem]">{row.key > 0 ? '+' : '-'}</span>}
         {Math.abs(row.key)}
@@ -449,42 +458,18 @@ export const RecordRow = memo(
         shouldWrap ? 'whitespace-pre-wrap wrap-break-word' : 'whitespace-nowrap',
       );
 
-      if (isTimestamp) {
-        els.push(
-          <CellContextMenu key={col} col={col} record={row.record}>
-            <div
-              ref={measureCellElement}
-              data-col-id={col}
-              role="button"
-              tabIndex={0}
-              className={cn(cellClassName, 'cursor-pointer select-none outline-none')}
-              style={minWidth ? { minWidth: `${minWidth}px` } : undefined}
-              onClick={(e) => onRowClick(row.key, e)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onRowClick(row.key, e as unknown as React.MouseEvent);
-                }
-              }}
-            >
-              {getAttribute(row.record, col)}
-            </div>
-          </CellContextMenu>,
-        );
-      } else {
-        els.push(
-          <CellContextMenu key={col} col={col} record={row.record}>
-            <div
-              ref={measureCellElement}
-              data-col-id={col}
-              className={cellClassName}
-              style={minWidth ? { minWidth: `${minWidth}px` } : undefined}
-            >
-              {getAttribute(row.record, col)}
-            </div>
-          </CellContextMenu>,
-        );
-      }
+      els.push(
+        <CellContextMenu key={col} col={col} record={row.record}>
+          <div
+            ref={measureCellElement}
+            data-col-id={col}
+            className={cellClassName}
+            style={minWidth ? { minWidth: `${minWidth}px` } : undefined}
+          >
+            {getAttribute(row.record, col)}
+          </div>
+        </CellContextMenu>,
+      );
     });
 
     return (

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -316,6 +316,7 @@ const HeaderRow = ({
           minWidth: isWrap ? '100%' : maxRowWidth || '100%',
         }}
       >
+        <div data-col-id="Pos" />
         {[...visibleCols].map((col) => {
           const minWidth = isWrap && col === ViewerColumn.Message ? undefined : colWidths.get(col);
           return (
@@ -411,6 +412,25 @@ export const RecordRow = memo(
     onRowClick,
   }: RecordRowProps) => {
     const els: React.ReactElement[] = [];
+
+    // Pos column (always first)
+    els.push(
+      <div
+        key="__pos__"
+        data-col-id="Pos"
+        className={cn(
+          isSelected && 'bg-blue-500/10 dark:bg-blue-500/15',
+          !isSelected && row.index % 2 !== 0 && 'bg-chrome-100',
+          row.key === 0 && 'border-l-2 border-green-500 font-extrabold',
+          row.key !== 0 && 'text-chrome-800',
+          'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5',
+        )}
+      >
+        {row.key !== 0 && <span className="text-chrome-300 text-[0.9rem]">{row.key > 0 ? '+' : '-'}</span>}
+        {Math.abs(row.key)}
+      </div>,
+    );
+
     visibleCols.forEach((col) => {
       const minWidth = isWrap && col === ViewerColumn.Message ? undefined : colWidths.get(col);
       const shouldWrap = isWrap && col === ViewerColumn.Message;
@@ -536,8 +556,8 @@ export const Main = () => {
   // Generate grid template
   const gridTemplate = useMemo(
     () =>
-      // Keep natural sizing - let cells determine column width
-      [...visibleCols].map((col) => (col === ViewerColumn.Message ? '1fr' : 'auto')).join(' '),
+      // Key column (auto) + visible columns
+      `3rem ${[...visibleCols].map((col) => (col === ViewerColumn.Message ? '1fr' : 'auto')).join(' ')}`,
     [visibleCols],
   );
 


### PR DESCRIPTION
Ref #777 

## Summary

Adds a new "Pos" column to the log viewer that displays the relative position of each log record from the cursor origin. The position column also serves as the row selector for click-based selection, replacing the previous timestamp-based selection.

<img width="1231" height="1034" alt="Screenshot 2026-04-11 at 7 39 45 AM" src="https://github.com/user-attachments/assets/4ff8ad80-a1f0-4f99-9606-c6f17b7399f0" />

## Key Changes

- Add `key` property to `DoubleTailedArray` and `LogViewerVirtualRow` to track relative position from cursor origin
- Add a "Pos" column as the first column in the log viewer grid, showing `0` for the origin, `+N`/`-N` for offsets
- Move row selection click handler from the Timestamp column to the Pos column
- Simplify Timestamp column rendering by removing its interactive behavior

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused