### PR TITLE
🐋 Add date range dropdown component

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "^4.1.7",
     "@fontsource-variable/roboto-flex": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
-    "@kubetail/ui": "2.5.0",
+    "@kubetail/ui": "2.7.1",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/dashboard-ui/pnpm-lock.yaml
+++ b/dashboard-ui/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
       '@kubetail/ui':
-        specifier: 2.5.0
-        version: 2.5.0(c564283f2d6f5581087f44dd22f53b44)
+        specifier: 2.7.1
+        version: 2.7.1(c564283f2d6f5581087f44dd22f53b44)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1108,8 +1108,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubetail/ui@2.5.0':
-    resolution: {integrity: sha512-K6oAHejPJhnOjAT5/GzZ5QFCC9GJiXSC0jFBYBtSMpkPKjcyfOpnpiugvJo9TvUbskkVr6eA9ZDuWg418D/yWQ==}
+  '@kubetail/ui@2.7.1':
+    resolution: {integrity: sha512-Hz0C7+Olmo6MtVUQ63NLkcUwdjNaCayQikx25rhh3RfYA3KhVFrb3pv3oWKFaaM1ESX9ncvopSusq5ADZhnNvQ==}
     peerDependencies:
       '@radix-ui/react-avatar': ^1
       '@radix-ui/react-checkbox': ^1
@@ -5579,7 +5579,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubetail/ui@2.5.0(c564283f2d6f5581087f44dd22f53b44)':
+  '@kubetail/ui@2.7.1(c564283f2d6f5581087f44dd22f53b44)':
     dependencies:
       class-variance-authority: 0.7.1
       clsx: 2.1.1

--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
@@ -1,0 +1,280 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DateRangeDropdown, Duration, DurationUnit, parseTimestamp } from './DateRangeDropdown';
+
+describe('parseTimestamp', () => {
+  describe('empty / whitespace input', () => {
+    it('should return undefined for empty string', () => {
+      expect(parseTimestamp('')).toBeUndefined();
+    });
+
+    it('should return undefined for whitespace-only string', () => {
+      expect(parseTimestamp('   ')).toBeUndefined();
+    });
+  });
+
+  describe('ISO 8601', () => {
+    it('should parse full ISO 8601 with UTC offset', () => {
+      const d = parseTimestamp('2006-01-02T15:04:05Z');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+
+    it('should parse ISO 8601 with numeric timezone offset', () => {
+      const d = parseTimestamp('2006-01-02T15:04:05+05:30');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05+05:30'));
+    });
+
+    it('should parse ISO 8601 with negative timezone offset', () => {
+      const d = parseTimestamp('2006-01-02T15:04:05-07:00');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05-07:00'));
+    });
+
+    it('should parse ISO 8601 with milliseconds', () => {
+      const d = parseTimestamp('2006-01-02T15:04:05.123Z');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05.123Z'));
+    });
+
+    it('should parse date-only ISO 8601 as UTC', () => {
+      const d = parseTimestamp('2006-01-02');
+      expect(d).toEqual(new Date('2006-01-02T00:00:00Z'));
+    });
+
+    it('should parse ISO 8601 without timezone as UTC', () => {
+      const d = parseTimestamp('2006-01-02T15:04:05');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+
+    it('should parse ISO 8601 with milliseconds and no timezone as UTC', () => {
+      const d = parseTimestamp('2026-04-15T10:10:03.184');
+      expect(d).toEqual(new Date('2026-04-15T10:10:03.184Z'));
+    });
+  });
+
+  describe('RFC 2822', () => {
+    it('should parse standard RFC 2822 format', () => {
+      const d = parseTimestamp('Mon, 02 Jan 2006 15:04:05 -0700');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05-07:00'));
+    });
+
+    it('should parse RFC 2822 with positive offset', () => {
+      const d = parseTimestamp('Tue, 03 Jan 2006 08:00:00 +0000');
+      expect(d).toEqual(new Date('2006-01-03T08:00:00Z'));
+    });
+  });
+
+  describe('Apache CLF', () => {
+    it('should parse CLF with timezone offset', () => {
+      const d = parseTimestamp('02/Jan/2006:15:04:05 -0700');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05-07:00'));
+    });
+
+    it('should parse CLF with positive timezone offset', () => {
+      const d = parseTimestamp('02/Jan/2006:15:04:05 +0000');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+
+    it('should parse CLF without timezone offset as UTC', () => {
+      const d = parseTimestamp('02/Jan/2006:15:04:05');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+  });
+
+  describe('Unix timestamp (milliseconds)', () => {
+    it('should parse a Unix timestamp in milliseconds', () => {
+      const d = parseTimestamp('1136214245000');
+      expect(d).toEqual(new Date(1136214245000));
+    });
+
+    it('should parse Unix epoch zero', () => {
+      const d = parseTimestamp('0');
+      expect(d).toEqual(new Date(0));
+    });
+
+    it('should parse a recent timestamp', () => {
+      const ms = new Date('2025-06-15T12:00:00Z').getTime();
+      const d = parseTimestamp(String(ms));
+      expect(d).toEqual(new Date('2025-06-15T12:00:00Z'));
+    });
+  });
+
+  describe('invalid input', () => {
+    it('should return undefined for garbage text', () => {
+      expect(parseTimestamp('not-a-date')).toBeUndefined();
+    });
+
+    it('should return undefined for partial timestamps', () => {
+      expect(parseTimestamp('2006-13-45')).toBeUndefined();
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('should trim leading and trailing whitespace', () => {
+      const d = parseTimestamp('  2006-01-02T15:04:05Z  ');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+  });
+});
+
+describe('Duration', () => {
+  describe('toDate', () => {
+    const from = new Date('2026-04-15T12:00:00Z');
+
+    it('should subtract minutes', () => {
+      const d = new Duration(30, DurationUnit.Minutes).toDate(from);
+      expect(d).toEqual(new Date('2026-04-15T11:30:00Z'));
+    });
+
+    it('should subtract hours', () => {
+      const d = new Duration(2, DurationUnit.Hours).toDate(from);
+      expect(d).toEqual(new Date('2026-04-15T10:00:00Z'));
+    });
+
+    it('should subtract days', () => {
+      const d = new Duration(3, DurationUnit.Days).toDate(from);
+      expect(d).toEqual(new Date('2026-04-12T12:00:00Z'));
+    });
+
+    it('should subtract weeks', () => {
+      const d = new Duration(1, DurationUnit.Weeks).toDate(from);
+      expect(d).toEqual(new Date('2026-04-08T12:00:00Z'));
+    });
+
+    it('should subtract months', () => {
+      const d = new Duration(2, DurationUnit.Months).toDate(from);
+      expect(d).toEqual(new Date('2026-02-15T12:00:00Z'));
+    });
+  });
+
+  describe('toISOString', () => {
+    it('should format minutes', () => {
+      expect(new Duration(5, DurationUnit.Minutes).toISOString()).toBe('PT5M');
+    });
+
+    it('should format hours', () => {
+      expect(new Duration(2, DurationUnit.Hours).toISOString()).toBe('PT2H');
+    });
+
+    it('should format days', () => {
+      expect(new Duration(7, DurationUnit.Days).toISOString()).toBe('P7D');
+    });
+
+    it('should format weeks', () => {
+      expect(new Duration(1, DurationUnit.Weeks).toISOString()).toBe('P1W');
+    });
+
+    it('should format months', () => {
+      expect(new Duration(3, DurationUnit.Months).toISOString()).toBe('P3M');
+    });
+  });
+});
+
+describe('DateRangeDropdown', () => {
+  const renderDropdown = () => {
+    const onChange = vi.fn();
+    render(
+      <DateRangeDropdown onChange={onChange}>
+        <button type="button">Open</button>
+      </DateRangeDropdown>,
+    );
+    fireEvent.click(screen.getByText('Open'));
+    return onChange;
+  };
+
+  describe('relative time form', () => {
+    it('should call onChange with Date when a preset is clicked', () => {
+      const now = new Date('2026-04-15T12:00:00Z');
+      vi.setSystemTime(now);
+      const onChange = renderDropdown();
+      fireEvent.click(screen.getByRole('button', { name: '5' }));
+      expect(onChange).toHaveBeenCalledWith({
+        since: new Date('2026-04-15T11:55:00Z'),
+        until: null,
+      });
+      vi.useRealTimers();
+    });
+
+    it('should call onChange with custom value and unit', () => {
+      const now = new Date('2026-04-15T12:00:00Z');
+      vi.setSystemTime(now);
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Value');
+      fireEvent.change(input, { target: { value: '10' } });
+      fireEvent.click(screen.getAllByText('Apply')[0]);
+      expect(onChange).toHaveBeenCalledWith({
+        since: new Date('2026-04-15T11:50:00Z'),
+        until: null,
+      });
+      vi.useRealTimers();
+    });
+
+    it('should not call onChange for invalid custom value', () => {
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Value');
+      fireEvent.change(input, { target: { value: '0' } });
+      fireEvent.click(screen.getAllByText('Apply')[0]);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should submit on Enter key in value input', () => {
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Value');
+      fireEvent.change(input, { target: { value: '15' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('absolute time form', () => {
+    it('should call onChange with Date for valid timestamp', () => {
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Timestamp');
+      fireEvent.change(input, { target: { value: '2006-01-02T15:04:05Z' } });
+      fireEvent.click(screen.getAllByText('Apply')[1]);
+      expect(onChange).toHaveBeenCalledWith({
+        since: new Date('2006-01-02T15:04:05Z'),
+        until: null,
+      });
+    });
+
+    it('should show error border for invalid timestamp', () => {
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Timestamp');
+      fireEvent.change(input, { target: { value: 'not-a-date' } });
+      fireEvent.click(screen.getAllByText('Apply')[1]);
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveClass('border-destructive');
+    });
+
+    it('should clear error on new input', () => {
+      renderDropdown();
+      const input = screen.getByPlaceholderText('Timestamp');
+      fireEvent.change(input, { target: { value: 'bad' } });
+      fireEvent.click(screen.getAllByText('Apply')[1]);
+      expect(input).toHaveClass('border-destructive');
+      fireEvent.change(input, { target: { value: 'bad1' } });
+      expect(input).not.toHaveClass('border-destructive');
+    });
+
+    it('should submit on Enter key in timestamp input', () => {
+      const onChange = renderDropdown();
+      const input = screen.getByPlaceholderText('Timestamp');
+      fireEvent.change(input, { target: { value: '2006-01-02T15:04:05Z' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { parse, isValid } from 'date-fns';
-import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import { parse as parseDate } from 'date-fns';
+import { fromZonedTime } from 'date-fns-tz';
+import { Clock } from 'lucide-react';
+import { Fragment, useRef, useState } from 'react';
 
+import { Alert, AlertDescription, AlertTitle } from '@kubetail/ui/elements/alert';
 import { Button } from '@kubetail/ui/elements/button';
-import { Calendar } from '@kubetail/ui/elements/calendar';
+import { Input } from '@kubetail/ui/elements/input';
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from '@kubetail/ui/elements/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@kubetail/ui/elements/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@kubetail/ui/elements/tabs';
 
 /**
  * Shared types
@@ -44,6 +45,30 @@ export class Duration {
     this.unit = unit;
   }
 
+  toDate(from?: Date) {
+    const d = new Date(from ?? Date.now());
+    switch (this.unit) {
+      case DurationUnit.Minutes:
+        d.setMinutes(d.getMinutes() - this.value);
+        break;
+      case DurationUnit.Hours:
+        d.setHours(d.getHours() - this.value);
+        break;
+      case DurationUnit.Days:
+        d.setDate(d.getDate() - this.value);
+        break;
+      case DurationUnit.Weeks:
+        d.setDate(d.getDate() - this.value * 7);
+        break;
+      case DurationUnit.Months:
+        d.setMonth(d.getMonth() - this.value);
+        break;
+      default:
+        throw new Error('not implemented');
+    }
+    return d;
+  }
+
   toISOString() {
     switch (this.unit) {
       case DurationUnit.Minutes:
@@ -62,221 +87,192 @@ export class Duration {
   }
 }
 
-/*
- * Duration button component
- */
-
-type DurationButtonProps = {
-  value: string;
-  unit: DurationUnit;
-  setDurationValue: React.Dispatch<string>;
-  setDurationUnit: React.Dispatch<DurationUnit>;
-};
-
-const DurationButton = ({ value, unit, setDurationValue, setDurationUnit }: DurationButtonProps) => (
-  <Button
-    variant="outline"
-    size="sm"
-    onClick={() => {
-      setDurationValue(value);
-      setDurationUnit(unit);
-    }}
-  >
-    {value}
-  </Button>
-);
-
 /**
- * Relative time picker component
+ * Relative time form
  */
 
-type RelativeTimePickerHandle = {
-  reset: () => void;
-  getValue: () => Duration | undefined;
-};
+const presetGroups: { label: string; unit: DurationUnit; values: number[] }[] = [
+  { label: 'Minutes', unit: DurationUnit.Minutes, values: [5, 15, 30] },
+  { label: 'Hours', unit: DurationUnit.Hours, values: [1, 2, 6] },
+  { label: 'Days', unit: DurationUnit.Days, values: [1, 3, 7] },
+];
 
-const RelativeTimePicker = forwardRef<RelativeTimePickerHandle, unknown>((_, ref) => {
-  const [durationValue, setDurationValue] = useState('5');
-  const [durationUnit, setDurationUnit] = useState(DurationUnit.Minutes);
-  const [errorMsg, setErrorMsg] = useState('');
+const RelativeTimeForm = ({ onApply }: { onApply: (duration: Duration) => void }) => {
+  const [customValue, setCustomValue] = useState('');
+  const [customUnit, setCustomUnit] = useState(DurationUnit.Minutes);
+  const [error, setError] = useState('');
 
-  const validate = () => {
-    if (durationValue.trim() === '') {
-      setErrorMsg('Please choose a number');
-      return undefined;
+  const handleApply = () => {
+    const num = Number(customValue);
+    if (Number.isNaN(num) || num <= 0) {
+      setError('Enter a positive number');
+      return;
     }
-    return new Duration(Number(durationValue), durationUnit);
-  };
-
-  // define handler api
-  useImperativeHandle(ref, () => ({
-    reset: () => {
-      setDurationValue('5');
-      setDurationUnit(DurationUnit.Minutes);
-    },
-    getValue: validate,
-  }));
-
-  const buttonArgs = { setDurationValue, setDurationUnit };
-
-  return (
-    <>
-      <div className="grid grid-cols-6 gap-2 text-sm pt-3 pl-3 pr-3">
-        <div className="flex items-center">Minutes</div>
-        {[5, 10, 15, 30, 45].map((val) => (
-          <DurationButton key={val} value={val.toString()} unit={DurationUnit.Minutes} {...buttonArgs} />
-        ))}
-        <div className="flex items-center">Hours</div>
-        {[1, 2, 3, 6, 12].map((val) => (
-          <DurationButton key={val} value={val.toString()} unit={DurationUnit.Hours} {...buttonArgs} />
-        ))}
-        <div className="flex items-center">Days</div>
-        {[1, 2, 3, 4, 5].map((val) => (
-          <DurationButton key={val} value={val.toString()} unit={DurationUnit.Days} {...buttonArgs} />
-        ))}
-        <div className="flex items-center">Weeks</div>
-        {[1, 2, 3, 4, 5].map((val) => (
-          <DurationButton key={val} value={val.toString()} unit={DurationUnit.Weeks} {...buttonArgs} />
-        ))}
-      </div>
-      <div className="grid grid-cols-2 w-full gap-5 mt-5">
-        <div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label>
-            Duration
-            <input type="number" min="1" value={durationValue} onChange={(ev) => setDurationValue(ev.target.value)} />
-          </label>
-          {errorMsg && <div>{errorMsg}</div>}
-        </div>
-        <div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label>
-            Unit
-            <Select value={durationUnit} onValueChange={(value) => setDurationUnit(value as DurationUnit)}>
-              <SelectTrigger className="mt-0">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={DurationUnit.Minutes}>Minutes ago</SelectItem>
-                <SelectItem value={DurationUnit.Hours}>Hours ago</SelectItem>
-                <SelectItem value={DurationUnit.Days}>Days ago</SelectItem>
-                <SelectItem value={DurationUnit.Weeks}>Weeks ago</SelectItem>
-                <SelectItem value={DurationUnit.Months}>Months ago</SelectItem>
-              </SelectContent>
-            </Select>
-          </label>
-        </div>
-      </div>
-    </>
-  );
-});
-
-/**
- * Absolute time picker component
- */
-
-type AbsoluteTimePickerHandle = {
-  reset: () => void;
-  getValue: () => Date | undefined;
-};
-
-const AbsoluteTimePicker = forwardRef<AbsoluteTimePickerHandle, unknown>((_, ref) => {
-  const today = new Date();
-  const dateFmt = Intl.DateTimeFormat().resolvedOptions().locale === 'en-US' ? 'MM/dd/yyyy' : 'dd/MM/yyyy';
-
-  const [calendarDate, setCalendarDate] = useState<Date | undefined>();
-
-  const [manualStartDate, setManualStartDate] = useState(formatInTimeZone(today, 'UTC', dateFmt));
-  const [manualStartTime, setManualStartTime] = useState('00:00:00.000');
-
-  const [errorMsgs, setErrorMsgs] = useState(new Map<string, string>());
-
-  const validate = () => {
-    if (!isValid(parse(manualStartDate, dateFmt, new Date()))) errorMsgs.set('startDate', dateFmt);
-    else errorMsgs.delete('startDate');
-
-    if (!isValid(parse(manualStartTime, 'HH:mm:ss.SSS', new Date()))) errorMsgs.set('startTime', 'HH:mm:ss.SSS');
-    else errorMsgs.delete('startTime');
-
-    setErrorMsgs(new Map(errorMsgs));
-
-    // return undefined if validation failed
-    if (errorMsgs.size) return undefined;
-
-    // parse
-    const localDate = parse(`${manualStartDate} ${manualStartTime}`, `${dateFmt} HH:mm:ss.SSS`, new Date());
-
-    // return as UTC time
-    return fromZonedTime(localDate, 'UTC');
-  };
-
-  // define handler api
-  useImperativeHandle(ref, () => ({
-    reset: () => {
-      setCalendarDate(today);
-      setManualStartDate(formatInTimeZone(today, 'UTC', dateFmt));
-      setManualStartTime('00:00:00.000');
-      setErrorMsgs(new Map<string, string>());
-    },
-    getValue: validate,
-  }));
-
-  const handleCalendarSelect = (value: Date | undefined) => {
-    if (!value) return;
-    setCalendarDate(value);
-    setManualStartDate(formatInTimeZone(value, 'UTC', dateFmt));
-    setManualStartTime('00:00:00.000');
-    setErrorMsgs(new Map<string, string>());
+    setError('');
+    onApply(new Duration(num, customUnit));
   };
 
   return (
-    <div className="flex flex-col items-center">
-      <Calendar
-        autoFocus
-        mode="single"
-        disabled={{ after: today }}
-        defaultMonth={today}
-        selected={calendarDate}
-        onSelect={handleCalendarSelect}
-        numberOfMonths={1}
-        timeZone="UTC"
-      />
-      <div className="mt-1 space-y-2">
-        <div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label>
-            Start date
-            <input
-              className="ml-1 w-[110px] border border-input"
-              value={manualStartDate}
-              onChange={(ev) => setManualStartDate(ev.target.value)}
-            />
-          </label>
-          {errorMsgs.has('startDate') && <div>{errorMsgs.get('startDate')}</div>}
+    <div className="flex flex-col flex-1">
+      <div className="border border-border rounded-md p-3 bg-muted flex-1 flex flex-col">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Relative Time</h3>
+        <div className="grid grid-cols-[auto_1fr_1fr_1fr] items-center gap-x-2 gap-y-1 my-auto">
+          {presetGroups.map((group) => (
+            <Fragment key={group.label}>
+              <span className="text-xs text-muted-foreground pl-3">{group.label}</span>
+              {group.values.map((v) => (
+                <Button
+                  key={v}
+                  variant="ghost"
+                  size="sm"
+                  className="text-right"
+                  onClick={() => onApply(new Duration(v, group.unit))}
+                >
+                  {v}
+                </Button>
+              ))}
+            </Fragment>
+          ))}
         </div>
-        <div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label>
-            Start time
-            <input
-              className="ml-1 w-[110px] border border-input"
-              value={manualStartTime}
-              onChange={(ev) => setManualStartTime(ev.target.value)}
-            />
-          </label>
-          {errorMsgs.has('startTime') && <div>{errorMsgs.get('startTime')}</div>}
+        <div className="flex gap-2 mt-auto" title={error || undefined}>
+          <Input
+            type="number"
+            min="1"
+            value={customValue}
+            placeholder="Value"
+            onChange={(ev) => {
+              setCustomValue(ev.target.value);
+              setError('');
+            }}
+            onKeyDown={(ev) => ev.key === 'Enter' && handleApply()}
+            className={`w-25 shrink-0 ${error ? 'border-destructive' : ''}`}
+          />
+          <Select value={customUnit} onValueChange={(value) => setCustomUnit(value as DurationUnit)}>
+            <SelectTrigger className="flex-1 w-30 px-2 gap-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DurationUnit.Minutes}>Minutes ago</SelectItem>
+              <SelectItem value={DurationUnit.Hours}>Hours ago</SelectItem>
+              <SelectItem value={DurationUnit.Days}>Days ago</SelectItem>
+              <SelectItem value={DurationUnit.Weeks}>Weeks ago</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
       </div>
+      <Button className="mt-3 w-full" onClick={handleApply}>
+        Apply
+      </Button>
     </div>
   );
-});
+};
+
+/**
+ * Absolute time form
+ */
+
+function isValidDate(d: Date): boolean {
+  return !Number.isNaN(d.getTime());
+}
+
+// Matches Z, ±HH:MM, ±HHMM, or ±HH at the end of a string
+const TZ_RE = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/i;
+
+export function parseTimestamp(input: string): Date | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  // Unix timestamp (milliseconds)
+  if (/^\d+$/.test(trimmed)) {
+    const ms = Number(trimmed);
+    const d = new Date(ms);
+    if (isValidDate(d)) return d;
+  }
+
+  // Try native Date parser (handles ISO 8601, RFC 2822, and common formats).
+  // If the input has no explicit timezone, use fromZonedTime to interpret as UTC.
+  const hasTZ = TZ_RE.test(trimmed);
+  if (hasTZ) {
+    const nativeDate = new Date(trimmed);
+    if (isValidDate(nativeDate)) return nativeDate;
+  } else {
+    const nativeDate = fromZonedTime(trimmed, 'UTC');
+    if (isValidDate(nativeDate)) return nativeDate;
+  }
+
+  // RFC 2822 fallback (e.g. "Mon, 02 Jan 2006 15:04:05 -0700")
+  const rfc2822Date = parseDate(trimmed, 'EEE, dd MMM yyyy HH:mm:ss xx', new Date());
+  if (isValidDate(rfc2822Date)) return rfc2822Date;
+
+  // Apache CLF with timezone (e.g. "02/Jan/2006:15:04:05 -0700")
+  const clfTzDate = parseDate(trimmed, 'dd/MMM/yyyy:HH:mm:ss xx', new Date());
+  if (isValidDate(clfTzDate)) return clfTzDate;
+
+  // Apache CLF without timezone — assume UTC (e.g. "02/Jan/2006:15:04:05")
+  const clfDate = parseDate(`${trimmed} +0000`, 'dd/MMM/yyyy:HH:mm:ss xx', new Date());
+  if (isValidDate(clfDate)) return clfDate;
+
+  return undefined;
+}
+
+const AbsoluteTimeForm = ({ onApply }: { onApply: (date: Date) => void }) => {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+
+  const handleApply = () => {
+    const date = parseTimestamp(input);
+    if (!date) {
+      setError('Unable to parse timestamp');
+      return;
+    }
+    setError('');
+    onApply(date);
+  };
+
+  return (
+    <div className="flex flex-col flex-1">
+      <div className="border border-border rounded-md p-3 bg-muted flex-1 flex flex-col">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Absolute Time</h3>
+        <Alert className="mb-3 text-xs">
+          <AlertTitle className="flex items-center">Supported Formats</AlertTitle>
+          <AlertDescription className="font-mono text-xs mt-1">
+            <ul className="space-y-1 whitespace-nowrap">
+              <li title="ISO 8601">&gt; 2006-01-02T15:04:05+07:00</li>
+              <li title="RFC 2822">&gt; Mon, 02 Jan 2006 15:04:05 -0700</li>
+              <li title="Apache CLF">&gt; 02/Jan/2006:15:04:05 -0700</li>
+              <li title="Unix timestamp (milliseconds)">&gt; 1776393600000</li>
+            </ul>
+          </AlertDescription>
+        </Alert>
+        <div className="relative mt-auto" title={error || undefined}>
+          <Input
+            placeholder="Timestamp"
+            value={input}
+            onChange={(ev) => {
+              setInput(ev.target.value);
+              setError('');
+            }}
+            onKeyDown={(ev) => ev.key === 'Enter' && handleApply()}
+            className={`pl-8 ${error ? 'border-destructive' : ''}`}
+          />
+          <Clock
+            className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 ${error ? 'text-destructive' : 'text-muted-foreground'}`}
+          />
+        </div>
+      </div>
+      <Button className="mt-3 w-full" onClick={handleApply}>
+        Apply
+      </Button>
+    </div>
+  );
+};
 
 /**
  * DateRangeDropdown component
  */
 
 export type DateRangeDropdownOnChangeArgs = {
-  since: Date | Duration | null;
+  since: Date | null;
   until: Date | null;
 };
 
@@ -285,70 +281,26 @@ type DateRangeDropdownProps = {
 };
 
 export const DateRangeDropdown = ({ onChange, children }: React.PropsWithChildren<DateRangeDropdownProps>) => {
-  const [tabValue, setTabValue] = useState('relative');
+  const closeRef = useRef<HTMLButtonElement>(null);
 
-  const cancelButtonRef = useRef<HTMLButtonElement>(null);
-  const relativePickerRef = useRef<RelativeTimePickerHandle>(null);
-  const absolutePickerRef = useRef<AbsoluteTimePickerHandle>(null);
-
-  const closePopover = () => {
-    cancelButtonRef.current?.click();
+  const handleApply = (date: Date) => {
+    closeRef.current?.click();
+    onChange({ since: date, until: null });
   };
 
-  const handleClear = () => {
-    if (tabValue === 'relative') relativePickerRef.current?.reset();
-    else if (tabValue === 'absolute') absolutePickerRef.current?.reset();
-  };
-
-  const handleApply = () => {
-    const args: DateRangeDropdownOnChangeArgs = { since: null, until: null };
-
-    if (tabValue === 'relative') {
-      const val = relativePickerRef.current?.getValue();
-      if (!val) return;
-      args.since = val;
-    } else {
-      const val = absolutePickerRef.current?.getValue();
-      if (!val) return;
-      args.since = val;
-    }
-
-    // close popover and call onChange handler
-    closePopover();
-    onChange(args);
+  const handleRelativeApply = (duration: Duration) => {
+    handleApply(duration.toDate());
   };
 
   return (
     <Popover>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-auto p-0 bg-background" align="start">
-        <Tabs className="w-[400px] p-3" defaultValue={tabValue} onValueChange={(value) => setTabValue(value)}>
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="relative">Relative</TabsTrigger>
-            <TabsTrigger value="absolute">Absolute</TabsTrigger>
-          </TabsList>
-          <TabsContent value="relative">
-            <RelativeTimePicker ref={relativePickerRef} />
-          </TabsContent>
-          <TabsContent value="absolute">
-            <AbsoluteTimePicker ref={absolutePickerRef} />
-          </TabsContent>
-        </Tabs>
-        <div className="flex justify-between mt-4 p-3 border-t">
-          <Button variant="outline" size="sm" onClick={handleClear}>
-            Clear
-          </Button>
-          <div className="flex space-x-2">
-            <PopoverClose asChild>
-              <Button ref={cancelButtonRef} variant="ghost" size="sm">
-                Cancel
-              </Button>
-            </PopoverClose>
-            <Button size="sm" onClick={handleApply}>
-              Apply
-            </Button>
-          </div>
+      <PopoverContent className="w-auto p-3" align="start">
+        <div className="flex items-stretch gap-3">
+          <RelativeTimeForm onApply={handleRelativeApply} />
+          <AbsoluteTimeForm onApply={handleApply} />
         </div>
+        <PopoverClose ref={closeRef} className="hidden" />
       </PopoverContent>
     </Popover>
   );

--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.test.tsx
@@ -71,13 +71,14 @@ function createMockRecords(count: number, startTimestamp = 0): LogRecord[] {
   });
 }
 
-function createMockRuntime(): Runtime {
+function createMockRuntime(): Runtime & { recordsRef: { current: DoubleTailedArray<LogRecord> } } {
   const recordsRef = { current: new DoubleTailedArray<LogRecord>() };
   const setCount = vi.fn();
 
   const { result } = renderHook(() => useRecordStore({ recordsRef, setCount }));
 
   return {
+    recordsRef,
     client: createMockClient(),
     config: {
       initialPosition: { type: 'head' },
@@ -476,6 +477,40 @@ describe('internal helpers', () => {
         expect(actions.setHasMoreBefore).toHaveBeenLastCalledWith(true);
         expect(actions.setHasMoreAfter).toHaveBeenCalledTimes(1);
         expect(actions.setHasMoreAfter).toHaveBeenLastCalledWith(true);
+      });
+
+      it('assigns key 0 to the first record after the cursor', async () => {
+        const runtime = createMockRuntime();
+        const { client, config, recordsRef } = runtime;
+
+        (config as any).initialPosition = { type: 'cursor', cursor: 'c0' };
+
+        const beforeRecords = createMockRecords(3);
+        const afterRecords = createMockRecords(2);
+
+        (client as MockClient).fetchBefore.mockResolvedValue({
+          records: beforeRecords,
+          nextCursor: null,
+        });
+
+        (client as MockClient).fetchSince.mockResolvedValue({
+          records: afterRecords,
+          nextCursor: null,
+        });
+
+        renderHook(() => useInit(runtime));
+
+        await act(() => vi.runAllTimersAsync());
+
+        // First "since" record should be the anchor (key 0)
+        const firstSinceIndex = beforeRecords.length;
+        expect(recordsRef.current.keyAt(firstSinceIndex)).toBe(0);
+
+        // "Before" records should have negative keys
+        expect(recordsRef.current.keyAt(0)).toBe(-beforeRecords.length);
+
+        // Second "since" record should be key 1
+        expect(recordsRef.current.keyAt(firstSinceIndex + 1)).toBe(1);
       });
     });
   });

--- a/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
+++ b/dashboard-ui/src/components/widgets/log-viewer/log-viewer.tsx
@@ -299,7 +299,7 @@ export const useInit = ({ client, config, refs, actions, services }: Runtime) =>
             });
 
             // Combine results
-            services.recordStore.new(afterResult.records, { skipSetCount: true });
+            services.recordStore.new(afterResult.records, { skipSetCount: true, zeroAt: 'first' });
             services.recordStore.prepend(beforeResult.records);
 
             await beforePaintPromise;

--- a/dashboard-ui/src/pages/home/index.tsx
+++ b/dashboard-ui/src/pages/home/index.tsx
@@ -683,11 +683,11 @@ const Main = () => {
                 className="w-50 bg-background"
                 value={searchInputValue}
                 placeholder="Search workloads..."
-                onChange={(e) => {
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   setSearchInputValue(e.target.value);
                   debouncedSearch(e.target.value);
                 }}
-                onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && e.preventDefault()}
                 disabled={isLoading}
               />
               <div className="block w-[200px]">


### PR DESCRIPTION
## Summary

Add a new `DateRangeDropdown` component to the dashboard UI that lets users select a time range via relative presets (minutes, hours, days) or by entering an absolute timestamp. The component supports ISO 8601, RFC 2822, Apache CLF, and Unix millisecond timestamp formats. Also fixes cursor-based initialization in the log viewer to correctly anchor record keys.

<img width="602" height="361" alt="Screenshot 2026-04-15 at 2 08 31 PM" src="https://github.com/user-attachments/assets/6e3eb053-a998-4cfd-9190-dbb5049e25aa" />

## Key Changes

- Add `DateRangeDropdown` component with relative time presets and absolute timestamp input via a popover
- Add `parseTimestamp` utility supporting ISO 8601, RFC 2822, Apache CLF, and Unix ms formats
- Add comprehensive tests for `DateRangeDropdown` and `parseTimestamp`
- Bump `@kubetail/ui` from 2.5.0 to 2.7.1 for new UI primitives (Alert, Popover, Select)
- Fix cursor-based init in log viewer to use `zeroAt: 'first'` so key 0 anchors at the first record after the cursor

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused