### PR TITLE
🎣 Fix build path in riscv64 post-merge checks workflow

### DIFF
--- a/.github/workflows/post-merge-checks-riscv64.yml
+++ b/.github/workflows/post-merge-checks-riscv64.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Build
         working-directory: ./modules/cli
         run: |
-          CGO_ENABLED=0 go build -ldflags="-s -w" ./cmd/main.go
+          CGO_ENABLED=0 go build -ldflags="-s -w" ./main.go


### PR DESCRIPTION
## Summary

The riscv64 post-merge checks workflow references `./cmd/main.go` as the build entrypoint, but the CLI module's main file is at `./main.go`. This fixes the build path so the workflow succeeds.

## Key Changes

- Update Go build path from `./cmd/main.go` to `./main.go` in the riscv64 post-merge checks workflow

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused