### PR TITLE
✨ Throttle drag-to-select and fix event listener leak in log viewer

### DIFF
--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -433,11 +433,13 @@ describe('useSelection', () => {
     let mockElementFromPoint: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
+      vi.useFakeTimers();
       mockElementFromPoint = vi.fn().mockReturnValue(null);
       document.elementFromPoint = mockElementFromPoint as typeof document.elementFromPoint;
     });
 
     afterEach(() => {
+      vi.useRealTimers();
       delete (document as Partial<Document>).elementFromPoint;
     });
 
@@ -449,6 +451,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(3));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 30 });
+        vi.advanceTimersByTime(16);
       });
 
       expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
@@ -467,6 +470,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(4));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
       });
       expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3, 4]));
 
@@ -474,6 +478,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(2));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 20 });
+        vi.advanceTimersByTime(16);
       });
       expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
 
@@ -490,6 +495,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(0));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 5 });
+        vi.advanceTimersByTime(16);
       });
 
       expect(result.current.selectedKeys).toEqual(new Set([0, 1, 2]));
@@ -507,6 +513,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(2));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 20 });
+        vi.advanceTimersByTime(16);
       });
       expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
 
@@ -518,6 +525,7 @@ describe('useSelection', () => {
       mockElementFromPoint.mockReturnValue(makeRowEl(4));
       act(() => {
         fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
       });
       expect(result.current.selectedKeys).toEqual(new Set([1, 2]));
     });
@@ -614,6 +622,78 @@ describe('useSelection', () => {
       act(() => {
         fireEvent.mouseUp(document);
       });
+    });
+
+    it('skips state update when mouse stays on same row', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      // Drag to row 3
+      mockElementFromPoint.mockReturnValue(makeRowEl(3));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 30 });
+        vi.advanceTimersByTime(16);
+      });
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
+
+      // Capture reference to verify it doesn't change
+      const prevKeys = result.current.selectedKeys;
+
+      // Move mouse within same row 3 (different coordinates, same row)
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 15, clientY: 35 });
+        vi.advanceTimersByTime(16);
+      });
+
+      // selectedKeys reference should be unchanged (no unnecessary state update)
+      expect(result.current.selectedKeys).toBe(prevKeys);
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('throttles mousemove via requestAnimationFrame', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeRowEl(3));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 30 });
+      });
+
+      // State should NOT be updated yet (deferred to rAF)
+      expect(result.current.selectedKeys).toEqual(new Set([1]));
+
+      // Flush the rAF
+      act(() => {
+        vi.advanceTimersByTime(16);
+      });
+
+      // Now state should be updated
+      expect(result.current.selectedKeys).toEqual(new Set([1, 2, 3]));
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('cleans up document listeners on unmount during active drag', () => {
+      const { result, unmount } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(1, clickEvent()));
+
+      // Unmount without mouseup
+      unmount();
+
+      // Reset mock to track new calls after unmount
+      mockElementFromPoint.mockClear();
+
+      // Subsequent mousemove should NOT trigger elementFromPoint (listener was removed)
+      fireEvent.mouseMove(document, { clientX: 10, clientY: 50 });
+      expect(mockElementFromPoint).not.toHaveBeenCalled();
     });
   });
 

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -134,6 +134,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   // Drag state refs (dragStartKeyRef !== null means a drag is active)
   const dragStartKeyRef = useRef<number | null>(null);
   const dragEndKeyRef = useRef<number | null>(null);
+  const dragAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
@@ -187,15 +188,18 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       setSelectedCell(null);
       setIsTextSelectMode(false);
 
-      const onMouseMove = (e: MouseEvent) => {
+      let rafId: number | null = null;
+      let pendingX = 0;
+      let pendingY = 0;
+
+      const processMove = () => {
+        rafId = null;
         if (dragStartKeyRef.current === null) return;
-        e.preventDefault();
-        const el = document.elementFromPoint(e.clientX, e.clientY);
+        const el = document.elementFromPoint(pendingX, pendingY);
         const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
         if (!rowEl) return;
         const endKey = Number(rowEl.dataset.rowKey);
-        if (Number.isNaN(endKey)) return;
-
+        if (Number.isNaN(endKey) || endKey === dragEndKeyRef.current) return;
         dragEndKeyRef.current = endKey;
         const minKey = Math.min(dragStartKeyRef.current, endKey);
         const maxKey = Math.max(dragStartKeyRef.current, endKey);
@@ -204,16 +208,36 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         setSelectedKeys(next);
       };
 
-      const onMouseUp = () => {
+      const onMouseMove = (e: MouseEvent) => {
+        if (dragStartKeyRef.current === null) return;
+        e.preventDefault();
+        pendingX = e.clientX;
+        pendingY = e.clientY;
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(processMove);
+      };
+
+      const onMouseUp = (e: MouseEvent) => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+          rafId = null;
+          pendingX = e.clientX;
+          pendingY = e.clientY;
+          processMove();
+        }
         setLastClickedKey(dragEndKeyRef.current);
         dragStartKeyRef.current = null;
         dragEndKeyRef.current = null;
-        document.removeEventListener('mousemove', onMouseMove);
-        document.removeEventListener('mouseup', onMouseUp);
+        dragAbortRef.current?.abort();
+        dragAbortRef.current = null;
       };
 
-      document.addEventListener('mousemove', onMouseMove);
-      document.addEventListener('mouseup', onMouseUp);
+      dragAbortRef.current?.abort();
+      dragAbortRef.current = new AbortController();
+      const { signal } = dragAbortRef.current;
+
+      document.addEventListener('mousemove', onMouseMove, { signal });
+      document.addEventListener('mouseup', onMouseUp, { signal });
     },
     [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode],
   );
@@ -276,6 +300,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [visibleCols, clearSelection]);
+
+  // Clean up drag listeners on unmount
+  useEffect(
+    () => () => {
+      dragAbortRef.current?.abort();
+    },
+    [],
+  );
 
   return {
     selectedKeys,


### PR DESCRIPTION
## Summary

The drag-to-select feature fired a React state update on every mousemove event (60+/sec), causing unnecessary re-renders. Additionally, document-level event listeners added during a drag were not cleaned up if the component unmounted mid-drag. This PR throttles drag updates to one per animation frame using requestAnimationFrame and uses AbortController for automatic listener cleanup.

## Key Changes

- Throttle drag-to-select mousemove handling with requestAnimationFrame so at most one state update occurs per frame
- Add early bail-out when the mouse stays on the same row to skip redundant Set construction
- Use AbortController with signal-based addEventListener for automatic cleanup of document listeners on drag end and component unmount
- Add tests for throttling behavior, same-row skip, and unmount cleanup

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused