### PR TITLE
🐋 Add multi-cell selection to log viewer

### DIFF
--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -197,7 +197,7 @@ describe('Main', () => {
       isSelectionBottom: false,
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
-      selectedCellCol: null as ViewerColumn | null,
+      selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -268,7 +268,7 @@ describe('Main', () => {
       isSelectionBottom: false,
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
-      selectedCellCol: null as ViewerColumn | null,
+      selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -278,7 +278,7 @@ describe('Main', () => {
     };
 
     it('sets userSelect to auto on mousedown of selected cell', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       fireEvent.mouseDown(messageCell);
       expect(messageCell.style.userSelect).toBe('auto');
@@ -318,26 +318,38 @@ describe('Main', () => {
     });
 
     it('selected cell shows ring highlight', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.classList.contains('ring-2')).toBe(true);
       expect(messageCell.classList.contains('ring-blue-500')).toBe(true);
     });
 
     it('non-selected cells do not show ring highlight', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
       expect(timestampCell.classList.contains('ring-2')).toBe(false);
     });
 
+    it('multiple selected cells in same row show ring highlight on each', () => {
+      render(
+        <RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />,
+      );
+      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(timestampCell.classList.contains('ring-2')).toBe(true);
+      expect(timestampCell.classList.contains('ring-blue-500')).toBe(true);
+      expect(messageCell.classList.contains('ring-2')).toBe(true);
+      expect(messageCell.classList.contains('ring-blue-500')).toBe(true);
+    });
+
     it('selected cell in text-select mode has userSelect auto style', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} isCellTextSelectable />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCellTextSelectable />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.style.userSelect).toBe('auto');
     });
 
     it('non-selected cells do not have userSelect auto when another cell is text-selectable', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} isCellTextSelectable />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCellTextSelectable />);
       const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
       expect(timestampCell.style.userSelect).toBe('');
     });
@@ -349,7 +361,7 @@ describe('Main', () => {
     });
 
     it('selected cell has cursor-text class', () => {
-      render(<RecordRow {...defaultProps} selectedCellCol={ViewerColumn.Message} />);
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.classList.contains('cursor-text')).toBe(true);
     });
@@ -384,7 +396,7 @@ describe('Main', () => {
       isSelectionBottom: false,
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
-      selectedCellCol: null as ViewerColumn | null,
+      selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -200,6 +200,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -273,6 +274,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -381,10 +383,16 @@ describe('Main', () => {
       expect(messageCell.classList.contains('cursor-default')).toBe(true);
     });
 
-    it('selected cell has cursor-text class', () => {
-      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
+    it('selected cell with isCursorText has cursor-text class', () => {
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCursorText />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.classList.contains('cursor-text')).toBe(true);
+    });
+
+    it('selected cell without isCursorText has cursor-default class', () => {
+      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCursorText={false} />);
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.classList.contains('cursor-default')).toBe(true);
     });
   });
 
@@ -420,6 +428,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -198,6 +198,8 @@ describe('Main', () => {
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -269,6 +271,8 @@ describe('Main', () => {
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),
@@ -317,29 +321,60 @@ describe('Main', () => {
       expect(messageCell.classList.contains('select-none')).toBe(true);
     });
 
-    it('selected cell shows ring highlight', () => {
+    it('single selected cell has all 4 edge shadows', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      expect(messageCell.classList.contains('ring-2')).toBe(true);
-      expect(messageCell.classList.contains('ring-blue-500')).toBe(true);
+      const shadow = messageCell.style.boxShadow;
+      expect(shadow).toContain('inset 0 2px 0 0'); // top
+      expect(shadow).toContain('inset 0 -2px 0 0'); // bottom
+      expect(shadow).toContain('inset 2px 0 0 0'); // left
+      expect(shadow).toContain('inset -2px 0 0 0'); // right
     });
 
-    it('non-selected cells do not show ring highlight', () => {
+    it('non-selected cells have no boxShadow', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
       const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
-      expect(timestampCell.classList.contains('ring-2')).toBe(false);
+      expect(timestampCell.style.boxShadow).toBe('');
     });
 
-    it('multiple selected cells in same row show ring highlight on each', () => {
+    it('adjacent selected cells share edges (no inner border)', () => {
       render(
         <RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />,
       );
       const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      expect(timestampCell.classList.contains('ring-2')).toBe(true);
-      expect(timestampCell.classList.contains('ring-blue-500')).toBe(true);
-      expect(messageCell.classList.contains('ring-2')).toBe(true);
-      expect(messageCell.classList.contains('ring-blue-500')).toBe(true);
+      // Timestamp: has left edge, no right edge (Message is adjacent)
+      expect(timestampCell.style.boxShadow).toContain('inset 2px 0 0 0'); // left
+      expect(timestampCell.style.boxShadow).not.toContain('inset -2px 0 0 0'); // no right
+      // Message: no left edge (Timestamp is adjacent), has right edge
+      expect(messageCell.style.boxShadow).not.toContain('inset 2px 0 0 0'); // no left
+      expect(messageCell.style.boxShadow).toContain('inset -2px 0 0 0'); // right
+    });
+
+    it('cell with selectedCellColsAbove has no top border', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          selectedCellCols={new Set([ViewerColumn.Message])}
+          selectedCellColsAbove={new Set([ViewerColumn.Message])}
+        />,
+      );
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.style.boxShadow).not.toContain('inset 0 2px 0 0'); // no top
+      expect(messageCell.style.boxShadow).toContain('inset 0 -2px 0 0'); // bottom
+    });
+
+    it('cell with selectedCellColsBelow has no bottom border', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          selectedCellCols={new Set([ViewerColumn.Message])}
+          selectedCellColsBelow={new Set([ViewerColumn.Message])}
+        />,
+      );
+      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
+      expect(messageCell.style.boxShadow).toContain('inset 0 2px 0 0'); // top
+      expect(messageCell.style.boxShadow).not.toContain('inset 0 -2px 0 0'); // no bottom
     });
 
     it('selected cell in text-select mode has userSelect auto style', () => {
@@ -397,6 +432,8 @@ describe('Main', () => {
       maxRowWidth: 500,
       colWidths: new Map<ViewerColumn, number>(),
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
       measureRowElement: vi.fn(),

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -394,6 +394,56 @@ describe('Main', () => {
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.classList.contains('cursor-default')).toBe(true);
     });
+
+    it('ColorDot cell has selection box-shadow when both neighbors are selected', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
+          selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
+        />,
+      );
+      const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
+      expect(colorDotCell.style.boxShadow).not.toBe('');
+    });
+
+    it('ColorDot cell has no selection box-shadow when only one neighbor is selected', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
+          selectedCellCols={new Set([ViewerColumn.Message])}
+        />,
+      );
+      const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
+      expect(colorDotCell.style.boxShadow).toBe('');
+    });
+
+    it('selected cell adjacent to ColorDot has no inner border when other side also selected', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
+          selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
+        />,
+      );
+      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
+      // Timestamp should NOT have a right border since Message (across ColorDot) is also selected
+      expect(timestampCell.style.boxShadow).not.toContain('inset -2px 0 0 0');
+    });
+
+    it('selected cell adjacent to ColorDot has border when other side is not selected', () => {
+      render(
+        <RecordRow
+          {...defaultProps}
+          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
+          selectedCellCols={new Set([ViewerColumn.Timestamp])}
+        />,
+      );
+      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
+      // Timestamp SHOULD have a right border since Message is not selected
+      expect(timestampCell.style.boxShadow).toContain('inset -2px 0 0 0');
+    });
   });
 
   describe('RecordRow Key column', () => {

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -365,13 +365,13 @@ describe('Main', () => {
       expect(messageCell.style.boxShadow).not.toContain('inset 0 -2px 0 0'); // no bottom
     });
 
-    it('selected cell in text-select mode has userSelect auto style', () => {
+    it('selected cell in text-select mode has userSelect text style', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCellTextSelectable />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      expect(messageCell.style.userSelect).toBe('auto');
+      expect(messageCell.style.userSelect).toBe('text');
     });
 
-    it('non-selected cells do not have userSelect auto when another cell is text-selectable', () => {
+    it('non-selected cells do not have userSelect when another cell is text-selectable', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCellTextSelectable />);
       const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
       expect(timestampCell.style.userSelect).toBe('');

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -205,7 +205,7 @@ describe('Main', () => {
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
       onRowMouseDown: vi.fn(),
-      onCellClick: vi.fn(),
+      onCellMouseDown: vi.fn(),
     };
 
     it('calls onRowMouseDown when mousedown on the pos cell', () => {
@@ -216,20 +216,20 @@ describe('Main', () => {
       expect(defaultProps.onRowMouseDown).toHaveBeenCalledWith(0, expect.any(Object));
     });
 
-    it('calls onCellClick when clicking the timestamp cell', () => {
-      const onCellClick = vi.fn();
-      render(<RecordRow {...defaultProps} onCellClick={onCellClick} />);
+    it('calls onCellMouseDown when mousedown on the timestamp cell', () => {
+      const onCellMouseDown = vi.fn();
+      render(<RecordRow {...defaultProps} onCellMouseDown={onCellMouseDown} />);
       const timestampCell = screen.getByText(/Jun 15, 2024/);
-      fireEvent.click(timestampCell);
-      expect(onCellClick).toHaveBeenCalledWith(0, ViewerColumn.Timestamp, expect.any(Object));
+      fireEvent.mouseDown(timestampCell);
+      expect(onCellMouseDown).toHaveBeenCalledWith(0, ViewerColumn.Timestamp, expect.any(Object));
     });
 
-    it('calls onCellClick when clicking the message cell', () => {
-      const onCellClick = vi.fn();
-      render(<RecordRow {...defaultProps} onCellClick={onCellClick} />);
+    it('calls onCellMouseDown when mousedown on the message cell', () => {
+      const onCellMouseDown = vi.fn();
+      render(<RecordRow {...defaultProps} onCellMouseDown={onCellMouseDown} />);
       const messageCell = screen.getByText('test message');
-      fireEvent.click(messageCell);
-      expect(onCellClick).toHaveBeenCalledWith(0, ViewerColumn.Message, expect.any(Object));
+      fireEvent.mouseDown(messageCell);
+      expect(onCellMouseDown).toHaveBeenCalledWith(0, ViewerColumn.Message, expect.any(Object));
     });
 
     it('does not call onRowMouseDown when clicking the row background', () => {
@@ -278,35 +278,21 @@ describe('Main', () => {
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
       onRowMouseDown: vi.fn(),
-      onCellClick: vi.fn(),
+      onCellMouseDown: vi.fn(),
     };
 
-    it('sets userSelect to auto on mousedown of selected cell', () => {
-      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      fireEvent.mouseDown(messageCell);
-      expect(messageCell.style.userSelect).toBe('auto');
-    });
-
-    it('does not set userSelect on mousedown of unselected cell', () => {
-      render(<RecordRow {...defaultProps} />);
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      fireEvent.mouseDown(messageCell);
-      expect(messageCell.style.userSelect).toBe('');
-    });
-
-    it('does not call onCellClick on ColorDot column', () => {
-      const onCellClick = vi.fn();
+    it('does not call onCellMouseDown on ColorDot column', () => {
+      const onCellMouseDown = vi.fn();
       render(
         <RecordRow
           {...defaultProps}
           visibleCols={new Set([ViewerColumn.ColorDot, ViewerColumn.Message])}
-          onCellClick={onCellClick}
+          onCellMouseDown={onCellMouseDown}
         />,
       );
       const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
-      fireEvent.click(colorDotCell);
-      expect(onCellClick).not.toHaveBeenCalled();
+      fireEvent.mouseDown(colorDotCell);
+      expect(onCellMouseDown).not.toHaveBeenCalled();
     });
 
     it('data cells have gridcell role', () => {
@@ -439,7 +425,7 @@ describe('Main', () => {
       measureRowElement: vi.fn(),
       measureCellElement: vi.fn(),
       onRowMouseDown: vi.fn(),
-      onCellClick: vi.fn(),
+      onCellMouseDown: vi.fn(),
     };
 
     it('renders "0" when row key is 0', () => {

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -411,7 +411,7 @@ type RecordRowProps = {
   measureRowElement: (el: HTMLDivElement | null) => void;
   measureCellElement: (el: HTMLDivElement | null) => void;
   onRowMouseDown: (key: number, event: React.MouseEvent) => void;
-  onCellClick: (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => void;
+  onCellMouseDown: (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => void;
 };
 
 export const RecordRow = memo(
@@ -433,7 +433,7 @@ export const RecordRow = memo(
     measureRowElement,
     measureCellElement,
     onRowMouseDown,
-    onCellClick,
+    onCellMouseDown,
   }: RecordRowProps) => {
     const els: React.ReactElement[] = [];
 
@@ -512,22 +512,14 @@ export const RecordRow = memo(
             tabIndex={isColorDot ? undefined : 0}
             className={cellClassName}
             style={cellStyle}
-            onClick={isColorDot ? undefined : (e) => onCellClick(row.key, col, e)}
-            onMouseDown={
-              isColorDot || !isCellSelected
-                ? undefined
-                : (e) => {
-                    // Enable text selection before drag starts
-                    e.currentTarget.style.userSelect = 'auto';
-                  }
-            }
+            onMouseDown={isColorDot ? undefined : (e) => onCellMouseDown(row.key, col, e)}
             onKeyDown={
               isColorDot
                 ? undefined
                 : (e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      onCellClick(row.key, col, e as unknown as React.MouseEvent);
+                      onCellMouseDown(row.key, col, e as unknown as React.MouseEvent);
                     }
                   }
             }
@@ -612,7 +604,7 @@ export const Main = () => {
     selectedCells,
     isTextSelectMode,
     handleRowMouseDown,
-    handleCellClick,
+    handleCellMouseDown,
     resetSelection,
   } = useSelection(virtualizerRef);
 
@@ -730,7 +722,7 @@ export const Main = () => {
                     measureRowElement={measureRowElement}
                     measureCellElement={measureCellElement}
                     onRowMouseDown={handleRowMouseDown}
-                    onCellClick={handleCellClick}
+                    onCellMouseDown={handleCellMouseDown}
                   />
                 ))}
                 {virtualizer.hasMoreAfter && (

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -518,7 +518,8 @@ export const RecordRow = memo(
         cellBg,
         'px-2',
         shouldWrap ? 'whitespace-pre-wrap wrap-break-word' : 'whitespace-nowrap',
-        !isColorDot && (isCellSelected && isCursorText ? 'cursor-text' : 'cursor-default'),
+        !isColorDot &&
+          (isCellSelected && isCursorText ? 'cursor-text group-data-[mod-key]:cursor-default' : 'cursor-default'),
         'select-none',
       );
 
@@ -685,8 +686,23 @@ export const Main = () => {
     logViewerRef.current?.measure();
   }, [wrap]);
 
+  // Track Ctrl/Cmd held state via data attribute (no re-renders)
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const onKey = (e: KeyboardEvent) => {
+      el.toggleAttribute('data-mod-key', e.metaKey || e.ctrlKey);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('keyup', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('keyup', onKey);
+    };
+  }, []);
+
   return (
-    <div ref={wrapperRef} className="relative h-full w-full flex flex-col">
+    <div ref={wrapperRef} className="group relative h-full w-full flex flex-col">
       {isLoading && <LoadingOverlay />}
       <HeaderRow
         scrollElRef={scrollElRef}

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -482,13 +482,34 @@ export const RecordRow = memo(
         cellBg = isTimestamp ? 'bg-chrome-200' : row.index % 2 !== 0 && 'bg-chrome-100';
       }
 
+      // ColorDot is visually selected when both adjacent columns are selected
+      const isColorDotVisuallySelected =
+        isColorDot &&
+        i > 0 &&
+        i < colsArray.length - 1 &&
+        (selectedCellCols?.has(colsArray[i - 1]) ?? false) &&
+        (selectedCellCols?.has(colsArray[i + 1]) ?? false);
+
       let cellShadow: string | undefined;
       if (isCellSelected) {
         const isEdgeTop = !selectedCellColsAbove?.has(col);
         const isEdgeBottom = !selectedCellColsBelow?.has(col);
-        const isEdgeLeft = i === 0 || !selectedCellCols!.has(colsArray[i - 1]);
-        const isEdgeRight = i === colsArray.length - 1 || !selectedCellCols!.has(colsArray[i + 1]);
+        // Skip over ColorDot when checking adjacent selected cells
+        let prevIdx = i - 1;
+        if (prevIdx >= 0 && colsArray[prevIdx] === ViewerColumn.ColorDot) prevIdx -= 1;
+        let nextIdx = i + 1;
+        if (nextIdx < colsArray.length && colsArray[nextIdx] === ViewerColumn.ColorDot) nextIdx += 1;
+        const isEdgeLeft = prevIdx < 0 || !selectedCellCols!.has(colsArray[prevIdx]);
+        const isEdgeRight = nextIdx >= colsArray.length || !selectedCellCols!.has(colsArray[nextIdx]);
         cellShadow = cellSelectionBoxShadow(isEdgeTop, isEdgeBottom, isEdgeLeft, isEdgeRight);
+      } else if (isColorDotVisuallySelected) {
+        const aboveAlsoVisual =
+          (selectedCellColsAbove?.has(colsArray[i - 1]) ?? false) &&
+          (selectedCellColsAbove?.has(colsArray[i + 1]) ?? false);
+        const belowAlsoVisual =
+          (selectedCellColsBelow?.has(colsArray[i - 1]) ?? false) &&
+          (selectedCellColsBelow?.has(colsArray[i + 1]) ?? false);
+        cellShadow = cellSelectionBoxShadow(!aboveAlsoVisual, !belowAlsoVisual, false, false);
       }
 
       const cellClassName = cn(

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -389,7 +389,7 @@ type RecordRowProps = {
   isSelectionBottom: boolean;
   maxRowWidth: number;
   colWidths: Map<ViewerColumn, number>;
-  selectedCellCol: ViewerColumn | null;
+  selectedCellCols: Set<ViewerColumn> | undefined;
   isCellTextSelectable: boolean;
   measureElement: (node: Element | null) => void;
   measureRowElement: (el: HTMLDivElement | null) => void;
@@ -409,7 +409,7 @@ export const RecordRow = memo(
     isSelectionBottom,
     maxRowWidth,
     colWidths,
-    selectedCellCol,
+    selectedCellCols,
     isCellTextSelectable,
     measureElement,
     measureRowElement,
@@ -450,7 +450,7 @@ export const RecordRow = memo(
       const minWidth = isWrap && col === ViewerColumn.Message ? undefined : colWidths.get(col);
       const shouldWrap = isWrap && col === ViewerColumn.Message;
       const isTimestamp = col === ViewerColumn.Timestamp;
-      const isCellSelected = selectedCellCol === col;
+      const isCellSelected = selectedCellCols?.has(col) ?? false;
       const isColorDot = col === ViewerColumn.ColorDot;
 
       let cellBg: string | false;
@@ -519,7 +519,7 @@ export const RecordRow = memo(
         data-row-key={row.key}
         role="row"
         aria-selected={isSelected}
-        className={cn('absolute top-0 left-0 grid leading-6 group', selectedCellCol && 'z-10')}
+        className={cn('absolute top-0 left-0 grid leading-6 group', selectedCellCols && 'z-10')}
         style={{
           gridTemplateColumns: gridTemplate,
           minWidth: isWrap ? '100%' : maxRowWidth || '100%',
@@ -544,7 +544,7 @@ export const RecordRow = memo(
     if (prev.isSelectionBottom !== next.isSelectionBottom) return false;
     if (prev.maxRowWidth !== next.maxRowWidth) return false;
     if (prev.colWidths !== next.colWidths) return false;
-    if (prev.selectedCellCol !== next.selectedCellCol) return false;
+    if (prev.selectedCellCols !== next.selectedCellCols) return false;
     if (prev.isCellTextSelectable !== next.isCellTextSelectable) return false;
     return true;
   },
@@ -578,7 +578,7 @@ export const Main = () => {
     selectedKeys,
     selectionTopKeys,
     selectionBottomKeys,
-    selectedCell,
+    selectedCells,
     isTextSelectMode,
     handleRowMouseDown,
     handleCellClick,
@@ -690,8 +690,10 @@ export const Main = () => {
                     isSelectionBottom={selectionBottomKeys.has(virtualRow.key)}
                     maxRowWidth={maxRowWidth}
                     colWidths={colWidths}
-                    selectedCellCol={selectedCell?.rowKey === virtualRow.key ? selectedCell.col : null}
-                    isCellTextSelectable={selectedCell?.rowKey === virtualRow.key && isTextSelectMode}
+                    selectedCellCols={selectedCells.get(virtualRow.key)}
+                    isCellTextSelectable={
+                      isTextSelectMode && selectedCells.size === 1 && selectedCells.has(virtualRow.key)
+                    }
                     measureRowElement={measureRowElement}
                     measureCellElement={measureCellElement}
                     onRowMouseDown={handleRowMouseDown}

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -406,6 +406,7 @@ type RecordRowProps = {
   selectedCellCols: Set<ViewerColumn> | undefined;
   selectedCellColsAbove: Set<ViewerColumn> | undefined;
   selectedCellColsBelow: Set<ViewerColumn> | undefined;
+  isCursorText: boolean;
   isCellTextSelectable: boolean;
   measureElement: (node: Element | null) => void;
   measureRowElement: (el: HTMLDivElement | null) => void;
@@ -428,6 +429,7 @@ export const RecordRow = memo(
     selectedCellCols,
     selectedCellColsAbove,
     selectedCellColsBelow,
+    isCursorText,
     isCellTextSelectable,
     measureElement,
     measureRowElement,
@@ -493,7 +495,7 @@ export const RecordRow = memo(
         cellBg,
         'px-2',
         shouldWrap ? 'whitespace-pre-wrap wrap-break-word' : 'whitespace-nowrap',
-        !isColorDot && (isCellSelected ? 'cursor-text' : 'cursor-default'),
+        !isColorDot && (isCellSelected && isCursorText ? 'cursor-text' : 'cursor-default'),
         'select-none',
       );
 
@@ -568,6 +570,7 @@ export const RecordRow = memo(
     if (prev.selectedCellCols !== next.selectedCellCols) return false;
     if (prev.selectedCellColsAbove !== next.selectedCellColsAbove) return false;
     if (prev.selectedCellColsBelow !== next.selectedCellColsBelow) return false;
+    if (prev.isCursorText !== next.isCursorText && (prev.selectedCellCols || next.selectedCellCols)) return false;
     if (prev.isCellTextSelectable !== next.isCellTextSelectable) return false;
     return true;
   },
@@ -603,6 +606,7 @@ export const Main = () => {
     selectionBottomKeys,
     selectedCells,
     isTextSelectMode,
+    isCursorText,
     handleRowMouseDown,
     handleCellMouseDown,
     resetSelection,
@@ -716,6 +720,7 @@ export const Main = () => {
                     selectedCellCols={selectedCells.get(virtualRow.key)}
                     selectedCellColsAbove={selectedCells.get(virtualRow.key - 1)}
                     selectedCellColsBelow={selectedCells.get(virtualRow.key + 1)}
+                    isCursorText={isCursorText}
                     isCellTextSelectable={
                       isTextSelectMode && selectedCells.size === 1 && selectedCells.has(virtualRow.key)
                     }

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -512,6 +512,8 @@ export const RecordRow = memo(
         cellShadow = cellSelectionBoxShadow(!aboveAlsoVisual, !belowAlsoVisual, false, false);
       }
 
+      const isNativeTextSelectable = isCellSelected && isCellTextSelectable;
+
       const cellClassName = cn(
         cellBg,
         'px-2',
@@ -522,7 +524,10 @@ export const RecordRow = memo(
 
       const cellStyle: React.CSSProperties = {
         ...(minWidth && { minWidth: `${minWidth}px` }),
-        ...(isCellSelected && isCellTextSelectable && { userSelect: 'auto' as const }),
+        ...(isNativeTextSelectable && {
+          userSelect: 'text' as const,
+          WebkitUserSelect: 'text' as const,
+        }),
         ...(cellShadow && { boxShadow: cellShadow }),
       };
 

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -379,6 +379,20 @@ function selectionBoxShadow(isTop: boolean, isBottom: boolean): string | undefin
   return undefined;
 }
 
+function cellSelectionBoxShadow(
+  isTop: boolean,
+  isBottom: boolean,
+  isLeft: boolean,
+  isRight: boolean,
+): string | undefined {
+  const shadows: string[] = [];
+  if (isTop) shadows.push('inset 0 2px 0 0 var(--color-blue-500)');
+  if (isBottom) shadows.push('inset 0 -2px 0 0 var(--color-blue-500)');
+  if (isLeft) shadows.push('inset 2px 0 0 0 var(--color-blue-500)');
+  if (isRight) shadows.push('inset -2px 0 0 0 var(--color-blue-500)');
+  return shadows.length > 0 ? shadows.join(', ') : undefined;
+}
+
 type RecordRowProps = {
   row: LogViewerVirtualRow;
   gridTemplate: string;
@@ -390,6 +404,8 @@ type RecordRowProps = {
   maxRowWidth: number;
   colWidths: Map<ViewerColumn, number>;
   selectedCellCols: Set<ViewerColumn> | undefined;
+  selectedCellColsAbove: Set<ViewerColumn> | undefined;
+  selectedCellColsBelow: Set<ViewerColumn> | undefined;
   isCellTextSelectable: boolean;
   measureElement: (node: Element | null) => void;
   measureRowElement: (el: HTMLDivElement | null) => void;
@@ -410,6 +426,8 @@ export const RecordRow = memo(
     maxRowWidth,
     colWidths,
     selectedCellCols,
+    selectedCellColsAbove,
+    selectedCellColsBelow,
     isCellTextSelectable,
     measureElement,
     measureRowElement,
@@ -446,7 +464,9 @@ export const RecordRow = memo(
       </div>,
     );
 
-    visibleCols.forEach((col) => {
+    const colsArray = [...visibleCols];
+    for (let i = 0; i < colsArray.length; i += 1) {
+      const col = colsArray[i];
       const minWidth = isWrap && col === ViewerColumn.Message ? undefined : colWidths.get(col);
       const shouldWrap = isWrap && col === ViewerColumn.Message;
       const isTimestamp = col === ViewerColumn.Timestamp;
@@ -460,18 +480,27 @@ export const RecordRow = memo(
         cellBg = isTimestamp ? 'bg-chrome-200' : row.index % 2 !== 0 && 'bg-chrome-100';
       }
 
+      let cellShadow: string | undefined;
+      if (isCellSelected) {
+        const isEdgeTop = !selectedCellColsAbove?.has(col);
+        const isEdgeBottom = !selectedCellColsBelow?.has(col);
+        const isEdgeLeft = i === 0 || !selectedCellCols!.has(colsArray[i - 1]);
+        const isEdgeRight = i === colsArray.length - 1 || !selectedCellCols!.has(colsArray[i + 1]);
+        cellShadow = cellSelectionBoxShadow(isEdgeTop, isEdgeBottom, isEdgeLeft, isEdgeRight);
+      }
+
       const cellClassName = cn(
         cellBg,
         'px-2',
         shouldWrap ? 'whitespace-pre-wrap wrap-break-word' : 'whitespace-nowrap',
         !isColorDot && (isCellSelected ? 'cursor-text' : 'cursor-default'),
         'select-none',
-        isCellSelected && 'ring-2 ring-blue-500 ring-inset',
       );
 
       const cellStyle: React.CSSProperties = {
         ...(minWidth && { minWidth: `${minWidth}px` }),
         ...(isCellSelected && isCellTextSelectable && { userSelect: 'auto' as const }),
+        ...(cellShadow && { boxShadow: cellShadow }),
       };
 
       els.push(
@@ -507,7 +536,7 @@ export const RecordRow = memo(
           </div>
         </CellContextMenu>,
       );
-    });
+    }
 
     return (
       <div
@@ -545,6 +574,8 @@ export const RecordRow = memo(
     if (prev.maxRowWidth !== next.maxRowWidth) return false;
     if (prev.colWidths !== next.colWidths) return false;
     if (prev.selectedCellCols !== next.selectedCellCols) return false;
+    if (prev.selectedCellColsAbove !== next.selectedCellColsAbove) return false;
+    if (prev.selectedCellColsBelow !== next.selectedCellColsBelow) return false;
     if (prev.isCellTextSelectable !== next.isCellTextSelectable) return false;
     return true;
   },
@@ -691,6 +722,8 @@ export const Main = () => {
                     maxRowWidth={maxRowWidth}
                     colWidths={colWidths}
                     selectedCellCols={selectedCells.get(virtualRow.key)}
+                    selectedCellColsAbove={selectedCells.get(virtualRow.key - 1)}
+                    selectedCellColsBelow={selectedCells.get(virtualRow.key + 1)}
                     isCellTextSelectable={
                       isTextSelectMode && selectedCells.size === 1 && selectedCells.has(virtualRow.key)
                     }

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -571,7 +571,8 @@ export const RecordRow = memo(
     if (prev.selectedCellColsAbove !== next.selectedCellColsAbove) return false;
     if (prev.selectedCellColsBelow !== next.selectedCellColsBelow) return false;
     if (prev.isCursorText !== next.isCursorText && (prev.selectedCellCols || next.selectedCellCols)) return false;
-    if (prev.isCellTextSelectable !== next.isCellTextSelectable) return false;
+    if (prev.isCellTextSelectable !== next.isCellTextSelectable && (prev.selectedCellCols || next.selectedCellCols))
+      return false;
     return true;
   },
 );
@@ -721,9 +722,7 @@ export const Main = () => {
                     selectedCellColsAbove={selectedCells.get(virtualRow.key - 1)}
                     selectedCellColsBelow={selectedCells.get(virtualRow.key + 1)}
                     isCursorText={isCursorText}
-                    isCellTextSelectable={
-                      isTextSelectMode && selectedCells.size === 1 && selectedCells.has(virtualRow.key)
-                    }
+                    isCellTextSelectable={isTextSelectMode && selectedCells.has(virtualRow.key)}
                     measureRowElement={measureRowElement}
                     measureCellElement={measureCellElement}
                     onRowMouseDown={handleRowMouseDown}

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -1290,6 +1290,33 @@ describe('useSelection', () => {
       });
     });
 
+    it('dragging over ColorDot cell does not change selection', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      const selectionBefore = result.current.selectedCells;
+
+      // Mouse moves over a ColorDot cell — selection should not change
+      mockElementFromPoint.mockReturnValue(makeCellEl(1, ViewerColumn.ColorDot));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 25 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(result.current.selectedCells).toBe(selectionBefore);
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
     it('drag clears row selection', () => {
       const { result } = renderUseSelection();
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -28,6 +28,7 @@ import {
 } from './selection';
 import { ViewerColumn } from './shared';
 import {
+  isCursorTextAtom,
   isTextSelectModeAtom,
   lastClickedCellAtom,
   lastClickedKeyAtom,
@@ -593,43 +594,70 @@ describe('useSelection', () => {
       expect(result.current.isTextSelectMode).toBe(false);
     });
 
-    it('sets cursor to default on clicked cell element after mouseup', () => {
-      const { result } = renderUseSelection();
-      const el = document.createElement('div');
+    it('isCursorText is false after cell mousedown', () => {
+      const { result, store } = renderUseSelection();
 
-      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
-      act(() => {
-        fireEvent.mouseUp(document);
-      });
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
 
-      expect(el.style.cursor).toBe('default');
+      expect(store.get(isCursorTextAtom)).toBe(false);
     });
 
-    it('restores cursor on mousemove after cell click', () => {
-      const { result } = renderUseSelection();
-      const el = document.createElement('div');
+    it('isCursorText becomes true after mousemove following mouseup', () => {
+      const { result, store } = renderUseSelection();
 
-      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       act(() => {
         fireEvent.mouseUp(document);
       });
-
       act(() => {
         fireEvent.mouseMove(document);
       });
 
-      expect(el.style.cursor).toBe('');
+      expect(store.get(isCursorTextAtom)).toBe(true);
     });
 
-    it('sets cursor to default on modifier click element', () => {
-      const { result } = renderUseSelection();
-      const el = document.createElement('div');
+    it('isCursorText is false after modifier click', () => {
+      const { result, store } = renderUseSelection();
 
-      act(() =>
-        result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el, metaKey: true })),
-      );
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
-      expect(el.style.cursor).toBe('default');
+      expect(store.get(isCursorTextAtom)).toBe(false);
+    });
+
+    it('isCursorText becomes true after mousemove following modifier click', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => {
+        fireEvent.mouseMove(document);
+      });
+
+      expect(store.get(isCursorTextAtom)).toBe(true);
+    });
+
+    it('isCursorText resets on clearSelection', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => {
+        store.set(isCursorTextAtom, true);
+      });
+      act(() => result.current.resetSelection());
+
+      expect(store.get(isCursorTextAtom)).toBe(false);
+    });
+
+    it('isCursorText resets on row mousedown', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => {
+        store.set(isCursorTextAtom, true);
+      });
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      expect(store.get(isCursorTextAtom)).toBe(false);
     });
 
     it('ignores ColorDot column clicks', () => {
@@ -1314,6 +1342,47 @@ describe('useSelection', () => {
           [2, new Set([ViewerColumn.Message])],
         ]),
       );
+    });
+
+    it('isCursorText is false during drag', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(store.get(isCursorTextAtom)).toBe(false);
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('isCursorText becomes true after mousemove following drag mouseup', () => {
+      const { result, store } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      expect(store.get(isCursorTextAtom)).toBe(false);
+
+      act(() => {
+        fireEvent.mouseMove(document);
+      });
+
+      expect(store.get(isCursorTextAtom)).toBe(true);
     });
   });
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -18,9 +18,9 @@ import { createRef } from 'react';
 
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
 
-import { getPlainAttribute, formatRowsForCopy, computeSelection, useSelection } from './selection';
+import { getPlainAttribute, formatRowsForCopy, formatCellsForCopy, computeSelection, useSelection } from './selection';
 import { ViewerColumn } from './shared';
-import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellAtom, visibleColsAtom } from './state';
+import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellsAtom, visibleColsAtom } from './state';
 
 const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
   timestamp: '2024-06-15T10:30:01.123Z',
@@ -120,6 +120,81 @@ describe('formatRowsForCopy', () => {
   it('returns empty string for empty records array', () => {
     const visibleCols = new Set([ViewerColumn.Message]);
     expect(formatRowsForCopy([], visibleCols)).toBe('');
+  });
+});
+
+describe('formatCellsForCopy', () => {
+  const records = [
+    makeRecord({ message: 'line one', timestamp: '2024-06-15T10:30:01.000Z' }),
+    makeRecord({ message: 'line two', timestamp: '2024-06-15T10:30:02.000Z' }),
+    makeRecord({ message: 'line three', timestamp: '2024-06-15T10:30:03.000Z' }),
+  ];
+
+  const getRecord = (key: number) => records[key];
+
+  it('formats a single selected cell', () => {
+    const selectedCells = new Map([[0, new Set([ViewerColumn.Message])]]);
+    const visibleCols = new Set([ViewerColumn.Timestamp, ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('line one');
+  });
+
+  it('formats multiple cells in the same row tab-separated', () => {
+    const selectedCells = new Map([[0, new Set([ViewerColumn.Timestamp, ViewerColumn.Message])]]);
+    const visibleCols = new Set([ViewerColumn.Timestamp, ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('Jun 15, 2024 10:30:01.000\tline one');
+  });
+
+  it('formats cells from different rows newline-separated', () => {
+    const selectedCells = new Map([
+      [0, new Set([ViewerColumn.Message])],
+      [1, new Set([ViewerColumn.Message])],
+    ]);
+    const visibleCols = new Set([ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('line one\nline two');
+  });
+
+  it('respects visibleCols order and skips unselected columns', () => {
+    const selectedCells = new Map([[0, new Set([ViewerColumn.Pod])]]);
+    const visibleCols = new Set([ViewerColumn.Timestamp, ViewerColumn.Pod, ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('my-pod-abc');
+  });
+
+  it('skips ColorDot column', () => {
+    const selectedCells = new Map([[0, new Set([ViewerColumn.ColorDot, ViewerColumn.Message])]]);
+    const visibleCols = new Set([ViewerColumn.ColorDot, ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('line one');
+  });
+
+  it('skips rows where getRecord returns undefined', () => {
+    const selectedCells = new Map([
+      [0, new Set([ViewerColumn.Message])],
+      [99, new Set([ViewerColumn.Message])],
+    ]);
+    const visibleCols = new Set([ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('line one');
+  });
+
+  it('sorts rows by key ascending', () => {
+    const selectedCells = new Map([
+      [2, new Set([ViewerColumn.Message])],
+      [0, new Set([ViewerColumn.Message])],
+    ]);
+    const visibleCols = new Set([ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('line one\nline three');
+  });
+
+  it('returns empty string for empty selection', () => {
+    const selectedCells = new Map<number, Set<ViewerColumn>>();
+    const visibleCols = new Set([ViewerColumn.Message]);
+    const result = formatCellsForCopy(selectedCells, visibleCols, getRecord);
+    expect(result).toBe('');
   });
 });
 
@@ -375,7 +450,7 @@ describe('useSelection', () => {
 
       act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
 
-      expect(result.current.selectedCell).toEqual({ rowKey: 1, col: ViewerColumn.Message });
+      expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
     });
 
     it('clears row selection when clicking a cell', () => {
@@ -390,7 +465,7 @@ describe('useSelection', () => {
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
 
       expect(result.current.selectedKeys.size).toBe(0);
-      expect(result.current.selectedCell).toEqual({ rowKey: 0, col: ViewerColumn.Message });
+      expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
     });
 
     it('clears text-select mode when clicking without a native selection', () => {
@@ -409,16 +484,75 @@ describe('useSelection', () => {
 
       act(() => result.current.handleCellClick(0, ViewerColumn.ColorDot, clickEvent()));
 
-      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.selectedCells).toEqual(new Map());
     });
 
-    it('replaces previously selected cell', () => {
+    it('replaces previously selected cell on plain click', () => {
       const { result } = renderUseSelection();
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
       act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent()));
 
-      expect(result.current.selectedCell).toEqual({ rowKey: 1, col: ViewerColumn.Pod });
+      expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Pod])]]));
+    });
+
+    it('adds cell to selection with meta+click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Pod])],
+        ]),
+      );
+    });
+
+    it('adds another column in same row with meta+click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(0, ViewerColumn.Timestamp, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([[0, new Set([ViewerColumn.Message, ViewerColumn.Timestamp])]]),
+      );
+    });
+
+    it('removes cell from selection with meta+click when already selected', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map());
+    });
+
+    it('removes cell and cleans up empty row entry', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+      // Now remove the only cell in row 0
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Pod])]]));
+    });
+
+    it('adds cell with ctrl+click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ ctrlKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+        ]),
+      );
     });
   });
 
@@ -573,11 +707,11 @@ describe('useSelection', () => {
       const { result } = renderUseSelection();
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      expect(result.current.selectedCell).not.toBeNull();
+      expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => result.current.handleRowMouseDown(1, clickEvent()));
 
-      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.selectedCells.size).toBe(0);
       expect(result.current.isTextSelectMode).toBe(false);
 
       act(() => {
@@ -702,21 +836,21 @@ describe('useSelection', () => {
       const { result } = renderUseSelection();
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      expect(result.current.selectedCell).not.toBeNull();
+      expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => result.current.handleRowMouseDown(0, clickEvent()));
       act(() => {
         fireEvent.mouseUp(document);
       });
 
-      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.selectedCells.size).toBe(0);
     });
 
     it('clears text-select mode when mousedown on Pos column', () => {
       const { result, store } = renderUseSelection();
 
       act(() => {
-        store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+        store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
         store.set(isTextSelectModeAtom, true);
       });
 
@@ -747,13 +881,13 @@ describe('useSelection', () => {
       const { result, store } = renderUseSelection();
 
       act(() => {
-        store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+        store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
         store.set(isTextSelectModeAtom, true);
       });
 
       act(() => result.current.resetSelection());
 
-      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.selectedCells.size).toBe(0);
       expect(result.current.isTextSelectMode).toBe(false);
     });
   });
@@ -861,24 +995,54 @@ describe('useSelection', () => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 1');
     });
 
+    it('copies multiple selected cells on Cmd+C', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'c', metaKey: true });
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 0\nlog message 1');
+    });
+
+    it('copies multiple cells in same row tab-separated on Cmd+C', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'c', metaKey: true });
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('my-pod-abc\tlog message 0');
+    });
+
     it('clears cell selection on Escape', () => {
       const { result } = renderUseSelection();
 
       act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      expect(result.current.selectedCell).not.toBeNull();
+      expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => {
         fireEvent.keyDown(document, { key: 'Escape' });
       });
 
-      expect(result.current.selectedCell).toBeNull();
+      expect(result.current.selectedCells.size).toBe(0);
     });
 
     it('clears text-select mode on Escape', () => {
       const { result, store } = renderUseSelection();
 
       act(() => {
-        store.set(selectedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+        store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
         store.set(isTextSelectModeAtom, true);
       });
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -1858,6 +1858,76 @@ describe('useCellDrag', () => {
 
     expect(store.get(isTextSelectModeAtom)).toBe(true);
   });
+
+  it('right-click (button=2) on a selected cell preserves multi-cell selection', () => {
+    const { result, store } = renderWithState(
+      (state) => useCellDrag(state),
+      (s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Timestamp, ViewerColumn.Message]));
+      },
+    );
+
+    const multiSelection = new Map([
+      [0, new Set([ViewerColumn.Timestamp, ViewerColumn.Message])],
+      [1, new Set([ViewerColumn.Timestamp, ViewerColumn.Message])],
+    ]);
+
+    act(() => {
+      store.set(selectedCellsAtom, multiSelection);
+    });
+
+    act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ button: 2 })));
+
+    expect(store.get(selectedCellsAtom)).toEqual(multiSelection);
+  });
+
+  it('Ctrl+click (macOS right-click) on a selected cell preserves multi-cell selection', () => {
+    const { result, store } = renderWithState(
+      (state) => useCellDrag(state),
+      (s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Timestamp, ViewerColumn.Message]));
+      },
+    );
+
+    const multiSelection = new Map([
+      [0, new Set([ViewerColumn.Timestamp, ViewerColumn.Message])],
+      [1, new Set([ViewerColumn.Timestamp, ViewerColumn.Message])],
+    ]);
+
+    act(() => {
+      store.set(selectedCellsAtom, multiSelection);
+    });
+
+    // macOS Ctrl+click: button=0, ctrlKey=true
+    act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ button: 0, ctrlKey: true })));
+
+    expect(store.get(selectedCellsAtom)).toEqual(multiSelection);
+  });
+
+  it('right-click on a non-selected cell selects it', () => {
+    const { result, store } = renderWithState((state) => useCellDrag(state));
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+    });
+
+    act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ button: 2 })));
+
+    expect(store.get(selectedCellsAtom)).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+  });
+
+  it('Ctrl+click (macOS right-click) on a non-selected cell selects it', () => {
+    const { result, store } = renderWithState((state) => useCellDrag(state));
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+    });
+
+    // macOS Ctrl+click on a different cell
+    act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ button: 0, ctrlKey: true })));
+
+    expect(store.get(selectedCellsAtom)).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+  });
 });
 
 describe('useSelectionKeyboard', () => {

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -18,7 +18,14 @@ import { createRef } from 'react';
 
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
 
-import { getPlainAttribute, formatRowsForCopy, formatCellsForCopy, computeSelection, useSelection } from './selection';
+import {
+  getPlainAttribute,
+  formatRowsForCopy,
+  formatCellsForCopy,
+  computeSelection,
+  computeCellRange,
+  useSelection,
+} from './selection';
 import { ViewerColumn } from './shared';
 import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellsAtom, visibleColsAtom } from './state';
 
@@ -290,6 +297,106 @@ describe('computeSelection', () => {
   });
 });
 
+describe('computeCellRange', () => {
+  const visibleCols = new Set([
+    ViewerColumn.Timestamp,
+    ViewerColumn.ColorDot,
+    ViewerColumn.Pod,
+    ViewerColumn.Container,
+    ViewerColumn.Message,
+  ]);
+
+  it('selects all columns between anchor and target in the same row', () => {
+    const result = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.Timestamp },
+      { rowKey: 0, col: ViewerColumn.Container },
+      visibleCols,
+    );
+    expect(result).toEqual(new Map([[0, new Set([ViewerColumn.Timestamp, ViewerColumn.Pod, ViewerColumn.Container])]]));
+  });
+
+  it('selects a single column across multiple rows', () => {
+    const result = computeCellRange(
+      { rowKey: 1, col: ViewerColumn.Pod },
+      { rowKey: 3, col: ViewerColumn.Pod },
+      visibleCols,
+    );
+    expect(result).toEqual(
+      new Map([
+        [1, new Set([ViewerColumn.Pod])],
+        [2, new Set([ViewerColumn.Pod])],
+        [3, new Set([ViewerColumn.Pod])],
+      ]),
+    );
+  });
+
+  it('selects a full rectangle across rows and columns', () => {
+    const result = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.Pod },
+      { rowKey: 2, col: ViewerColumn.Container },
+      visibleCols,
+    );
+    expect(result).toEqual(
+      new Map([
+        [0, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+        [1, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+        [2, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+      ]),
+    );
+  });
+
+  it('produces the same result regardless of direction', () => {
+    const forward = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.Pod },
+      { rowKey: 2, col: ViewerColumn.Message },
+      visibleCols,
+    );
+    const backward = computeCellRange(
+      { rowKey: 2, col: ViewerColumn.Message },
+      { rowKey: 0, col: ViewerColumn.Pod },
+      visibleCols,
+    );
+    expect(forward).toEqual(backward);
+  });
+
+  it('returns a single cell when anchor equals target', () => {
+    const result = computeCellRange(
+      { rowKey: 1, col: ViewerColumn.Message },
+      { rowKey: 1, col: ViewerColumn.Message },
+      visibleCols,
+    );
+    expect(result).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+  });
+
+  it('skips ColorDot column in the range', () => {
+    // Timestamp -> Pod spans across ColorDot, which should be excluded
+    const result = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.Timestamp },
+      { rowKey: 0, col: ViewerColumn.Pod },
+      visibleCols,
+    );
+    expect(result).toEqual(new Map([[0, new Set([ViewerColumn.Timestamp, ViewerColumn.Pod])]]));
+  });
+
+  it('returns single target cell when anchor column is ColorDot', () => {
+    const result = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.ColorDot },
+      { rowKey: 1, col: ViewerColumn.Message },
+      visibleCols,
+    );
+    expect(result).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+  });
+
+  it('returns single target cell when target column is ColorDot', () => {
+    const result = computeCellRange(
+      { rowKey: 0, col: ViewerColumn.Message },
+      { rowKey: 1, col: ViewerColumn.ColorDot },
+      visibleCols,
+    );
+    expect(result).toEqual(new Map([[1, new Set([ViewerColumn.ColorDot])]]));
+  });
+});
+
 describe('useSelection', () => {
   const records = [
     makeRecord({ message: 'log message 0', timestamp: '2024-06-15T10:30:00.000Z' }),
@@ -551,6 +658,99 @@ describe('useSelection', () => {
         new Map([
           [0, new Set([ViewerColumn.Message])],
           [1, new Set([ViewerColumn.Message])],
+        ]),
+      );
+    });
+
+    it('selects range with shift+click from anchor to target', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellClick(2, ViewerColumn.Container, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+          [1, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+          [2, new Set([ViewerColumn.Pod, ViewerColumn.Container])],
+        ]),
+      );
+    });
+
+    it('shift+click with no prior anchor behaves like plain click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+    });
+
+    it('shift+click within same column selects column range', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+    });
+
+    it('shift+click clears row selection', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      expect(result.current.selectedKeys.size).toBe(1);
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedKeys.size).toBe(0);
+    });
+
+    it('anchor stays on shift+click so subsequent shift+click extends from original', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      // Extend further from the same anchor (row 0)
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+    });
+
+    it('plain click after shift-range resets anchor', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      // Plain click sets new anchor
+      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+
+      // Now shift+click from new anchor (row 1)
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
         ]),
       );
     });

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -430,6 +430,7 @@ describe('useSelection', () => {
       metaKey: false,
       ctrlKey: false,
       stopPropagation: vi.fn(),
+      currentTarget: document.createElement('div'),
       ...overrides,
     }) as unknown as React.MouseEvent;
 
@@ -584,6 +585,44 @@ describe('useSelection', () => {
       act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
 
       expect(result.current.isTextSelectMode).toBe(false);
+    });
+
+    it('sets cursor to default on clicked cell element', () => {
+      const { result } = renderUseSelection();
+      const el = document.createElement('div');
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+
+      expect(el.style.cursor).toBe('default');
+    });
+
+    it('restores cursor on mousemove after cell click', () => {
+      const { result } = renderUseSelection();
+      const el = document.createElement('div');
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+
+      act(() => {
+        fireEvent.mouseMove(document);
+      });
+
+      expect(el.style.cursor).toBe('');
+    });
+
+    it('sets cursor to default on new cell click element', () => {
+      const { result } = renderUseSelection();
+      const elA = document.createElement('div');
+      const elB = document.createElement('div');
+
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: elA })));
+      act(() => {
+        fireEvent.mouseMove(document);
+      });
+      expect(elA.style.cursor).toBe('');
+
+      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ currentTarget: elB })));
+
+      expect(elB.style.cursor).toBe('default');
     });
 
     it('ignores ColorDot column clicks', () => {

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -1982,6 +1982,40 @@ describe('useSelectionKeyboard', () => {
     expect(result.current.selectedCells.size).toBe(0);
   });
 
+  it('does not clear selection on Escape when a context menu is open', () => {
+    const { result, store } = renderKeyboard();
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+    });
+
+    // Simulate Radix behavior: when a context menu is open and Escape is pressed,
+    // Radix's useEscapeKeydown calls event.preventDefault() before our handler runs.
+    // We use capture phase to ensure preventDefault() is called first.
+    document.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key === 'Escape') e.preventDefault();
+      },
+      { capture: true, once: true },
+    );
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    // Selection should be preserved — Escape only closes the menu
+    expect(result.current.selectedCells.size).toBe(1);
+
+    // Press Escape again — no context menu this time, no preventDefault
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    // Now selection should be cleared
+    expect(result.current.selectedCells.size).toBe(0);
+  });
+
   it('copies selected rows on Cmd+C', () => {
     const { store } = renderKeyboard();
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -27,7 +27,13 @@ import {
   useSelection,
 } from './selection';
 import { ViewerColumn } from './shared';
-import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellsAtom, visibleColsAtom } from './state';
+import {
+  isTextSelectModeAtom,
+  lastClickedCellAtom,
+  lastClickedKeyAtom,
+  selectedCellsAtom,
+  visibleColsAtom,
+} from './state';
 
 const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
   timestamp: '2024-06-15T10:30:01.123Z',
@@ -552,11 +558,11 @@ describe('useSelection', () => {
     });
   });
 
-  describe('handleCellClick', () => {
+  describe('handleCellMouseDown', () => {
     it('selects a cell on click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
 
       expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
     });
@@ -570,7 +576,7 @@ describe('useSelection', () => {
       });
       expect(result.current.selectedKeys.size).toBe(1);
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
 
       expect(result.current.selectedKeys.size).toBe(0);
       expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
@@ -580,18 +586,21 @@ describe('useSelection', () => {
       const { result } = renderUseSelection();
 
       // Simulate entering text-select mode via a prior drag
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
 
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
 
       expect(result.current.isTextSelectMode).toBe(false);
     });
 
-    it('sets cursor to default on clicked cell element', () => {
+    it('sets cursor to default on clicked cell element after mouseup', () => {
       const { result } = renderUseSelection();
       const el = document.createElement('div');
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       expect(el.style.cursor).toBe('default');
     });
@@ -600,7 +609,10 @@ describe('useSelection', () => {
       const { result } = renderUseSelection();
       const el = document.createElement('div');
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el })));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       act(() => {
         fireEvent.mouseMove(document);
@@ -609,26 +621,21 @@ describe('useSelection', () => {
       expect(el.style.cursor).toBe('');
     });
 
-    it('sets cursor to default on new cell click element', () => {
+    it('sets cursor to default on modifier click element', () => {
       const { result } = renderUseSelection();
-      const elA = document.createElement('div');
-      const elB = document.createElement('div');
+      const el = document.createElement('div');
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ currentTarget: elA })));
-      act(() => {
-        fireEvent.mouseMove(document);
-      });
-      expect(elA.style.cursor).toBe('');
+      act(() =>
+        result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ currentTarget: el, metaKey: true })),
+      );
 
-      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ currentTarget: elB })));
-
-      expect(elB.style.cursor).toBe('default');
+      expect(el.style.cursor).toBe('default');
     });
 
     it('ignores ColorDot column clicks', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.ColorDot, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.ColorDot, clickEvent()));
 
       expect(result.current.selectedCells).toEqual(new Map());
     });
@@ -636,8 +643,8 @@ describe('useSelection', () => {
     it('replaces previously selected cell on plain click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Pod, clickEvent()));
 
       expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Pod])]]));
     });
@@ -645,8 +652,8 @@ describe('useSelection', () => {
     it('adds cell to selection with meta+click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -659,8 +666,8 @@ describe('useSelection', () => {
     it('adds another column in same row with meta+click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(0, ViewerColumn.Timestamp, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Timestamp, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([[0, new Set([ViewerColumn.Message, ViewerColumn.Timestamp])]]),
@@ -670,8 +677,8 @@ describe('useSelection', () => {
     it('removes cell from selection with meta+click when already selected', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(new Map());
     });
@@ -679,10 +686,10 @@ describe('useSelection', () => {
     it('removes cell and cleans up empty row entry', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
       // Now remove the only cell in row 0
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Pod])]]));
     });
@@ -690,8 +697,8 @@ describe('useSelection', () => {
     it('adds cell with ctrl+click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ ctrlKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ ctrlKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -706,8 +713,11 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
-      act(() => result.current.handleCellClick(2, ViewerColumn.Container, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Container, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -721,7 +731,7 @@ describe('useSelection', () => {
     it('shift+click with no prior anchor behaves like plain click', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
     });
@@ -729,8 +739,11 @@ describe('useSelection', () => {
     it('shift+click within same column selects column range', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -750,8 +763,11 @@ describe('useSelection', () => {
       });
       expect(result.current.selectedKeys.size).toBe(1);
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedKeys.size).toBe(0);
     });
@@ -759,11 +775,14 @@ describe('useSelection', () => {
     it('anchor stays on shift+click so subsequent shift+click extends from original', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       // Extend further from the same anchor (row 0)
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -780,11 +799,14 @@ describe('useSelection', () => {
       });
 
       // Select a cell, then Cmd+click another
-      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       // Shift+click should add the range to existing selection, not replace it
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -801,11 +823,14 @@ describe('useSelection', () => {
       });
 
       // Select Pod in row 0
-      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
       // Cmd+click Container in row 1 (sets new anchor to row 1, Container)
-      act(() => result.current.handleCellClick(1, ViewerColumn.Container, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Container, clickEvent({ metaKey: true })));
       // Shift+click Message in row 2 — range is Container+Message in rows 1-2, merged with existing
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -819,14 +844,20 @@ describe('useSelection', () => {
     it('plain click after shift-range resets anchor', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       // Plain click sets new anchor
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
 
       // Now shift+click from new anchor (row 1)
-      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
@@ -987,7 +1018,7 @@ describe('useSelection', () => {
     it('clears cell selection when drag starts', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => result.current.handleRowMouseDown(1, clickEvent()));
@@ -1112,11 +1143,185 @@ describe('useSelection', () => {
     });
   });
 
+  describe('cell drag selection', () => {
+    function makeCellEl(rowKey: number, colId: string) {
+      const cellEl = document.createElement('div');
+      cellEl.dataset.colId = colId;
+      const rowEl = document.createElement('div');
+      rowEl.dataset.rowKey = String(rowKey);
+      rowEl.appendChild(cellEl);
+      cellEl.closest = (selector: string) => {
+        if (selector === '[data-col-id]') return cellEl;
+        if (selector === '[data-row-key]') return rowEl;
+        return null;
+      };
+      return cellEl;
+    }
+
+    let mockElementFromPoint: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockElementFromPoint = vi.fn().mockReturnValue(null);
+      document.elementFromPoint = mockElementFromPoint as typeof document.elementFromPoint;
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      delete (document as Partial<Document>).elementFromPoint;
+    });
+
+    it('drag across cells selects rectangular range', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 100, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message])],
+        ]),
+      );
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('drag within single row selects column range', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(0, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 200, clientY: 10 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([[0, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message])]]),
+      );
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('drag within single column selects row range', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('drag clears row selection', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleRowMouseDown(0, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      expect(result.current.selectedKeys.size).toBe(1);
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      expect(result.current.selectedKeys.size).toBe(0);
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+    });
+
+    it('sets lastClickedCell on mouseup', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 100, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 2, col: ViewerColumn.Message });
+    });
+
+    it('modifier mousedown does not start drag', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      // Should be range select, not drag
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+
+      // Mousemove should NOT change selection
+      mockElementFromPoint.mockReturnValue(makeCellEl(4, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 50 });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+    });
+  });
+
   describe('handleRowMouseDown clears cell state', () => {
     it('clears cell selection when mousedown on Pos column', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => result.current.handleRowMouseDown(0, clickEvent()));
@@ -1236,7 +1441,7 @@ describe('useSelection', () => {
     it('copies cell text on Cmd+C when a cell is selected', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -1250,7 +1455,7 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -1267,7 +1472,7 @@ describe('useSelection', () => {
       act(() => {
         fireEvent.mouseUp(document);
       });
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -1281,8 +1486,8 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
-      act(() => result.current.handleCellClick(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -1296,8 +1501,8 @@ describe('useSelection', () => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Message]));
       });
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       act(() => {
         fireEvent.keyDown(document, { key: 'c', metaKey: true });
@@ -1309,7 +1514,7 @@ describe('useSelection', () => {
     it('clears cell selection on Escape', () => {
       const { result } = renderUseSelection();
 
-      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       expect(result.current.selectedCells.size).toBeGreaterThan(0);
 
       act(() => {

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -735,6 +735,48 @@ describe('useSelection', () => {
       );
     });
 
+    it('shift+click after cmd+click is additive to existing selection', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Select a cell, then Cmd+click another
+      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellClick(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      // Shift+click should add the range to existing selection, not replace it
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Pod, ViewerColumn.Message])],
+          [1, new Set([ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Message])],
+        ]),
+      );
+    });
+
+    it('shift+click merges range columns with existing columns in same row', () => {
+      const { result } = renderUseSelection((store) => {
+        store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Select Pod in row 0
+      act(() => result.current.handleCellClick(0, ViewerColumn.Pod, clickEvent()));
+      // Cmd+click Container in row 1 (sets new anchor to row 1, Container)
+      act(() => result.current.handleCellClick(1, ViewerColumn.Container, clickEvent({ metaKey: true })));
+      // Shift+click Message in row 2 — range is Container+Message in rows 1-2, merged with existing
+      act(() => result.current.handleCellClick(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(result.current.selectedCells).toEqual(
+        new Map([
+          [0, new Set([ViewerColumn.Pod])],
+          [1, new Set([ViewerColumn.Container, ViewerColumn.Message])],
+          [2, new Set([ViewerColumn.Container, ViewerColumn.Message])],
+        ]),
+      );
+    });
+
     it('plain click after shift-range resets anchor', () => {
       const { result } = renderUseSelection();
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -583,10 +583,9 @@ describe('useSelection', () => {
       expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
     });
 
-    it('clears text-select mode when clicking without a native selection', () => {
+    it('clears text-select mode when clicking a new cell', () => {
       const { result } = renderUseSelection();
 
-      // Simulate entering text-select mode via a prior drag
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
 
       act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
@@ -633,6 +632,25 @@ describe('useSelection', () => {
       });
 
       expect(store.get(isCursorTextAtom)).toBe(true);
+    });
+
+    it('clears native text selection on modifier click', () => {
+      const removeAllRanges = vi.fn();
+      vi.spyOn(window, 'getSelection').mockReturnValue({ removeAllRanges, isCollapsed: false } as unknown as Selection);
+
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      removeAllRanges.mockClear();
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(removeAllRanges).toHaveBeenCalled();
+
+      vi.restoreAllMocks();
     });
 
     it('isCursorText resets on clearSelection', () => {
@@ -878,19 +896,20 @@ describe('useSelection', () => {
       });
       act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
-      // Plain click sets new anchor
-      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
+      // Plain click on unselected cell sets new anchor
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Message, clickEvent()));
       act(() => {
         fireEvent.mouseUp(document);
       });
 
-      // Now shift+click from new anchor (row 1)
-      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+      // Now shift+click from new anchor (row 5)
+      act(() => result.current.handleCellMouseDown(7, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
-          [1, new Set([ViewerColumn.Message])],
-          [2, new Set([ViewerColumn.Message])],
+          [5, new Set([ViewerColumn.Message])],
+          [6, new Set([ViewerColumn.Message])],
+          [7, new Set([ViewerColumn.Message])],
         ]),
       );
     });
@@ -1383,6 +1402,75 @@ describe('useSelection', () => {
       });
 
       expect(store.get(isCursorTextAtom)).toBe(true);
+    });
+
+    it('enters text-select mode after multi-cell drag mouseup', () => {
+      const { result } = renderUseSelection();
+
+      // Start drag on row 0
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+
+      // Drag to row 2
+      mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
+      act(() => {
+        fireEvent.mouseMove(document, { clientX: 10, clientY: 40 });
+        vi.advanceTimersByTime(16);
+      });
+
+      // mouseup completes the drag
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+
+      expect(result.current.isTextSelectMode).toBe(true);
+    });
+
+    it('enters text-select mode after modifier click', () => {
+      const { result } = renderUseSelection();
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(result.current.isTextSelectMode).toBe(true);
+    });
+
+    it('defers to browser on re-click of any selected cell in text-select mode', () => {
+      const { result } = renderUseSelection();
+
+      // Select multiple cells via Cmd+click (sets isTextSelectMode to true)
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      const selectionBefore = result.current.selectedCells;
+
+      // Click on one of the selected cells — should NOT start a new drag
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
+
+      // Selection should be unchanged (early return, browser handles text selection)
+      expect(result.current.selectedCells).toBe(selectionBefore);
+    });
+
+    it('exits text-select mode when clicking unselected cell from multi-cell selection', () => {
+      const { result } = renderUseSelection();
+
+      // Select multiple cells via Cmd+click (sets isTextSelectMode to true)
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      // Click on an unselected cell — should start new selection
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent()));
+
+      expect(result.current.selectedCells).toEqual(new Map([[2, new Set([ViewerColumn.Message])]]));
+      expect(result.current.isTextSelectMode).toBe(false);
     });
   });
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -1904,29 +1904,30 @@ describe('useCellDrag', () => {
     expect(store.get(selectedCellsAtom)).toEqual(multiSelection);
   });
 
-  it('right-click on a non-selected cell selects it', () => {
+  it('right-click on a non-selected cell preserves existing selection', () => {
     const { result, store } = renderWithState((state) => useCellDrag(state));
 
+    const original = new Map([[0, new Set([ViewerColumn.Message])]]);
     act(() => {
-      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(selectedCellsAtom, original);
     });
 
     act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ button: 2 })));
 
-    expect(store.get(selectedCellsAtom)).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+    expect(store.get(selectedCellsAtom)).toEqual(original);
   });
 
-  it('Ctrl+click (macOS right-click) on a non-selected cell selects it', () => {
+  it('Ctrl+click (macOS right-click) on a non-selected cell preserves existing selection', () => {
     const { result, store } = renderWithState((state) => useCellDrag(state));
 
+    const original = new Map([[0, new Set([ViewerColumn.Message])]]);
     act(() => {
-      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(selectedCellsAtom, original);
     });
 
-    // macOS Ctrl+click on a different cell
     act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ button: 0, ctrlKey: true })));
 
-    expect(store.get(selectedCellsAtom)).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+    expect(store.get(selectedCellsAtom)).toEqual(original);
   });
 });
 

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -25,6 +25,10 @@ import {
   computeSelection,
   computeCellRange,
   useSelection,
+  useSelectionState,
+  useRowDrag,
+  useCellDrag,
+  useSelectionKeyboard,
 } from './selection';
 import { ViewerColumn } from './shared';
 import {
@@ -33,6 +37,7 @@ import {
   lastClickedCellAtom,
   lastClickedKeyAtom,
   selectedCellsAtom,
+  selectedKeysAtom,
   visibleColsAtom,
 } from './state';
 
@@ -404,6 +409,35 @@ describe('computeCellRange', () => {
   });
 });
 
+const clickEvent = (overrides: Partial<React.MouseEvent> = {}) =>
+  ({
+    shiftKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    stopPropagation: vi.fn(),
+    currentTarget: document.createElement('div'),
+    ...overrides,
+  }) as unknown as React.MouseEvent;
+
+function renderWithState<T>(
+  hookFn: (state: ReturnType<typeof useSelectionState>) => T,
+  storeOverrides?: (store: ReturnType<typeof createStore>) => void,
+) {
+  const store = createStore();
+  store.set(visibleColsAtom, new Set([ViewerColumn.Message]));
+  storeOverrides?.(store);
+
+  const result = renderHook(
+    () => {
+      const state = useSelectionState();
+      return hookFn(state);
+    },
+    { wrapper: ({ children }) => <Provider store={store}>{children}</Provider> },
+  );
+
+  return { ...result, store };
+}
+
 describe('useSelection', () => {
   const records = [
     makeRecord({ message: 'log message 0', timestamp: '2024-06-15T10:30:00.000Z' }),
@@ -430,16 +464,6 @@ describe('useSelection', () => {
 
     return { ...result, store, virtualizerRef };
   }
-
-  const clickEvent = (overrides: Partial<React.MouseEvent> = {}) =>
-    ({
-      shiftKey: false,
-      metaKey: false,
-      ctrlKey: false,
-      stopPropagation: vi.fn(),
-      currentTarget: document.createElement('div'),
-      ...overrides,
-    }) as unknown as React.MouseEvent;
 
   beforeEach(() => {
     Object.assign(navigator, {
@@ -1743,5 +1767,161 @@ describe('useSelection', () => {
       expect(copied).not.toMatch(/\t\t/);
       expect(copied).toContain('log message 0');
     });
+  });
+});
+
+describe('useSelectionState', () => {
+  it('returns atom values and setters', () => {
+    const { result } = renderWithState((state) => state);
+
+    expect(result.current.selectedKeys).toEqual(new Set());
+    expect(result.current.selectedCells).toEqual(new Map());
+    expect(result.current.visibleCols).toEqual(new Set([ViewerColumn.Message]));
+    expect(result.current.isTextSelectMode).toBe(false);
+    expect(result.current.isCursorText).toBe(false);
+    expect(typeof result.current.setSelectedKeys).toBe('function');
+    expect(typeof result.current.setSelectedCells).toBe('function');
+  });
+
+  it('clearSelection resets all state', () => {
+    const { result, store } = renderWithState((state) => state);
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(isTextSelectModeAtom, true);
+      store.set(isCursorTextAtom, true);
+    });
+
+    act(() => result.current.clearSelection());
+
+    expect(result.current.selectedKeys).toEqual(new Set());
+    expect(result.current.selectedCells).toEqual(new Map());
+    expect(result.current.isTextSelectMode).toBe(false);
+    expect(result.current.isCursorText).toBe(false);
+  });
+
+  it('scheduleCursorText sets isCursorText on mousemove', () => {
+    const { result, store } = renderWithState((state) => state);
+
+    act(() => result.current.scheduleCursorText());
+    act(() => {
+      fireEvent.mouseMove(document);
+    });
+
+    expect(store.get(isCursorTextAtom)).toBe(true);
+  });
+});
+
+describe('useRowDrag', () => {
+  it('selects a single row on plain mousedown', () => {
+    const { result } = renderWithState((state) => useRowDrag(state));
+
+    act(() => result.current.handleRowMouseDown(1, clickEvent()));
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(result.current.selectionTopKeys).toEqual(new Set([1]));
+    expect(result.current.selectionBottomKeys).toEqual(new Set([1]));
+  });
+
+  it('computes selection boundaries for contiguous range', () => {
+    const { result } = renderWithState((state) => useRowDrag(state));
+
+    act(() => result.current.handleRowMouseDown(0, clickEvent()));
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+    act(() => result.current.handleRowMouseDown(2, clickEvent({ shiftKey: true })));
+
+    expect(result.current.selectionTopKeys).toEqual(new Set([0]));
+    expect(result.current.selectionBottomKeys).toEqual(new Set([2]));
+  });
+});
+
+describe('useCellDrag', () => {
+  it('selects a cell on click', () => {
+    const { result, store } = renderWithState((state) => useCellDrag(state));
+
+    act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent()));
+
+    expect(store.get(selectedCellsAtom)).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+  });
+
+  it('enters text-select mode after mouseup', () => {
+    const { result, store } = renderWithState((state) => useCellDrag(state));
+
+    act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+
+    expect(store.get(isTextSelectModeAtom)).toBe(true);
+  });
+});
+
+describe('useSelectionKeyboard', () => {
+  const records = [
+    makeRecord({ message: 'log message 0', timestamp: '2024-06-15T10:30:00.000Z' }),
+    makeRecord({ message: 'log message 1', timestamp: '2024-06-15T10:30:01.000Z' }),
+  ];
+
+  const fakeVirtualizer = {
+    getRecord: (key: number) => records[key],
+  } as LogViewerVirtualizer;
+
+  function renderKeyboard(storeOverrides?: (store: ReturnType<typeof createStore>) => void) {
+    const store = createStore();
+    store.set(visibleColsAtom, new Set([ViewerColumn.Message]));
+    storeOverrides?.(store);
+
+    const virtualizerRef =
+      createRef<LogViewerVirtualizer | null>() as React.MutableRefObject<LogViewerVirtualizer | null>;
+    virtualizerRef.current = fakeVirtualizer;
+
+    const result = renderHook(
+      () => {
+        const state = useSelectionState();
+        useSelectionKeyboard(state, virtualizerRef);
+        return state;
+      },
+      { wrapper: ({ children }) => <Provider store={store}>{children}</Provider> },
+    );
+
+    return { ...result, store };
+  }
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('clears selection on Escape', () => {
+    const { result, store } = renderKeyboard();
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(result.current.selectedCells.size).toBe(0);
+  });
+
+  it('copies selected rows on Cmd+C', () => {
+    const { store } = renderKeyboard();
+
+    act(() => {
+      store.set(selectedKeysAtom, new Set([0, 1]));
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'c', metaKey: true });
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 0\nlog message 1');
   });
 });

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -183,11 +183,7 @@ export function computeSelection({
   return new Set([clickedKey]);
 }
 
-/**
- * useSelection - Hook that manages row selection, cell selection, text-select mode,
- * click handling, boundary computation, and keyboard shortcuts.
- */
-export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {
+export function useSelectionState() {
   const visibleCols = useAtomValue(visibleColsAtom);
   const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
   const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
@@ -196,23 +192,13 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
   const [isCursorText, setIsCursorText] = useAtom(isCursorTextAtom);
 
-  // Refs to avoid stale closures in callbacks
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
   const selectedCellsRef = useRef(selectedCells);
   const lastClickedCellRef = useRef(lastClickedCell);
   const isTextSelectModeRef = useRef(isTextSelectMode);
-
-  // Row drag state refs (dragStartKeyRef !== null means a row drag is active)
-  const dragStartKeyRef = useRef<number | null>(null);
-  const dragEndKeyRef = useRef<number | null>(null);
   const dragAbortRef = useRef<AbortController | null>(null);
 
-  // Cell drag state refs
-  const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
-  const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
-
-  // Schedule cursor-text restoration on next mousemove (at most one pending)
   const cursorTextPendingRef = useRef(false);
   const scheduleCursorText = useCallback(() => {
     if (cursorTextPendingRef.current) return;
@@ -235,7 +221,56 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     isTextSelectModeRef.current = isTextSelectMode;
   }, [selectedKeys, lastClickedKey, selectedCells, lastClickedCell, isTextSelectMode]);
 
-  // Pre-compute selection boundary sets (keys are sequential integers)
+  const clearSelection = useCallback(() => {
+    setSelectedKeys(new Set());
+    setLastClickedKey(null);
+    setSelectedCells(new Map());
+    setLastClickedCell(null);
+    setIsTextSelectMode(false);
+    setIsCursorText(false);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText]);
+
+  return {
+    visibleCols,
+    selectedKeys,
+    setSelectedKeys,
+    setLastClickedKey,
+    selectedCells,
+    setSelectedCells,
+    setLastClickedCell,
+    isTextSelectMode,
+    setIsTextSelectMode,
+    isCursorText,
+    setIsCursorText,
+    selectedKeysRef,
+    lastClickedKeyRef,
+    selectedCellsRef,
+    lastClickedCellRef,
+    isTextSelectModeRef,
+    dragAbortRef,
+    clearSelection,
+    scheduleCursorText,
+  };
+}
+
+export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
+  const {
+    selectedKeys,
+    setSelectedKeys,
+    setLastClickedKey,
+    setSelectedCells,
+    setLastClickedCell,
+    setIsTextSelectMode,
+    setIsCursorText,
+    selectedKeysRef,
+    lastClickedKeyRef,
+    selectedCellsRef,
+    dragAbortRef,
+  } = state;
+
+  const dragStartKeyRef = useRef<number | null>(null);
+  const dragEndKeyRef = useRef<number | null>(null);
+
   const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
     if (selectedKeys.size === 0) return { selectionTopKeys: selectedKeys, selectionBottomKeys: selectedKeys };
     const top = new Set<number>();
@@ -247,17 +282,6 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     return { selectionTopKeys: top, selectionBottomKeys: bottom };
   }, [selectedKeys]);
 
-  // Clear all selection state
-  const clearSelection = useCallback(() => {
-    setSelectedKeys(new Set());
-    setLastClickedKey(null);
-    setSelectedCells(new Map());
-    setLastClickedCell(null);
-    setIsTextSelectMode(false);
-    setIsCursorText(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText]);
-
-  // Row mousedown handler (Pos column) — supports click and drag-to-select
   const handleRowMouseDown = useCallback(
     (key: number, event: React.MouseEvent) => {
       // Modifier clicks don't start a drag
@@ -278,7 +302,6 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         return;
       }
 
-      // Start drag
       dragStartKeyRef.current = key;
       dragEndKeyRef.current = key;
       setSelectedKeys(new Set([key]));
@@ -338,10 +361,43 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText],
+    [
+      setSelectedKeys,
+      setLastClickedKey,
+      setSelectedCells,
+      setLastClickedCell,
+      setIsTextSelectMode,
+      setIsCursorText,
+      selectedKeysRef,
+      lastClickedKeyRef,
+      selectedCellsRef,
+      dragAbortRef,
+    ],
   );
 
-  // Cell mousedown handler — supports click, drag, Shift+click range, Cmd/Ctrl+click toggle
+  return { handleRowMouseDown, selectionTopKeys, selectionBottomKeys };
+}
+
+export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
+  const {
+    visibleCols,
+    setSelectedKeys,
+    setLastClickedKey,
+    setSelectedCells,
+    setLastClickedCell,
+    setIsTextSelectMode,
+    setIsCursorText,
+    selectedKeysRef,
+    selectedCellsRef,
+    lastClickedCellRef,
+    isTextSelectModeRef,
+    dragAbortRef,
+    scheduleCursorText,
+  } = state;
+
+  const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
+  const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
+
   const handleCellMouseDown = useCallback(
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
@@ -391,7 +447,6 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         return;
       }
 
-      // Start cell drag
       const start = { rowKey, col };
       cellDragStartRef.current = start;
       cellDragEndRef.current = start;
@@ -465,11 +520,24 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       setLastClickedKey,
       setIsTextSelectMode,
       setIsCursorText,
+      selectedKeysRef,
+      selectedCellsRef,
+      lastClickedCellRef,
+      isTextSelectModeRef,
+      dragAbortRef,
       scheduleCursorText,
     ],
   );
 
-  // Keyboard shortcuts
+  return { handleCellMouseDown };
+}
+
+export function useSelectionKeyboard(
+  state: ReturnType<typeof useSelectionState>,
+  virtualizerRef: React.RefObject<LogViewerVirtualizer | null>,
+) {
+  const { visibleCols, selectedKeysRef, selectedCellsRef, clearSelection } = state;
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -480,11 +548,9 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
 
       const isMod = e.metaKey || e.ctrlKey;
       if (isMod && e.key === 'c') {
-        // If user has native text selection (from text-select mode), let browser handle it
         const nativeSel = window.getSelection();
         if (nativeSel && !nativeSel.isCollapsed) return;
 
-        // Copy selected cells
         const cells = selectedCellsRef.current;
         if (cells.size > 0) {
           e.preventDefault();
@@ -510,25 +576,32 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
 
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [visibleCols, clearSelection]);
+  }, [visibleCols, clearSelection, selectedKeysRef, selectedCellsRef, virtualizerRef]);
+}
+
+export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {
+  const state = useSelectionState();
+  const { handleRowMouseDown, selectionTopKeys, selectionBottomKeys } = useRowDrag(state);
+  const { handleCellMouseDown } = useCellDrag(state);
+  useSelectionKeyboard(state, virtualizerRef);
 
   // Clean up drag listeners on unmount
   useEffect(
     () => () => {
-      dragAbortRef.current?.abort();
+      state.dragAbortRef.current?.abort();
     },
     [],
   );
 
   return {
-    selectedKeys,
+    selectedKeys: state.selectedKeys,
     selectionTopKeys,
     selectionBottomKeys,
-    selectedCells,
-    isTextSelectMode,
-    isCursorText,
+    selectedCells: state.selectedCells,
+    isTextSelectMode: state.isTextSelectMode,
+    isCursorText: state.isCursorText,
     handleRowMouseDown,
     handleCellMouseDown,
-    resetSelection: clearSelection,
+    resetSelection: state.clearSelection,
   };
 }

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -21,7 +21,13 @@ import { stripAnsi } from 'fancy-ansi';
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
 
 import { ViewerColumn } from './shared';
-import { isTextSelectModeAtom, lastClickedKeyAtom, selectedCellAtom, selectedKeysAtom, visibleColsAtom } from './state';
+import {
+  isTextSelectModeAtom,
+  lastClickedKeyAtom,
+  selectedCellsAtom,
+  selectedKeysAtom,
+  visibleColsAtom,
+} from './state';
 
 /**
  * getPlainAttribute - Returns a plain text string for a given log record column.
@@ -57,19 +63,46 @@ export function getPlainAttribute(record: LogRecord, col: ViewerColumn): string 
 }
 
 /**
+ * formatRow - Formats a single record as tab-separated column values.
+ * ColorDot is skipped. When filter is provided, only matching columns are included.
+ */
+function formatRow(record: LogRecord, visibleCols: Set<ViewerColumn>, filter?: Set<ViewerColumn>): string {
+  const parts: string[] = [];
+  visibleCols.forEach((col) => {
+    if (col === ViewerColumn.ColorDot) return;
+    if (filter && !filter.has(col)) return;
+    parts.push(getPlainAttribute(record, col));
+  });
+  return parts.join('\t');
+}
+
+/**
  * formatRowsForCopy - Formats an array of log records as copyable text.
  * Columns are tab-separated, rows are newline-separated. ColorDot is skipped.
  */
 export function formatRowsForCopy(records: LogRecord[], visibleCols: Set<ViewerColumn>): string {
-  return records
-    .map((record) => {
-      const parts: string[] = [];
-      visibleCols.forEach((col) => {
-        if (col === ViewerColumn.ColorDot) return;
-        parts.push(getPlainAttribute(record, col));
-      });
-      return parts.join('\t');
+  return records.map((record) => formatRow(record, visibleCols)).join('\n');
+}
+
+/**
+ * formatCellsForCopy - Formats selected cells as copyable text.
+ * Columns are tab-separated within a row, rows are newline-separated. ColorDot is skipped.
+ * Rows are sorted by key ascending; only selected columns (in visibleCols order) are included.
+ */
+export function formatCellsForCopy(
+  selectedCells: Map<number, Set<ViewerColumn>>,
+  visibleCols: Set<ViewerColumn>,
+  getRecord: (key: number) => LogRecord | undefined,
+): string {
+  return [...selectedCells.keys()]
+    .sort((a, b) => a - b)
+    .map((rowKey) => {
+      const record = getRecord(rowKey);
+      if (!record) return null;
+      const text = formatRow(record, visibleCols, selectedCells.get(rowKey));
+      return text || null;
     })
+    .filter((line): line is string => line !== null)
     .join('\n');
 }
 
@@ -123,13 +156,13 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const visibleCols = useAtomValue(visibleColsAtom);
   const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
   const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
-  const [selectedCell, setSelectedCell] = useAtom(selectedCellAtom);
+  const [selectedCells, setSelectedCells] = useAtom(selectedCellsAtom);
   const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
 
   // Refs to avoid stale closures in callbacks
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
-  const selectedCellRef = useRef(selectedCell);
+  const selectedCellsRef = useRef(selectedCells);
 
   // Drag state refs (dragStartKeyRef !== null means a drag is active)
   const dragStartKeyRef = useRef<number | null>(null);
@@ -139,8 +172,8 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
     lastClickedKeyRef.current = lastClickedKey;
-    selectedCellRef.current = selectedCell;
-  }, [selectedKeys, lastClickedKey, selectedCell]);
+    selectedCellsRef.current = selectedCells;
+  }, [selectedKeys, lastClickedKey, selectedCells]);
 
   // Pre-compute selection boundary sets (keys are sequential integers)
   const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
@@ -158,9 +191,9 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const clearSelection = useCallback(() => {
     setSelectedKeys(new Set());
     setLastClickedKey(null);
-    setSelectedCell(null);
+    setSelectedCells(new Map());
     setIsTextSelectMode(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode]);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setIsTextSelectMode]);
 
   // Row mousedown handler (Pos column) — supports click and drag-to-select
   const handleRowMouseDown = useCallback(
@@ -176,7 +209,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         });
         setSelectedKeys(next);
         setLastClickedKey(key);
-        setSelectedCell(null);
+        if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
         setIsTextSelectMode(false);
         return;
       }
@@ -185,7 +218,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       dragStartKeyRef.current = key;
       dragEndKeyRef.current = key;
       setSelectedKeys(new Set([key]));
-      setSelectedCell(null);
+      if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
       setIsTextSelectMode(false);
 
       let rafId: number | null = null;
@@ -239,21 +272,40 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [setSelectedKeys, setLastClickedKey, setSelectedCell, setIsTextSelectMode],
+    [setSelectedKeys, setLastClickedKey, setSelectedCells, setIsTextSelectMode],
   );
 
-  // Cell click handler (data cells)
+  // Cell click handler (data cells) — supports Cmd/Ctrl+click for multi-cell selection
   const handleCellClick = useCallback(
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
       const hasTextSelection = !window.getSelection()?.isCollapsed;
-      setSelectedCell({ rowKey, col });
-      setSelectedKeys(new Set());
+
+      if (event.metaKey || event.ctrlKey) {
+        // Toggle cell in/out of selection
+        const next = new Map(selectedCellsRef.current);
+        const newCols = new Set(next.get(rowKey) ?? []);
+        if (newCols.has(col)) {
+          newCols.delete(col);
+        } else {
+          newCols.add(col);
+        }
+        if (newCols.size === 0) {
+          next.delete(rowKey);
+        } else {
+          next.set(rowKey, newCols);
+        }
+        setSelectedCells(next);
+      } else {
+        setSelectedCells(new Map([[rowKey, new Set([col])]]));
+      }
+
+      if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
       setIsTextSelectMode(hasTextSelection);
     },
-    [setSelectedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
+    [setSelectedCells, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
   );
 
   // Keyboard shortcuts
@@ -271,16 +323,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         const nativeSel = window.getSelection();
         if (nativeSel && !nativeSel.isCollapsed) return;
 
-        // Copy selected cell text
-        const cell = selectedCellRef.current;
-        if (cell) {
+        // Copy selected cells
+        const cells = selectedCellsRef.current;
+        if (cells.size > 0) {
           e.preventDefault();
           const v = virtualizerRef.current;
           if (!v) return;
-          const record = v.getRecord(cell.rowKey);
-          if (record) {
-            navigator.clipboard.writeText(getPlainAttribute(record, cell.col));
-          }
+          const text = formatCellsForCopy(cells, visibleCols, (k) => v.getRecord(k));
+          navigator.clipboard.writeText(text);
           return;
         }
 
@@ -313,7 +363,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectedKeys,
     selectionTopKeys,
     selectionBottomKeys,
-    selectedCell,
+    selectedCells,
     isTextSelectMode,
     handleRowMouseDown,
     handleCellClick,

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -22,6 +22,7 @@ import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-v
 
 import { ViewerColumn } from './shared';
 import {
+  isCursorTextAtom,
   isTextSelectModeAtom,
   lastClickedCellAtom,
   lastClickedKeyAtom,
@@ -183,23 +184,6 @@ export function computeSelection({
 }
 
 /**
- * Keep the default cursor on a cell until the next mousemove,
- * then let the CSS cursor-text class take over.
- */
-/* eslint-disable no-param-reassign */
-function delayCursorText(el: HTMLElement) {
-  el.style.cursor = 'default';
-  document.addEventListener(
-    'mousemove',
-    () => {
-      el.style.cursor = '';
-    },
-    { once: true },
-  );
-}
-/* eslint-enable no-param-reassign */
-
-/**
  * useSelection - Hook that manages row selection, cell selection, text-select mode,
  * click handling, boundary computation, and keyboard shortcuts.
  */
@@ -210,12 +194,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const [selectedCells, setSelectedCells] = useAtom(selectedCellsAtom);
   const [lastClickedCell, setLastClickedCell] = useAtom(lastClickedCellAtom);
   const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
+  const [isCursorText, setIsCursorText] = useAtom(isCursorTextAtom);
 
   // Refs to avoid stale closures in callbacks
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
   const selectedCellsRef = useRef(selectedCells);
   const lastClickedCellRef = useRef(lastClickedCell);
+  const isTextSelectModeRef = useRef(isTextSelectMode);
 
   // Row drag state refs (dragStartKeyRef !== null means a row drag is active)
   const dragStartKeyRef = useRef<number | null>(null);
@@ -226,12 +212,28 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
   const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
 
+  // Schedule cursor-text restoration on next mousemove (at most one pending)
+  const cursorTextPendingRef = useRef(false);
+  const scheduleCursorText = useCallback(() => {
+    if (cursorTextPendingRef.current) return;
+    cursorTextPendingRef.current = true;
+    document.addEventListener(
+      'mousemove',
+      () => {
+        cursorTextPendingRef.current = false;
+        setIsCursorText(true);
+      },
+      { once: true },
+    );
+  }, [setIsCursorText]);
+
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
     lastClickedKeyRef.current = lastClickedKey;
     selectedCellsRef.current = selectedCells;
     lastClickedCellRef.current = lastClickedCell;
-  }, [selectedKeys, lastClickedKey, selectedCells, lastClickedCell]);
+    isTextSelectModeRef.current = isTextSelectMode;
+  }, [selectedKeys, lastClickedKey, selectedCells, lastClickedCell, isTextSelectMode]);
 
   // Pre-compute selection boundary sets (keys are sequential integers)
   const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
@@ -252,7 +254,8 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     setSelectedCells(new Map());
     setLastClickedCell(null);
     setIsTextSelectMode(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode]);
+    setIsCursorText(false);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText]);
 
   // Row mousedown handler (Pos column) — supports click and drag-to-select
   const handleRowMouseDown = useCallback(
@@ -271,6 +274,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
         setLastClickedCell(null);
         setIsTextSelectMode(false);
+        setIsCursorText(false);
         return;
       }
 
@@ -281,6 +285,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
       setLastClickedCell(null);
       setIsTextSelectMode(false);
+      setIsCursorText(false);
 
       let rafId: number | null = null;
       let pendingX = 0;
@@ -333,7 +338,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode],
+    [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText],
   );
 
   // Cell mousedown handler — supports click, drag, Shift+click range, Cmd/Ctrl+click toggle
@@ -342,7 +347,6 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
       const hasTextSelection = !window.getSelection()?.isCollapsed;
-      const clickedEl = event.currentTarget as HTMLElement;
 
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
         if (event.shiftKey && lastClickedCellRef.current !== null) {
@@ -378,8 +382,17 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
         setLastClickedKey(null);
         setIsTextSelectMode(hasTextSelection);
-        delayCursorText(clickedEl);
+        setIsCursorText(false);
+        scheduleCursorText();
         return;
+      }
+
+      // In text-select mode on the only selected cell, let the browser handle it
+      if (isTextSelectModeRef.current) {
+        const prevRowCols = selectedCellsRef.current.get(rowKey);
+        if (selectedCellsRef.current.size === 1 && prevRowCols?.size === 1 && prevRowCols.has(col)) {
+          return;
+        }
       }
 
       // Start cell drag
@@ -390,6 +403,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
       setIsTextSelectMode(false);
+      setIsCursorText(false);
 
       let rafId: number | null = null;
       let pendingX = 0;
@@ -431,12 +445,16 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         const end = cellDragEndRef.current;
         if (end) {
           setLastClickedCell(end);
+          // Click without drag — enable text selection for the next click
+          if (end.rowKey === cellDragStartRef.current?.rowKey && end.col === cellDragStartRef.current?.col) {
+            setIsTextSelectMode(true);
+          }
         }
         cellDragStartRef.current = null;
         cellDragEndRef.current = null;
         dragAbortRef.current?.abort();
         dragAbortRef.current = null;
-        delayCursorText(clickedEl);
+        scheduleCursorText();
       };
 
       dragAbortRef.current?.abort();
@@ -446,7 +464,16 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [visibleCols, setSelectedCells, setLastClickedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
+    [
+      visibleCols,
+      setSelectedCells,
+      setLastClickedCell,
+      setSelectedKeys,
+      setLastClickedKey,
+      setIsTextSelectMode,
+      setIsCursorText,
+      scheduleCursorText,
+    ],
   );
 
   // Keyboard shortcuts
@@ -506,6 +533,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectionBottomKeys,
     selectedCells,
     isTextSelectMode,
+    isCursorText,
     handleRowMouseDown,
     handleCellMouseDown,
     resetSelection: clearSelection,

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -116,7 +116,7 @@ export function computeCellRange(
   target: { rowKey: number; col: ViewerColumn },
   visibleCols: Set<ViewerColumn>,
 ): Map<number, Set<ViewerColumn>> {
-  const cols = [...visibleCols].filter((c) => c !== ViewerColumn.ColorDot);
+  const cols: ViewerColumn[] = [...visibleCols].filter((c) => c !== ViewerColumn.ColorDot);
   const anchorIdx = cols.indexOf(anchor.col);
   const targetIdx = cols.indexOf(target.col);
 
@@ -358,6 +358,17 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
       setIsTextSelectMode(hasTextSelection);
+
+      // Keep default cursor until mouse moves, then let the cursor-text class take over
+      const el = event.currentTarget as HTMLElement;
+      el.style.cursor = 'default';
+      document.addEventListener(
+        'mousemove',
+        () => {
+          el.style.cursor = '';
+        },
+        { once: true },
+      );
     },
     [visibleCols, setSelectedCells, setLastClickedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
   );

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -403,17 +403,10 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
 
-      // Right-click (or macOS Ctrl+click): preserve selection if cell is selected, otherwise select just this cell
+      // Right-click (or macOS Ctrl+click): preserve selection for the context menu
       const isContextClick =
         event.button === 2 || (event.button === 0 && event.ctrlKey && !event.metaKey && !event.shiftKey);
-      if (isContextClick) {
-        if (selectedCellsRef.current.get(rowKey)?.has(col)) return;
-        setSelectedCells(new Map([[rowKey, new Set([col])]]));
-        if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
-        setLastClickedKey(null);
-        setLastClickedCell({ rowKey, col });
-        return;
-      }
+      if (isContextClick) return;
 
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
         if (event.shiftKey && lastClickedCellRef.current !== null) {

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -402,6 +402,19 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
+
+      // Right-click (or macOS Ctrl+click): preserve selection if cell is selected, otherwise select just this cell
+      const isContextClick =
+        event.button === 2 || (event.button === 0 && event.ctrlKey && !event.metaKey && !event.shiftKey);
+      if (isContextClick) {
+        if (selectedCellsRef.current.get(rowKey)?.has(col)) return;
+        setSelectedCells(new Map([[rowKey, new Set([col])]]));
+        if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
+        setLastClickedKey(null);
+        setLastClickedCell({ rowKey, col });
+        return;
+      }
+
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
         if (event.shiftKey && lastClickedCellRef.current !== null) {
           const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -323,9 +323,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       const hasTextSelection = !window.getSelection()?.isCollapsed;
 
       if (event.shiftKey && lastClickedCellRef.current !== null) {
-        // Range select from anchor to target; keep anchor unchanged for subsequent shift+clicks
+        // Range select from anchor to target, merged with existing selection
         const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
-        setSelectedCells(range);
+        const merged = new Map(selectedCellsRef.current);
+        range.forEach((cols, rk) => {
+          const existing = merged.get(rk);
+          merged.set(rk, existing ? new Set([...existing, ...cols]) : cols);
+        });
+        setSelectedCells(merged);
       } else {
         if (event.metaKey || event.ctrlKey) {
           // Toggle cell in/out of selection

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -183,6 +183,23 @@ export function computeSelection({
 }
 
 /**
+ * Keep the default cursor on a cell until the next mousemove,
+ * then let the CSS cursor-text class take over.
+ */
+/* eslint-disable no-param-reassign */
+function delayCursorText(el: HTMLElement) {
+  el.style.cursor = 'default';
+  document.addEventListener(
+    'mousemove',
+    () => {
+      el.style.cursor = '';
+    },
+    { once: true },
+  );
+}
+/* eslint-enable no-param-reassign */
+
+/**
  * useSelection - Hook that manages row selection, cell selection, text-select mode,
  * click handling, boundary computation, and keyboard shortcuts.
  */
@@ -200,10 +217,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const selectedCellsRef = useRef(selectedCells);
   const lastClickedCellRef = useRef(lastClickedCell);
 
-  // Drag state refs (dragStartKeyRef !== null means a drag is active)
+  // Row drag state refs (dragStartKeyRef !== null means a row drag is active)
   const dragStartKeyRef = useRef<number | null>(null);
   const dragEndKeyRef = useRef<number | null>(null);
   const dragAbortRef = useRef<AbortController | null>(null);
+
+  // Cell drag state refs
+  const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
+  const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
 
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
@@ -315,25 +336,24 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode],
   );
 
-  // Cell click handler (data cells) — supports Shift+click range, Cmd/Ctrl+click toggle
-  const handleCellClick = useCallback(
+  // Cell mousedown handler — supports click, drag, Shift+click range, Cmd/Ctrl+click toggle
+  const handleCellMouseDown = useCallback(
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
       const hasTextSelection = !window.getSelection()?.isCollapsed;
+      const clickedEl = event.currentTarget as HTMLElement;
 
-      if (event.shiftKey && lastClickedCellRef.current !== null) {
-        // Range select from anchor to target, merged with existing selection
-        const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
-        const merged = new Map(selectedCellsRef.current);
-        range.forEach((cols, rk) => {
-          const existing = merged.get(rk);
-          merged.set(rk, existing ? new Set([...existing, ...cols]) : cols);
-        });
-        setSelectedCells(merged);
-      } else {
-        if (event.metaKey || event.ctrlKey) {
-          // Toggle cell in/out of selection
+      if (event.shiftKey || event.metaKey || event.ctrlKey) {
+        if (event.shiftKey && lastClickedCellRef.current !== null) {
+          const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
+          const merged = new Map(selectedCellsRef.current);
+          range.forEach((cols, rk) => {
+            const existing = merged.get(rk);
+            merged.set(rk, existing ? new Set([...existing, ...cols]) : cols);
+          });
+          setSelectedCells(merged);
+        } else if (event.metaKey || event.ctrlKey) {
           const next = new Map(selectedCellsRef.current);
           const newCols = new Set(next.get(rowKey) ?? []);
           if (newCols.has(col)) {
@@ -347,28 +367,84 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
             next.set(rowKey, newCols);
           }
           setSelectedCells(next);
+          if (lastClickedCellRef.current?.rowKey !== rowKey || lastClickedCellRef.current?.col !== col) {
+            setLastClickedCell({ rowKey, col });
+          }
         } else {
           setSelectedCells(new Map([[rowKey, new Set([col])]]));
-        }
-        if (lastClickedCellRef.current?.rowKey !== rowKey || lastClickedCellRef.current?.col !== col) {
           setLastClickedCell({ rowKey, col });
         }
+
+        if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
+        setLastClickedKey(null);
+        setIsTextSelectMode(hasTextSelection);
+        delayCursorText(clickedEl);
+        return;
       }
 
+      // Start cell drag
+      const start = { rowKey, col };
+      cellDragStartRef.current = start;
+      cellDragEndRef.current = start;
+      setSelectedCells(new Map([[rowKey, new Set([col])]]));
       if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
-      setIsTextSelectMode(hasTextSelection);
+      setIsTextSelectMode(false);
 
-      // Keep default cursor until mouse moves, then let the cursor-text class take over
-      const el = event.currentTarget as HTMLElement;
-      el.style.cursor = 'default';
-      document.addEventListener(
-        'mousemove',
-        () => {
-          el.style.cursor = '';
-        },
-        { once: true },
-      );
+      let rafId: number | null = null;
+      let pendingX = 0;
+      let pendingY = 0;
+
+      const processMove = () => {
+        rafId = null;
+        if (cellDragStartRef.current === null) return;
+        const el = document.elementFromPoint(pendingX, pendingY);
+        const cellEl = el?.closest('[data-col-id]') as HTMLElement | null;
+        const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
+        if (!cellEl || !rowEl) return;
+        const endRowKey = Number(rowEl.dataset.rowKey);
+        const endCol = cellEl.dataset.colId;
+        if (Number.isNaN(endRowKey) || !endCol) return;
+        const end = { rowKey: endRowKey, col: endCol as ViewerColumn };
+        if (end.rowKey === cellDragEndRef.current?.rowKey && end.col === cellDragEndRef.current?.col) return;
+        cellDragEndRef.current = end;
+        setSelectedCells(computeCellRange(cellDragStartRef.current, end, visibleCols));
+      };
+
+      const onMouseMove = (e: MouseEvent) => {
+        if (cellDragStartRef.current === null) return;
+        e.preventDefault();
+        pendingX = e.clientX;
+        pendingY = e.clientY;
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(processMove);
+      };
+
+      const onMouseUp = (e: MouseEvent) => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+          rafId = null;
+          pendingX = e.clientX;
+          pendingY = e.clientY;
+          processMove();
+        }
+        const end = cellDragEndRef.current;
+        if (end) {
+          setLastClickedCell(end);
+        }
+        cellDragStartRef.current = null;
+        cellDragEndRef.current = null;
+        dragAbortRef.current?.abort();
+        dragAbortRef.current = null;
+        delayCursorText(clickedEl);
+      };
+
+      dragAbortRef.current?.abort();
+      dragAbortRef.current = new AbortController();
+      const { signal } = dragAbortRef.current;
+
+      document.addEventListener('mousemove', onMouseMove, { signal });
+      document.addEventListener('mouseup', onMouseUp, { signal });
     },
     [visibleCols, setSelectedCells, setLastClickedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
   );
@@ -431,7 +507,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectedCells,
     isTextSelectMode,
     handleRowMouseDown,
-    handleCellClick,
+    handleCellMouseDown,
     resetSelection: clearSelection,
   };
 }

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -23,6 +23,7 @@ import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-v
 import { ViewerColumn } from './shared';
 import {
   isTextSelectModeAtom,
+  lastClickedCellAtom,
   lastClickedKeyAtom,
   selectedCellsAtom,
   selectedKeysAtom,
@@ -107,6 +108,39 @@ export function formatCellsForCopy(
 }
 
 /**
+ * computeCellRange - Pure function that computes a rectangular cell selection between two cells.
+ * If either anchor or target is ColorDot, returns just the target cell.
+ */
+export function computeCellRange(
+  anchor: { rowKey: number; col: ViewerColumn },
+  target: { rowKey: number; col: ViewerColumn },
+  visibleCols: Set<ViewerColumn>,
+): Map<number, Set<ViewerColumn>> {
+  const cols = [...visibleCols].filter((c) => c !== ViewerColumn.ColorDot);
+  const anchorIdx = cols.indexOf(anchor.col);
+  const targetIdx = cols.indexOf(target.col);
+
+  if (anchorIdx === -1 || targetIdx === -1) {
+    return new Map([[target.rowKey, new Set([target.col])]]);
+  }
+
+  const minRow = Math.min(anchor.rowKey, target.rowKey);
+  const maxRow = Math.max(anchor.rowKey, target.rowKey);
+  const minCol = Math.min(anchorIdx, targetIdx);
+  const maxCol = Math.max(anchorIdx, targetIdx);
+
+  const result = new Map<number, Set<ViewerColumn>>();
+  for (let r = minRow; r <= maxRow; r += 1) {
+    const colSet = new Set<ViewerColumn>();
+    for (let c = minCol; c <= maxCol; c += 1) {
+      colSet.add(cols[c]);
+    }
+    result.set(r, colSet);
+  }
+  return result;
+}
+
+/**
  * computeSelection - Pure function that computes the next selection state based on a click event.
  */
 export function computeSelection({
@@ -157,12 +191,14 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
   const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
   const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
   const [selectedCells, setSelectedCells] = useAtom(selectedCellsAtom);
+  const [lastClickedCell, setLastClickedCell] = useAtom(lastClickedCellAtom);
   const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
 
   // Refs to avoid stale closures in callbacks
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
   const selectedCellsRef = useRef(selectedCells);
+  const lastClickedCellRef = useRef(lastClickedCell);
 
   // Drag state refs (dragStartKeyRef !== null means a drag is active)
   const dragStartKeyRef = useRef<number | null>(null);
@@ -173,7 +209,8 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectedKeysRef.current = selectedKeys;
     lastClickedKeyRef.current = lastClickedKey;
     selectedCellsRef.current = selectedCells;
-  }, [selectedKeys, lastClickedKey, selectedCells]);
+    lastClickedCellRef.current = lastClickedCell;
+  }, [selectedKeys, lastClickedKey, selectedCells, lastClickedCell]);
 
   // Pre-compute selection boundary sets (keys are sequential integers)
   const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
@@ -192,8 +229,9 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     setSelectedKeys(new Set());
     setLastClickedKey(null);
     setSelectedCells(new Map());
+    setLastClickedCell(null);
     setIsTextSelectMode(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setIsTextSelectMode]);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode]);
 
   // Row mousedown handler (Pos column) — supports click and drag-to-select
   const handleRowMouseDown = useCallback(
@@ -210,6 +248,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         setSelectedKeys(next);
         setLastClickedKey(key);
         if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
+        setLastClickedCell(null);
         setIsTextSelectMode(false);
         return;
       }
@@ -219,6 +258,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       dragEndKeyRef.current = key;
       setSelectedKeys(new Set([key]));
       if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
+      setLastClickedCell(null);
       setIsTextSelectMode(false);
 
       let rafId: number | null = null;
@@ -272,40 +312,49 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [setSelectedKeys, setLastClickedKey, setSelectedCells, setIsTextSelectMode],
+    [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode],
   );
 
-  // Cell click handler (data cells) — supports Cmd/Ctrl+click for multi-cell selection
+  // Cell click handler (data cells) — supports Shift+click range, Cmd/Ctrl+click toggle
   const handleCellClick = useCallback(
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
       const hasTextSelection = !window.getSelection()?.isCollapsed;
 
-      if (event.metaKey || event.ctrlKey) {
-        // Toggle cell in/out of selection
-        const next = new Map(selectedCellsRef.current);
-        const newCols = new Set(next.get(rowKey) ?? []);
-        if (newCols.has(col)) {
-          newCols.delete(col);
-        } else {
-          newCols.add(col);
-        }
-        if (newCols.size === 0) {
-          next.delete(rowKey);
-        } else {
-          next.set(rowKey, newCols);
-        }
-        setSelectedCells(next);
+      if (event.shiftKey && lastClickedCellRef.current !== null) {
+        // Range select from anchor to target; keep anchor unchanged for subsequent shift+clicks
+        const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
+        setSelectedCells(range);
       } else {
-        setSelectedCells(new Map([[rowKey, new Set([col])]]));
+        if (event.metaKey || event.ctrlKey) {
+          // Toggle cell in/out of selection
+          const next = new Map(selectedCellsRef.current);
+          const newCols = new Set(next.get(rowKey) ?? []);
+          if (newCols.has(col)) {
+            newCols.delete(col);
+          } else {
+            newCols.add(col);
+          }
+          if (newCols.size === 0) {
+            next.delete(rowKey);
+          } else {
+            next.set(rowKey, newCols);
+          }
+          setSelectedCells(next);
+        } else {
+          setSelectedCells(new Map([[rowKey, new Set([col])]]));
+        }
+        if (lastClickedCellRef.current?.rowKey !== rowKey || lastClickedCellRef.current?.col !== col) {
+          setLastClickedCell({ rowKey, col });
+        }
       }
 
       if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
       setIsTextSelectMode(hasTextSelection);
     },
-    [setSelectedCells, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
+    [visibleCols, setSelectedCells, setLastClickedCell, setSelectedKeys, setLastClickedKey, setIsTextSelectMode],
   );
 
   // Keyboard shortcuts

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -198,7 +198,6 @@ export function useSelectionState() {
   const lastClickedCellRef = useRef(lastClickedCell);
   const isTextSelectModeRef = useRef(isTextSelectMode);
   const dragAbortRef = useRef<AbortController | null>(null);
-
   const cursorTextPendingRef = useRef(false);
   const scheduleCursorText = useCallback(() => {
     if (cursorTextPendingRef.current) return;
@@ -547,6 +546,8 @@ export function useSelectionKeyboard(
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // If Radix already handled Escape (e.g. closing a context menu), skip
+        if (e.defaultPrevented) return;
         clearSelection();
         window.getSelection()?.removeAllRanges();
         return;

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -413,9 +413,9 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
         if (!cellEl || !rowEl) return;
         const endRowKey = Number(rowEl.dataset.rowKey);
-        const endCol = cellEl.dataset.colId;
-        if (Number.isNaN(endRowKey) || !endCol) return;
-        const end = { rowKey: endRowKey, col: endCol as ViewerColumn };
+        const endCol = cellEl.dataset.colId as ViewerColumn | undefined;
+        if (Number.isNaN(endRowKey) || !endCol || endCol === ViewerColumn.ColorDot) return;
+        const end = { rowKey: endRowKey, col: endCol };
         if (end.rowKey === cellDragEndRef.current?.rowKey && end.col === cellDragEndRef.current?.col) return;
         cellDragEndRef.current = end;
         setSelectedCells(computeCellRange(cellDragStartRef.current, end, visibleCols));

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -346,8 +346,6 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
       if (col === ViewerColumn.ColorDot) return;
       event.stopPropagation();
-      const hasTextSelection = !window.getSelection()?.isCollapsed;
-
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
         if (event.shiftKey && lastClickedCellRef.current !== null) {
           const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
@@ -381,18 +379,16 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
 
         if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
         setLastClickedKey(null);
-        setIsTextSelectMode(hasTextSelection);
+        setIsTextSelectMode(true);
         setIsCursorText(false);
         scheduleCursorText();
+        window.getSelection()?.removeAllRanges();
         return;
       }
 
-      // In text-select mode on the only selected cell, let the browser handle it
-      if (isTextSelectModeRef.current) {
-        const prevRowCols = selectedCellsRef.current.get(rowKey);
-        if (selectedCellsRef.current.size === 1 && prevRowCols?.size === 1 && prevRowCols.has(col)) {
-          return;
-        }
+      // In text-select mode on a selected cell, let the browser handle it
+      if (isTextSelectModeRef.current && selectedCellsRef.current.get(rowKey)?.has(col)) {
+        return;
       }
 
       // Start cell drag
@@ -445,10 +441,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
         const end = cellDragEndRef.current;
         if (end) {
           setLastClickedCell(end);
-          // Click without drag — enable text selection for the next click
-          if (end.rowKey === cellDragStartRef.current?.rowKey && end.col === cellDragStartRef.current?.col) {
-            setIsTextSelectMode(true);
-          }
+          setIsTextSelectMode(true);
         }
         cellDragStartRef.current = null;
         cellDragEndRef.current = null;

--- a/dashboard-ui/src/pages/console/state.ts
+++ b/dashboard-ui/src/pages/console/state.ts
@@ -30,7 +30,7 @@ export const selectedKeysAtom = atom(new Set<number>());
 
 export const lastClickedKeyAtom = atom<number | null>(null);
 
-export const selectedCellAtom = atom<{ rowKey: number; col: ViewerColumn } | null>(null);
+export const selectedCellsAtom = atom<Map<number, Set<ViewerColumn>>>(new Map());
 
 export const isTextSelectModeAtom = atom(false);
 

--- a/dashboard-ui/src/pages/console/state.ts
+++ b/dashboard-ui/src/pages/console/state.ts
@@ -36,6 +36,8 @@ export const lastClickedCellAtom = atom<{ rowKey: number; col: ViewerColumn } | 
 
 export const isTextSelectModeAtom = atom(false);
 
+export const isCursorTextAtom = atom(false);
+
 export const isWrapAtom = atom(false);
 
 export const visibleColsAtom = atom(

--- a/dashboard-ui/src/pages/console/state.ts
+++ b/dashboard-ui/src/pages/console/state.ts
@@ -32,6 +32,8 @@ export const lastClickedKeyAtom = atom<number | null>(null);
 
 export const selectedCellsAtom = atom<Map<number, Set<ViewerColumn>>>(new Map());
 
+export const lastClickedCellAtom = atom<{ rowKey: number; col: ViewerColumn } | null>(null);
+
 export const isTextSelectModeAtom = atom(false);
 
 export const isWrapAtom = atom(false);


### PR DESCRIPTION
Ref #777 

## Summary

Adds multi-cell selection to the log viewer console, allowing users to select individual cells, ranges, and rectangular regions. Selected cells support native text selection, clipboard copy (Cmd/Ctrl+C), and visual feedback including contiguous borders and cursor changes. Right-click and Escape interactions are handled correctly alongside Radix context menus.

## Key Changes

- Add Cmd/Ctrl+click to toggle individual cell selection and Shift+click for rectangular range selection
- Add click-and-drag to select rectangular cell regions
- Enable native text selection within selected cells with delayed cursor-text feedback
- Include ColorDot column in selection border visuals for contiguous appearance
- Extract `useSelection` into composable sub-hooks (`useSelectionState`, `useRowDrag`, `useCellDrag`, `useSelectionKeyboard`)
- Preserve cell selection on right-click (button=2 and macOS Ctrl+click) for context menu use
- Show default cursor on selected cells when holding Ctrl/Cmd via Tailwind `group-data-[mod-key]` variant
- Skip selection clear on Escape when Radix context menu already handled the event (`e.defaultPrevented`)
- Add comprehensive test coverage for all selection interactions

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused