### PR TITLE
🐋 Disable autoscroll on mousedown in log viewer

### DIFF
--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
@@ -889,6 +889,42 @@ describe('internal helpers', () => {
 
       expect(refs.isAutoScrollEnabled.current).toBe(true);
     });
+
+    it('disables on mousedown', () => {
+      const runtime = createMockRuntime();
+      const { refs } = runtime;
+
+      (runtime as any).state = {
+        ...runtime.state,
+        isLoading: false,
+        hasMoreAfter: false,
+      };
+
+      refs.isAutoScrollEnabled.current = true;
+      renderHook(() => useAutoScroll(runtime));
+
+      refs.scrollEl.current?.dispatchEvent(new Event('mousedown'));
+
+      expect(refs.isAutoScrollEnabled.current).toBe(false);
+    });
+
+    it('mousedown is noop when autoscroll already disabled', () => {
+      const runtime = createMockRuntime();
+      const { refs } = runtime;
+
+      (runtime as any).state = {
+        ...runtime.state,
+        isLoading: false,
+        hasMoreAfter: false,
+      };
+
+      refs.isAutoScrollEnabled.current = false;
+      renderHook(() => useAutoScroll(runtime));
+
+      refs.scrollEl.current?.dispatchEvent(new Event('mousedown'));
+
+      expect(refs.isAutoScrollEnabled.current).toBe(false);
+    });
   });
 
   describe('usePullToRefresh', () => {

--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
@@ -545,7 +545,12 @@ export const useAutoScroll = ({ config, state, refs }: Runtime) => {
       }
     };
 
+    const handleMouseDown = () => {
+      refs.isAutoScrollEnabled.current = false;
+    };
+
     scrollElement.addEventListener('scroll', handleScroll);
+    scrollElement.addEventListener('mousedown', handleMouseDown);
 
     // When the scroll container resizes (e.g. the OS switches between classic and
     // overlay scrollbars, changing clientHeight), re-pin to the bottom if auto-scroll
@@ -559,6 +564,7 @@ export const useAutoScroll = ({ config, state, refs }: Runtime) => {
 
     return () => {
       scrollElement.removeEventListener('scroll', handleScroll);
+      scrollElement.removeEventListener('mousedown', handleMouseDown);
       resizeObserver.disconnect();
     };
   }, [config.pinToBottomTolerance, config.follow, state.isLoading, state.hasMoreAfter]);


### PR DESCRIPTION
## Summary

When tailing logs in the dashboard console, autoscroll keeps the view pinned to the bottom as new records arrive. This makes it difficult to inspect a specific row or cell because the view jumps away on click. This PR disables autoscroll when the user clicks anywhere in the log viewer, using the same mechanism that already disables autoscroll on scroll-up — a `mousedown` listener in `useAutoScroll`.

## Key Changes

- Add a `mousedown` event listener in `useAutoScroll` that sets `isAutoScrollEnabled` to `false`
- Add corresponding cleanup in the effect teardown
- Add two tests: one verifying mousedown disables autoscroll, one verifying it's a no-op when already disabled

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused