### PR TITLE
🐋 Add cell-level selection and copy to log viewer

### DIFF
--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -197,10 +197,13 @@ describe('Main', () => {
       isSelectionBottom: false,
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
+      selectedCellCol: null as ViewerColumn | null,
+      isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
       onRowClick: vi.fn(),
+      onCellClick: vi.fn(),
     };
 
     it('calls onRowClick when clicking the pos cell', () => {
@@ -211,20 +214,20 @@ describe('Main', () => {
       expect(defaultProps.onRowClick).toHaveBeenCalledWith(0, expect.any(Object));
     });
 
-    it('does not call onRowClick when clicking the timestamp cell', () => {
-      const onRowClick = vi.fn();
-      render(<RecordRow {...defaultProps} onRowClick={onRowClick} />);
+    it('calls onCellClick when clicking the timestamp cell', () => {
+      const onCellClick = vi.fn();
+      render(<RecordRow {...defaultProps} onCellClick={onCellClick} />);
       const timestampCell = screen.getByText(/Jun 15, 2024/);
       fireEvent.click(timestampCell);
-      expect(onRowClick).not.toHaveBeenCalled();
+      expect(onCellClick).toHaveBeenCalledWith(0, ViewerColumn.Timestamp, expect.any(Object));
     });
 
-    it('does not call onRowClick when clicking the message cell', () => {
-      const onRowClick = vi.fn();
-      render(<RecordRow {...defaultProps} onRowClick={onRowClick} />);
+    it('calls onCellClick when clicking the message cell', () => {
+      const onCellClick = vi.fn();
+      render(<RecordRow {...defaultProps} onCellClick={onCellClick} />);
       const messageCell = screen.getByText('test message');
       fireEvent.click(messageCell);
-      expect(onRowClick).not.toHaveBeenCalled();
+      expect(onCellClick).toHaveBeenCalledWith(0, ViewerColumn.Message, expect.any(Object));
     });
 
     it('does not call onRowClick when clicking the row background', () => {
@@ -233,6 +236,122 @@ describe('Main', () => {
       const row = screen.getByRole('row');
       fireEvent.click(row);
       expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('RecordRow cell selection', () => {
+    const mockRow: LogViewerVirtualRow = {
+      index: 0,
+      key: 0,
+      size: 20,
+      start: 0,
+      record: {
+        timestamp: '2024-06-15T10:30:01.123Z',
+        message: 'test message',
+        cursor: 'cursor-1',
+        source: {
+          metadata: { region: 'us-east-1', zone: 'us-east-1a', os: 'linux', arch: 'amd64', node: 'node-1' },
+          namespace: 'default',
+          podName: 'my-pod',
+          containerName: 'my-container',
+        },
+      },
+    };
+
+    const defaultProps = {
+      row: mockRow,
+      gridTemplate: 'auto 1fr',
+      visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      isWrap: false,
+      isSelected: false,
+      isSelectionTop: false,
+      isSelectionBottom: false,
+      maxRowWidth: 500,
+      colWidths: new Map<ViewerColumn, number>(),
+      selectedCellCol: null as ViewerColumn | null,
+      isCellTextSelectable: false,
+      measureElement: vi.fn(),
+      measureRowElement: vi.fn(),
+      measureCellElement: vi.fn(),
+      onRowClick: vi.fn(),
+      onCellClick: vi.fn(),
+    };
+
+    it('sets userSelect to auto on mousedown of selected cell', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      fireEvent.mouseDown(messageCell);
+      expect(messageCell.style.userSelect).toBe('auto');
+    });
+
+    it('does not set userSelect on mousedown of unselected cell', () => {
+      render(<RecordRow {...defaultProps} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      fireEvent.mouseDown(messageCell);
+      expect(messageCell.style.userSelect).toBe('');
+    });
+
+    it('does not call onCellClick on ColorDot column', () => {
+      const onCellClick = vi.fn();
+      render(
+        <RecordRow
+          {...defaultProps}
+          visibleCols={new Set([ViewerColumn.ColorDot, ViewerColumn.Message])}
+          onCellClick={onCellClick}
+        />,
+      );
+      const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
+      fireEvent.click(colorDotCell);
+      expect(onCellClick).not.toHaveBeenCalled();
+    });
+
+    it('data cells have gridcell role', () => {
+      render(<RecordRow {...defaultProps} />);
+      const gridcells = screen.getAllByRole('gridcell');
+      expect(gridcells.length).toBe(2); // Timestamp + Message
+    });
+
+    it('data cells have select-none by default', () => {
+      render(<RecordRow {...defaultProps} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.classList.contains('select-none')).toBe(true);
+    });
+
+    it('selected cell shows ring highlight', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.classList.contains('ring-2')).toBe(true);
+      expect(messageCell.classList.contains('ring-blue-500')).toBe(true);
+    });
+
+    it('non-selected cells do not show ring highlight', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
+      expect(timestampCell.classList.contains('ring-2')).toBe(false);
+    });
+
+    it('selected cell in text-select mode has userSelect auto style', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} isCellTextSelectable />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.style.userSelect).toBe('auto');
+    });
+
+    it('non-selected cells do not have userSelect auto when another cell is text-selectable', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} isCellTextSelectable />);
+      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
+      expect(timestampCell.style.userSelect).toBe('');
+    });
+
+    it('unselected cells have cursor-default class', () => {
+      render(<RecordRow {...defaultProps} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.classList.contains('cursor-default')).toBe(true);
+    });
+
+    it('selected cell has cursor-text class', () => {
+      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.classList.contains('cursor-text')).toBe(true);
     });
   });
 
@@ -265,10 +384,13 @@ describe('Main', () => {
       isSelectionBottom: false,
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
+      selectedCellCol: null as ViewerColumn | null,
+      isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
       onRowClick: vi.fn(),
+      onCellClick: vi.fn(),
     };
 
     it('renders "0" when row key is 0', () => {

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -389,10 +389,13 @@ type RecordRowProps = {
   isSelectionBottom: boolean;
   maxRowWidth: number;
   colWidths: Map<ViewerColumn, number>;
+  selectedCellCol: ViewerColumn | null;
+  isCellTextSelectable: boolean;
   measureElement: (node: Element | null) => void;
   measureRowElement: (el: HTMLDivElement | null) => void;
   measureCellElement: (el: HTMLDivElement | null) => void;
   onRowClick: (key: number, event: React.MouseEvent) => void;
+  onCellClick: (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => void;
 };
 
 export const RecordRow = memo(
@@ -406,10 +409,13 @@ export const RecordRow = memo(
     isSelectionBottom,
     maxRowWidth,
     colWidths,
+    selectedCellCol,
+    isCellTextSelectable,
     measureElement,
     measureRowElement,
     measureCellElement,
     onRowClick,
+    onCellClick,
   }: RecordRowProps) => {
     const els: React.ReactElement[] = [];
 
@@ -421,9 +427,9 @@ export const RecordRow = memo(
         role="button"
         tabIndex={0}
         className={cn(
-          isSelected && 'bg-blue-500/10 dark:bg-blue-500/15',
+          isSelected && 'bg-blue-500/20 dark:bg-blue-500/25',
           !isSelected && row.index % 2 !== 0 && 'bg-chrome-100',
-          row.key === 0 && 'border-l-2 border-green-500 font-extrabold',
+          row.key === 0 && 'border-l-2 border-green-500 font-extrabold pl-[7px]',
           row.key !== 0 && 'text-chrome-800',
           'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5 cursor-pointer select-none outline-none',
         )}
@@ -444,10 +450,12 @@ export const RecordRow = memo(
       const minWidth = isWrap && col === ViewerColumn.Message ? undefined : colWidths.get(col);
       const shouldWrap = isWrap && col === ViewerColumn.Message;
       const isTimestamp = col === ViewerColumn.Timestamp;
+      const isCellSelected = selectedCellCol === col;
+      const isColorDot = col === ViewerColumn.ColorDot;
 
       let cellBg: string | false;
       if (isSelected) {
-        cellBg = isTimestamp ? 'bg-blue-500/35 dark:bg-blue-500/35' : 'bg-blue-500/10 dark:bg-blue-500/15';
+        cellBg = isTimestamp ? 'bg-blue-500/25 dark:bg-blue-500/25' : 'bg-blue-500/15 dark:bg-blue-500/20';
       } else {
         cellBg = isTimestamp ? 'bg-chrome-200' : row.index % 2 !== 0 && 'bg-chrome-100';
       }
@@ -456,15 +464,44 @@ export const RecordRow = memo(
         cellBg,
         'px-2',
         shouldWrap ? 'whitespace-pre-wrap wrap-break-word' : 'whitespace-nowrap',
+        !isColorDot && (isCellSelected ? 'cursor-text' : 'cursor-default'),
+        'select-none',
+        isCellSelected && 'ring-2 ring-blue-500 ring-inset',
       );
+
+      const cellStyle: React.CSSProperties = {
+        ...(minWidth && { minWidth: `${minWidth}px` }),
+        ...(isCellSelected && isCellTextSelectable && { userSelect: 'auto' as const }),
+      };
 
       els.push(
         <CellContextMenu key={col} col={col} record={row.record}>
           <div
             ref={measureCellElement}
             data-col-id={col}
+            role={isColorDot ? undefined : 'gridcell'}
+            tabIndex={isColorDot ? undefined : 0}
             className={cellClassName}
-            style={minWidth ? { minWidth: `${minWidth}px` } : undefined}
+            style={cellStyle}
+            onClick={isColorDot ? undefined : (e) => onCellClick(row.key, col, e)}
+            onMouseDown={
+              isColorDot || !isCellSelected
+                ? undefined
+                : (e) => {
+                    // Enable text selection before drag starts
+                    e.currentTarget.style.userSelect = 'auto';
+                  }
+            }
+            onKeyDown={
+              isColorDot
+                ? undefined
+                : (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onCellClick(row.key, col, e as unknown as React.MouseEvent);
+                    }
+                  }
+            }
           >
             {getAttribute(row.record, col)}
           </div>
@@ -482,7 +519,7 @@ export const RecordRow = memo(
         data-row-key={row.key}
         role="row"
         aria-selected={isSelected}
-        className="absolute top-0 left-0 grid leading-6 group"
+        className={cn('absolute top-0 left-0 grid leading-6 group', selectedCellCol && 'z-10')}
         style={{
           gridTemplateColumns: gridTemplate,
           minWidth: isWrap ? '100%' : maxRowWidth || '100%',
@@ -507,6 +544,8 @@ export const RecordRow = memo(
     if (prev.isSelectionBottom !== next.isSelectionBottom) return false;
     if (prev.maxRowWidth !== next.maxRowWidth) return false;
     if (prev.colWidths !== next.colWidths) return false;
+    if (prev.selectedCellCol !== next.selectedCellCol) return false;
+    if (prev.isCellTextSelectable !== next.isCellTextSelectable) return false;
     return true;
   },
 );
@@ -535,8 +574,16 @@ export const Main = () => {
   const visibleCols = useAtomValue(visibleColsAtom);
   const virtualizerRef = useRef<LogViewerVirtualizer | null>(null);
 
-  const { selectedKeys, selectionTopKeys, selectionBottomKeys, handleRowClick, resetSelection } =
-    useSelection(virtualizerRef);
+  const {
+    selectedKeys,
+    selectionTopKeys,
+    selectionBottomKeys,
+    selectedCell,
+    isTextSelectMode,
+    handleRowClick,
+    handleCellClick,
+    resetSelection,
+  } = useSelection(virtualizerRef);
 
   // Generate grid template
   const gridTemplate = useMemo(
@@ -643,9 +690,12 @@ export const Main = () => {
                     isSelectionBottom={selectionBottomKeys.has(virtualRow.key)}
                     maxRowWidth={maxRowWidth}
                     colWidths={colWidths}
+                    selectedCellCol={selectedCell?.rowKey === virtualRow.key ? selectedCell.col : null}
+                    isCellTextSelectable={selectedCell?.rowKey === virtualRow.key && isTextSelectMode}
                     measureRowElement={measureRowElement}
                     measureCellElement={measureCellElement}
                     onRowClick={handleRowClick}
+                    onCellClick={handleCellClick}
                   />
                 ))}
                 {virtualizer.hasMoreAfter && (

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -20,7 +20,7 @@ import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-v
 
 import { getPlainAttribute, formatRowsForCopy, computeSelection, useSelection } from './selection';
 import { ViewerColumn } from './shared';
-import { visibleColsAtom } from './state';
+import { isTextSelectModeAtom, selectedCellAtom, visibleColsAtom } from './state';
 
 const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
   timestamp: '2024-06-15T10:30:01.123Z',
@@ -243,7 +243,13 @@ describe('useSelection', () => {
   }
 
   const clickEvent = (overrides: Partial<React.MouseEvent> = {}) =>
-    ({ shiftKey: false, metaKey: false, ctrlKey: false, ...overrides }) as React.MouseEvent;
+    ({
+      shiftKey: false,
+      metaKey: false,
+      ctrlKey: false,
+      stopPropagation: vi.fn(),
+      ...overrides,
+    }) as unknown as React.MouseEvent;
 
   beforeEach(() => {
     Object.assign(navigator, {
@@ -336,6 +342,80 @@ describe('useSelection', () => {
     });
   });
 
+  describe('handleCellClick', () => {
+    it('selects a cell on click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+
+      expect(result.current.selectedCell).toEqual({ rowKey: 1, col: ViewerColumn.Message });
+    });
+
+    it('clears row selection when clicking a cell', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowClick(0, clickEvent()));
+      expect(result.current.selectedKeys.size).toBe(1);
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+
+      expect(result.current.selectedKeys.size).toBe(0);
+      expect(result.current.selectedCell).toEqual({ rowKey: 0, col: ViewerColumn.Message });
+    });
+
+    it('clears text-select mode when clicking without a native selection', () => {
+      const { result } = renderUseSelection();
+
+      // Simulate entering text-select mode via a prior drag
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+
+      expect(result.current.isTextSelectMode).toBe(false);
+    });
+
+    it('ignores ColorDot column clicks', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.ColorDot, clickEvent()));
+
+      expect(result.current.selectedCell).toBeNull();
+    });
+
+    it('replaces previously selected cell', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent()));
+
+      expect(result.current.selectedCell).toEqual({ rowKey: 1, col: ViewerColumn.Pod });
+    });
+  });
+
+  describe('handleRowClick clears cell state', () => {
+    it('clears cell selection when clicking Pos column', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      expect(result.current.selectedCell).not.toBeNull();
+
+      act(() => result.current.handleRowClick(0, clickEvent()));
+
+      expect(result.current.selectedCell).toBeNull();
+    });
+
+    it('clears text-select mode when clicking Pos column', () => {
+      const { result, store } = renderUseSelection();
+
+      store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(isTextSelectModeAtom, true);
+
+      act(() => result.current.handleRowClick(0, clickEvent()));
+
+      expect(result.current.isTextSelectMode).toBe(false);
+    });
+  });
+
   describe('resetSelection', () => {
     it('clears selection state', () => {
       const { result } = renderUseSelection();
@@ -345,6 +425,18 @@ describe('useSelection', () => {
 
       act(() => result.current.resetSelection());
       expect(result.current.selectedKeys.size).toBe(0);
+    });
+
+    it('clears cell selection and text-select mode', () => {
+      const { result, store } = renderUseSelection();
+
+      store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(isTextSelectModeAtom, true);
+
+      act(() => result.current.resetSelection());
+
+      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.isTextSelectMode).toBe(false);
     });
   });
 
@@ -397,6 +489,72 @@ describe('useSelection', () => {
       });
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('my-pod-abc\tlog message 0');
+    });
+
+    it('copies cell text on Cmd+C when a cell is selected', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'c', metaKey: true });
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 0');
+    });
+
+    it('copies cell text for non-message columns', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'c', metaKey: true });
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('my-pod-abc');
+    });
+
+    it('prefers cell copy over row copy when cell is selected', () => {
+      const { result } = renderUseSelection();
+
+      // Select a row, then select a cell (which clears row selection)
+      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'c', metaKey: true });
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 1');
+    });
+
+    it('clears cell selection on Escape', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      expect(result.current.selectedCell).not.toBeNull();
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+
+      expect(result.current.selectedCell).toBeNull();
+    });
+
+    it('clears text-select mode on Escape', () => {
+      const { result, store } = renderUseSelection();
+
+      store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(isTextSelectModeAtom, true);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+
+      expect(result.current.isTextSelectMode).toBe(false);
     });
 
     it('excludes ColorDot from default columns (Timestamp + ColorDot + Message)', () => {

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -21,7 +21,7 @@ import { stripAnsi } from 'fancy-ansi';
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
 
 import { ViewerColumn } from './shared';
-import { lastClickedKeyAtom, selectedKeysAtom, visibleColsAtom } from './state';
+import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellAtom, selectedKeysAtom, visibleColsAtom } from './state';
 
 /**
  * getPlainAttribute - Returns a plain text string for a given log record column.
@@ -116,25 +116,26 @@ export function computeSelection({
 }
 
 /**
- * useSelection - Hook that manages row selection state, click handling, boundary
- * computation, and keyboard shortcuts (Escape to clear, Cmd/Ctrl+C to copy).
+ * useSelection - Hook that manages row selection, cell selection, text-select mode,
+ * click handling, boundary computation, and keyboard shortcuts.
  */
 export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {
   const visibleCols = useAtomValue(visibleColsAtom);
   const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
   const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
+  const [selectedCell, setSelectedCell] = useAtom(selectedCellAtom);
+  const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
 
   // Refs to avoid stale closures in callbacks
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
+  const selectedCellRef = useRef(selectedCell);
 
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
-  }, [selectedKeys]);
-
-  useEffect(() => {
     lastClickedKeyRef.current = lastClickedKey;
-  }, [lastClickedKey]);
+    selectedCellRef.current = selectedCell;
+  }, [selectedKeys, lastClickedKey, selectedCell]);
 
   // Pre-compute selection boundary sets (keys are sequential integers)
   const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
@@ -148,7 +149,15 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     return { selectionTopKeys: top, selectionBottomKeys: bottom };
   }, [selectedKeys]);
 
-  // Row click handler
+  // Clear all selection state
+  const clearSelection = useCallback(() => {
+    setSelectedKeys(new Set());
+    setLastClickedKey(null);
+    setSelectedCell(null);
+    setIsTextSelectMode(false);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode]);
+
+  // Row click handler (Pos column)
   const handleRowClick = useCallback(
     (key: number, event: React.MouseEvent) => {
       const next = computeSelection({
@@ -160,47 +169,79 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       });
       setSelectedKeys(next);
       setLastClickedKey(key);
+      setSelectedCell(null);
+      setIsTextSelectMode(false);
     },
-    [setSelectedKeys, setLastClickedKey],
+    [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode],
   );
 
-  // Reset selection
-  const resetSelection = useCallback(() => {
-    setSelectedKeys(new Set());
-    setLastClickedKey(null);
-  }, [setSelectedKeys, setLastClickedKey]);
+  // Cell click handler (data cells)
+  const handleCellClick = useCallback(
+    (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
+      if (col === ViewerColumn.ColorDot) return;
+      event.stopPropagation();
+      const hasTextSelection = !window.getSelection()?.isCollapsed;
+      setSelectedCell({ rowKey, col });
+      setSelectedKeys(new Set());
+      setLastClickedKey(null);
+      setIsTextSelectMode(hasTextSelection);
+    },
+    [setSelectedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
+  );
 
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const isMod = e.metaKey || e.ctrlKey;
-
       if (e.key === 'Escape') {
-        setSelectedKeys(new Set());
+        clearSelection();
+        window.getSelection()?.removeAllRanges();
         return;
       }
 
-      if (isMod && e.key === 'c' && selectedKeysRef.current.size > 0) {
-        e.preventDefault();
-        const v = virtualizerRef.current;
-        if (!v) return;
-        // Keys are sequential so numeric sort gives display order
-        const sorted = [...selectedKeysRef.current].sort((a, b) => a - b);
-        const records = sorted.map((k) => v.getRecord(k)).filter((r): r is LogRecord => r !== undefined);
-        const text = formatRowsForCopy(records, visibleCols);
-        navigator.clipboard.writeText(text);
+      const isMod = e.metaKey || e.ctrlKey;
+      if (isMod && e.key === 'c') {
+        // If user has native text selection (from text-select mode), let browser handle it
+        const nativeSel = window.getSelection();
+        if (nativeSel && !nativeSel.isCollapsed) return;
+
+        // Copy selected cell text
+        const cell = selectedCellRef.current;
+        if (cell) {
+          e.preventDefault();
+          const v = virtualizerRef.current;
+          if (!v) return;
+          const record = v.getRecord(cell.rowKey);
+          if (record) {
+            navigator.clipboard.writeText(getPlainAttribute(record, cell.col));
+          }
+          return;
+        }
+
+        // Copy selected rows as TSV
+        if (selectedKeysRef.current.size > 0) {
+          e.preventDefault();
+          const v = virtualizerRef.current;
+          if (!v) return;
+          const sorted = [...selectedKeysRef.current].sort((a, b) => a - b);
+          const records = sorted.map((k) => v.getRecord(k)).filter((r): r is LogRecord => r !== undefined);
+          const text = formatRowsForCopy(records, visibleCols);
+          navigator.clipboard.writeText(text);
+        }
       }
     };
 
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [visibleCols, setSelectedKeys]);
+  }, [visibleCols, clearSelection]);
 
   return {
     selectedKeys,
     selectionTopKeys,
     selectionBottomKeys,
+    selectedCell,
+    isTextSelectMode,
     handleRowClick,
-    resetSelection,
+    handleCellClick,
+    resetSelection: clearSelection,
   };
 }

--- a/dashboard-ui/src/pages/console/state.ts
+++ b/dashboard-ui/src/pages/console/state.ts
@@ -30,6 +30,10 @@ export const selectedKeysAtom = atom(new Set<number>());
 
 export const lastClickedKeyAtom = atom<number | null>(null);
 
+export const selectedCellAtom = atom<{ rowKey: number; col: ViewerColumn } | null>(null);
+
+export const isTextSelectModeAtom = atom(false);
+
 export const isWrapAtom = atom(false);
 
 export const visibleColsAtom = atom(


### PR DESCRIPTION
## Summary

Adds the ability to click individual cells in the log viewer to select them with a ring highlight, then copy the cell text with Cmd/Ctrl+C. Selected cells enter a text-select mode that allows drag-to-select within the cell for partial text copying. Escape clears all selection state.

## Key Changes

- Add cell click handler that selects individual cells with a blue ring highlight, clearing any row selection
- Support Cmd/Ctrl+C to copy selected cell text (cell copy takes priority over native text selection)
- Enable text-select mode on selected cells so users can drag-to-select within a cell
- Add `selectedCellAtom` and `isTextSelectModeAtom` to Jotai state for cell selection tracking
- Adjust row selection highlight opacity and fix Pos column padding for the key=0 border
- Add comprehensive tests for cell selection, click handling, keyboard shortcuts, and rendering

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused