### PR TITLE
✨ Rename post-merge-checks-riscv64 workflow and job

### DIFF
--- a/.github/workflows/post-merge-checks-riscv64.yml
+++ b/.github/workflows/post-merge-checks-riscv64.yml
@@ -1,4 +1,4 @@
-name: riscv64-post-merge-checks
+name: post-merge-checks-riscv64
 
 permissions:
   contents: read
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  go-test-riscv64:
+  go-test:
     strategy:
       matrix:
         module:


### PR DESCRIPTION
## Summary

Changes post-merge-checks workflow name and job name.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
