### PR TITLE
✨ Simplify riscv64 post-merge checks workflow

### DIFF
--- a/.github/workflows/riscv64-post-merge-checks.yml
+++ b/.github/workflows/riscv64-post-merge-checks.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  modules-test-riscv64:
+  go-test-riscv64:
     strategy:
       matrix:
         module:
@@ -28,49 +28,14 @@ jobs:
         working-directory: ./modules/${{ matrix.module }}
         run: go test ./...
 
-  docker-builds:
-    strategy:
-      matrix:
-        component:
-          - cli
-          - cluster-agent
-          - cluster-api
-          - dashboard
-        target:
-          - final
-          - final-alpine
-        include:
-          - component: cli
-            dockerfile: build/package/Dockerfile.cli
-          - component: cluster-agent
-            dockerfile: build/package/Dockerfile.cluster-agent
-          - component: cluster-api
-            dockerfile: build/package/Dockerfile.cluster-api
-          - component: dashboard
-            dockerfile: build/package/Dockerfile.dashboard
-    runs-on: ubuntu-24.04-riscv
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
-          push: false
-          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.target }}-riscv64
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.target }}-riscv64
-
-  cli-builds:
+  build-cli:
     runs-on: ubuntu-24.04-riscv
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-environment
         with:
-          setup-node: "true"
           setup-go: "true"
       - name: Build
-        run: make build
+        working-directory: ./modules/cli
+        run: |
+          CGO_ENABLED=0 go build -ldflags="-s -w" cmd/main.go


### PR DESCRIPTION
## Summary

Simplifies the riscv64 post-merge checks workflow by removing the docker-builds job and streamlining the CLI build step to use `go build` directly instead of `make build`. Job names are also renamed for consistency with other CI workflows.

## Key Changes

- Remove the `docker-builds` job (builds all component Docker images on riscv64)
- Simplify `cli-builds` → `build-cli` to run `go build` directly in the CLI module
- Rename `modules-test-riscv64` → `go-test-riscv64` for naming consistency

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused