### PR TITLE
✨ Rename riscv64 post-merge checks workflow to match naming convention

### DIFF
--- a/.github/workflows/post-merge-checks-riscv64.yml
+++ b/.github/workflows/post-merge-checks-riscv64.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Build
         working-directory: ./modules/cli
         run: |
-          CGO_ENABLED=0 go build -ldflags="-s -w" cmd/main.go
+          CGO_ENABLED=0 go build -ldflags="-s -w" ./cmd/main.go


### PR DESCRIPTION
Ref #1071

## Summary

Renames the riscv64 post-merge checks workflow file from `riscv64-post-merge-checks.yml` to `post-merge-checks-riscv64.yml` to align with the `post-merge-checks-*` naming convention used by other workflow files.

## Key Changes

- Renamed `.github/workflows/riscv64-post-merge-checks.yml` → `post-merge-checks-riscv64.yml`
- Fixed build command path from `cmd/main.go` to `./cmd/main.go`

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused