### PR TITLE
🐋 Add drag-to-select on Pos column in log viewer

### DIFF
--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -202,16 +202,16 @@ describe('Main', () => {
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
-      onRowClick: vi.fn(),
+      onRowMouseDown: vi.fn(),
       onCellClick: vi.fn(),
     };
 
-    it('calls onRowClick when clicking the pos cell', () => {
+    it('calls onRowMouseDown when mousedown on the pos cell', () => {
       render(<RecordRow {...defaultProps} />);
       const posCell = screen.getByRole('button');
-      fireEvent.click(posCell);
-      expect(defaultProps.onRowClick).toHaveBeenCalledTimes(1);
-      expect(defaultProps.onRowClick).toHaveBeenCalledWith(0, expect.any(Object));
+      fireEvent.mouseDown(posCell);
+      expect(defaultProps.onRowMouseDown).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onRowMouseDown).toHaveBeenCalledWith(0, expect.any(Object));
     });
 
     it('calls onCellClick when clicking the timestamp cell', () => {
@@ -230,12 +230,12 @@ describe('Main', () => {
       expect(onCellClick).toHaveBeenCalledWith(0, ViewerColumn.Message, expect.any(Object));
     });
 
-    it('does not call onRowClick when clicking the row background', () => {
-      const onRowClick = vi.fn();
-      render(<RecordRow {...defaultProps} onRowClick={onRowClick} />);
+    it('does not call onRowMouseDown when clicking the row background', () => {
+      const onRowMouseDown = vi.fn();
+      render(<RecordRow {...defaultProps} onRowMouseDown={onRowMouseDown} />);
       const row = screen.getByRole('row');
-      fireEvent.click(row);
-      expect(onRowClick).not.toHaveBeenCalled();
+      fireEvent.mouseDown(row);
+      expect(onRowMouseDown).not.toHaveBeenCalled();
     });
   });
 
@@ -273,7 +273,7 @@ describe('Main', () => {
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
-      onRowClick: vi.fn(),
+      onRowMouseDown: vi.fn(),
       onCellClick: vi.fn(),
     };
 
@@ -389,7 +389,7 @@ describe('Main', () => {
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
-      onRowClick: vi.fn(),
+      onRowMouseDown: vi.fn(),
       onCellClick: vi.fn(),
     };
 

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -394,7 +394,7 @@ type RecordRowProps = {
   measureElement: (node: Element | null) => void;
   measureRowElement: (el: HTMLDivElement | null) => void;
   measureCellElement: (el: HTMLDivElement | null) => void;
-  onRowClick: (key: number, event: React.MouseEvent) => void;
+  onRowMouseDown: (key: number, event: React.MouseEvent) => void;
   onCellClick: (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => void;
 };
 
@@ -414,7 +414,7 @@ export const RecordRow = memo(
     measureElement,
     measureRowElement,
     measureCellElement,
-    onRowClick,
+    onRowMouseDown,
     onCellClick,
   }: RecordRowProps) => {
     const els: React.ReactElement[] = [];
@@ -431,13 +431,13 @@ export const RecordRow = memo(
           !isSelected && row.index % 2 !== 0 && 'bg-chrome-100',
           row.key === 0 && 'border-l-2 border-green-500 font-extrabold pl-[7px]',
           row.key !== 0 && 'text-chrome-800',
-          'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5 cursor-pointer select-none outline-none',
+          'whitespace-nowrap tabular-nums text-[0.65rem] text-center pr-1.5 cursor-default select-none outline-none',
         )}
-        onClick={(e) => onRowClick(row.key, e)}
+        onMouseDown={(e) => onRowMouseDown(row.key, e)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            onRowClick(row.key, e as unknown as React.MouseEvent);
+            onRowMouseDown(row.key, e as unknown as React.MouseEvent);
           }
         }}
       >
@@ -580,7 +580,7 @@ export const Main = () => {
     selectionBottomKeys,
     selectedCell,
     isTextSelectMode,
-    handleRowClick,
+    handleRowMouseDown,
     handleCellClick,
     resetSelection,
   } = useSelection(virtualizerRef);
@@ -694,7 +694,7 @@ export const Main = () => {
                     isCellTextSelectable={selectedCell?.rowKey === virtualRow.key && isTextSelectMode}
                     measureRowElement={measureRowElement}
                     measureCellElement={measureCellElement}
-                    onRowClick={handleRowClick}
+                    onRowMouseDown={handleRowMouseDown}
                     onCellClick={handleCellClick}
                   />
                 ))}

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -20,7 +20,7 @@ import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-v
 
 import { getPlainAttribute, formatRowsForCopy, computeSelection, useSelection } from './selection';
 import { ViewerColumn } from './shared';
-import { isTextSelectModeAtom, selectedCellAtom, visibleColsAtom } from './state';
+import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellAtom, visibleColsAtom } from './state';
 
 const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
   timestamp: '2024-06-15T10:30:01.123Z',
@@ -257,48 +257,66 @@ describe('useSelection', () => {
     });
   });
 
-  describe('handleRowClick', () => {
-    it('selects a single row on plain click', () => {
+  describe('handleRowMouseDown', () => {
+    it('selects a single row on plain mousedown', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(1, clickEvent()));
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(result.current.selectedKeys).toEqual(new Set([1]));
     });
 
-    it('replaces selection on plain click', () => {
+    it('replaces selection on plain mousedown', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(1, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(result.current.selectedKeys).toEqual(new Set([1]));
     });
 
-    it('toggles individual rows with meta+click', () => {
+    it('toggles individual rows with meta+mousedown', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(1, clickEvent({ metaKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(1, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedKeys).toEqual(new Set([0, 1]));
     });
 
-    it('deselects a row with meta+click when already selected', () => {
+    it('deselects a row with meta+mousedown when already selected', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       expect(result.current.selectedKeys).toEqual(new Set([0]));
 
-      act(() => result.current.handleRowClick(0, clickEvent({ metaKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent({ metaKey: true })));
       expect(result.current.selectedKeys).toEqual(new Set());
     });
 
-    it('selects range with shift+click', () => {
+    it('selects range with shift+mousedown', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(2, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(2, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedKeys).toEqual(new Set([0, 1, 2]));
     });
@@ -308,7 +326,10 @@ describe('useSelection', () => {
     it('single selected row is both top and bottom', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(1, clickEvent()));
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(result.current.selectionTopKeys).toEqual(new Set([1]));
       expect(result.current.selectionBottomKeys).toEqual(new Set([1]));
@@ -317,8 +338,11 @@ describe('useSelection', () => {
     it('contiguous block has top on first and bottom on last', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(2, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(2, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectionTopKeys).toEqual(new Set([0]));
       expect(result.current.selectionBottomKeys).toEqual(new Set([2]));
@@ -327,8 +351,11 @@ describe('useSelection', () => {
     it('non-contiguous selection creates separate boundary groups', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(2, clickEvent({ metaKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(2, clickEvent({ metaKey: true })));
 
       expect(result.current.selectionTopKeys).toEqual(new Set([0, 2]));
       expect(result.current.selectionBottomKeys).toEqual(new Set([0, 2]));
@@ -354,7 +381,10 @@ describe('useSelection', () => {
     it('clears row selection when clicking a cell', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       expect(result.current.selectedKeys.size).toBe(1);
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
@@ -392,25 +422,226 @@ describe('useSelection', () => {
     });
   });
 
-  describe('handleRowClick clears cell state', () => {
-    it('clears cell selection when clicking Pos column', () => {
+  describe('drag selection', () => {
+    function makeRowEl(key: number) {
+      const el = document.createElement('div');
+      el.dataset.rowKey = String(key);
+      el.closest = (selector: string) => (selector === '[data-row-key]' ? el : null);
+      return el;
+    }
+
+    let mockElementFromPoint: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockElementFromPoint = vi.fn().mockReturnValue(null);
+      document.elementFromPoint = mockElementFromPoint as typeof document.elementFromPoint;
+    });
+
+    afterEach(() => {
+      delete (document as Partial<Document>).elementFromPoint;
+    });
+
+    it('selects range when dragging from one row to another', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeRowEl(3));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 30 });
+      });
+
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('updates range dynamically as mouse moves', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      // Drag to row 4
+      mockElementFromPoint.mockReturnValue(makeRowEl(4));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3, 4]));
+
+      // Move back to row 2 — range shrinks
+      mockElementFromPoint.mockReturnValue(makeRowEl(2));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 20 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('supports dragging upward (to lower keys)', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(2, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeRowEl(0));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 5 });
+      });
+
+      expect(result.current.selectedKeys).toEqual(new Set([0, 1, 2]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('ends drag on mouseup — subsequent mousemove has no effect', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeRowEl(2));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 20 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      // Move to row 4 after mouseup — selection should NOT change
+      mockElementFromPoint.mockReturnValue(makeRowEl(4));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
+    });
+
+    it('does not start drag on shift+mousedown', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(3, clickEvent({ shiftKey: true })));
+
+      // Should be a range select from shift, not a drag
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
+
+      // mousemove should NOT extend the selection
+      mockElementFromPoint.mockReturnValue(makeRowEl(5));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 50 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
+    });
+
+    it('does not start drag on meta+mousedown', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(3, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedKeys).toEqual(new Set([1, 3]));
+
+      // mousemove should NOT change selection
+      mockElementFromPoint.mockReturnValue(makeRowEl(5));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 50 });
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 3]));
+    });
+
+    it('clears cell selection when drag starts', () => {
       const { result } = renderUseSelection();
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
       expect(result.current.selectedCell).not.toBeNull();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.isTextSelectMode).toBe(false);
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('sets lastClickedKey on mouseup so shift-click extends from drag endpoint', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeRowEl(3));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 30 });
+      });
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      // lastClickedKey should be set to the drag endpoint
+      expect(store.get(lastClickedKeyAtom)).toBe(3);
+
+      // shift+mousedown from there should extend
+      act(() => result.current.handleRowMouseDown(5, clickEvent({ shiftKey: true })));
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3, 4, 5]));
+    });
+
+    it('ignores mousemove when elementFromPoint returns null', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(null);
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 999 });
+      });
+
+      // Should still just have the initial selection
+      expect(result.current.selectedKeys).toEqual(new Set([1]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+  });
+
+  describe('handleRowMouseDown clears cell state', () => {
+    it('clears cell selection when mousedown on Pos column', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      expect(result.current.selectedCell).not.toBeNull();
+
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(result.current.selectedCell).toBeNull();
     });
 
-    it('clears text-select mode when clicking Pos column', () => {
+    it('clears text-select mode when mousedown on Pos column', () => {
       const { result, store } = renderUseSelection();
 
       store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
       store.set(isTextSelectModeAtom, true);
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(result.current.isTextSelectMode).toBe(false);
     });
@@ -420,7 +651,10 @@ describe('useSelection', () => {
     it('clears selection state', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       expect(result.current.selectedKeys.size).toBe(1);
 
       act(() => result.current.resetSelection());
@@ -444,7 +678,10 @@ describe('useSelection', () => {
     it('clears selection on Escape', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       expect(result.current.selectedKeys.size).toBe(1);
 
       act(() => {
@@ -457,8 +694,11 @@ describe('useSelection', () => {
     it('copies selected rows to clipboard on Cmd+C', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
-      act(() => result.current.handleRowClick(1, clickEvent({ metaKey: true })));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleRowMouseDown(1, clickEvent({ metaKey: true })));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -482,7 +722,10 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.ColorDot, ViewerColumn.Pod, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -521,7 +764,10 @@ describe('useSelection', () => {
       const { result } = renderUseSelection();
 
       // Select a row, then select a cell (which clears row selection)
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
 
       act(() => {
@@ -562,7 +808,10 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleRowClick(0, clickEvent()));
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -131,6 +131,10 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const lastClickedKeyRef = useRef(lastClickedKey);
   const selectedCellRef = useRef(selectedCell);
 
+  // Drag state refs (dragStartKeyRef !== null means a drag is active)
+  const dragStartKeyRef = useRef<number | null>(null);
+  const dragEndKeyRef = useRef<number | null>(null);
+
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
     lastClickedKeyRef.current = lastClickedKey;
@@ -157,20 +161,59 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     setIsTextSelectMode(false);
   }, [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode]);
 
-  // Row click handler (Pos column)
-  const handleRowClick = useCallback(
+  // Row mousedown handler (Pos column) — supports click and drag-to-select
+  const handleRowMouseDown = useCallback(
     (key: number, event: React.MouseEvent) => {
-      const next = computeSelection({
-        prev: selectedKeysRef.current,
-        clickedKey: key,
-        shiftKey: event.shiftKey,
-        metaOrCtrlKey: event.metaKey || event.ctrlKey,
-        lastClickedKey: lastClickedKeyRef.current,
-      });
-      setSelectedKeys(next);
-      setLastClickedKey(key);
+      // Modifier clicks don't start a drag
+      if (event.shiftKey || event.metaKey || event.ctrlKey) {
+        const next = computeSelection({
+          prev: selectedKeysRef.current,
+          clickedKey: key,
+          shiftKey: event.shiftKey,
+          metaOrCtrlKey: event.metaKey || event.ctrlKey,
+          lastClickedKey: lastClickedKeyRef.current,
+        });
+        setSelectedKeys(next);
+        setLastClickedKey(key);
+        setSelectedCell(null);
+        setIsTextSelectMode(false);
+        return;
+      }
+
+      // Start drag
+      dragStartKeyRef.current = key;
+      dragEndKeyRef.current = key;
+      setSelectedKeys(new Set([key]));
       setSelectedCell(null);
       setIsTextSelectMode(false);
+
+      const onMouseMove = (e: MouseEvent) => {
+        if (dragStartKeyRef.current === null) return;
+        e.preventDefault();
+        const el = document.elementFromPoint(e.clientX, e.clientY);
+        const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
+        if (!rowEl) return;
+        const endKey = Number(rowEl.dataset.rowKey);
+        if (Number.isNaN(endKey)) return;
+
+        dragEndKeyRef.current = endKey;
+        const minKey = Math.min(dragStartKeyRef.current, endKey);
+        const maxKey = Math.max(dragStartKeyRef.current, endKey);
+        const next = new Set<number>();
+        for (let k = minKey; k <= maxKey; k += 1) next.add(k);
+        setSelectedKeys(next);
+      };
+
+      const onMouseUp = () => {
+        setLastClickedKey(dragEndKeyRef.current);
+        dragStartKeyRef.current = null;
+        dragEndKeyRef.current = null;
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
     },
     [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode],
   );
@@ -240,7 +283,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectionBottomKeys,
     selectedCell,
     isTextSelectMode,
-    handleRowClick,
+    handleRowMouseDown,
     handleCellClick,
     resetSelection: clearSelection,
   };


### PR DESCRIPTION
## Summary

Add spreadsheet-like drag-to-select behavior to the Pos column in the log viewer. Users can now click and drag across Pos cells to select a contiguous range of rows. The Pos column cursor is changed from pointer to default to better reflect its dual click/drag behavior.

## Key Changes

- Replace `onClick` with `onMouseDown` on the Pos column to support drag-to-select via global `mousemove`/`mouseup` listeners
- Modifier clicks (shift, meta/ctrl) retain existing behavior and do not initiate a drag
- Use `document.elementFromPoint` during drag to resolve which row the cursor is over
- Change Pos column cursor from `cursor-pointer` to `cursor-default`
- Add 9 new drag-selection tests covering range selection, dynamic updates, upward drag, mouseup termination, modifier non-drag, and edge cases

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused