### PR TITLE
🎣 Preserve ANSI escape sequences when copying console messages

### DIFF
--- a/dashboard-ui/src/pages/console/context-menu.test.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.test.tsx
@@ -34,7 +34,7 @@ const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
 
 beforeEach(() => {
   Object.assign(navigator, {
-    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    clipboard: { write: vi.fn().mockResolvedValue(undefined), writeText: vi.fn().mockResolvedValue(undefined) },
   });
 });
 
@@ -146,6 +146,26 @@ describe('CellContextMenu', () => {
       renderWithContextMenu(ViewerColumn.Message);
       await openContextMenu();
       fireEvent.click(screen.getByText('Copy message (ANSI)'));
+      expect(navigator.clipboard.write).toHaveBeenCalledTimes(1);
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it('falls back to writeText when ClipboardItem is unavailable', async () => {
+      const { clipboard } = navigator;
+      const originalClipboardItem = globalThis.ClipboardItem;
+      delete (globalThis as typeof globalThis & { ClipboardItem?: typeof ClipboardItem }).ClipboardItem;
+      Object.assign(navigator, {
+        clipboard: { ...clipboard, write: undefined },
+      });
+
+      try {
+        renderWithContextMenu(ViewerColumn.Message);
+        await openContextMenu();
+        fireEvent.click(screen.getByText('Copy message (ANSI)'));
+      } finally {
+        globalThis.ClipboardItem = originalClipboardItem;
+      }
+
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('\x1b[31mERROR\x1b[0m: something failed');
     });
   });

--- a/dashboard-ui/src/pages/console/context-menu.test.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.test.tsx
@@ -152,8 +152,11 @@ describe('CellContextMenu', () => {
 
     it('falls back to writeText when ClipboardItem is unavailable', async () => {
       const { clipboard } = navigator;
-      const originalClipboardItem = globalThis.ClipboardItem;
-      delete (globalThis as typeof globalThis & { ClipboardItem?: typeof ClipboardItem }).ClipboardItem;
+      const globalWithOptionalClipboardItem = globalThis as typeof globalThis & {
+        ClipboardItem?: typeof ClipboardItem;
+      };
+      const originalClipboardItem = globalWithOptionalClipboardItem.ClipboardItem;
+      Reflect.deleteProperty(globalWithOptionalClipboardItem, 'ClipboardItem');
       Object.assign(navigator, {
         clipboard: { ...clipboard, write: undefined },
       });
@@ -163,7 +166,7 @@ describe('CellContextMenu', () => {
         await openContextMenu();
         fireEvent.click(screen.getByText('Copy message (ANSI)'));
       } finally {
-        globalThis.ClipboardItem = originalClipboardItem;
+        globalWithOptionalClipboardItem.ClipboardItem = originalClipboardItem;
       }
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('\x1b[31mERROR\x1b[0m: something failed');

--- a/dashboard-ui/src/pages/console/context-menu.test.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.test.tsx
@@ -151,23 +151,30 @@ describe('CellContextMenu', () => {
     });
 
     it('falls back to writeText when ClipboardItem is unavailable', async () => {
-      const { clipboard } = navigator;
-      const globalWithOptionalClipboardItem = globalThis as typeof globalThis & {
-        ClipboardItem?: typeof ClipboardItem;
-      };
-      const originalClipboardItem = globalWithOptionalClipboardItem.ClipboardItem;
-      Reflect.deleteProperty(globalWithOptionalClipboardItem, 'ClipboardItem');
-      Object.assign(navigator, {
-        clipboard: { ...clipboard, write: undefined },
-      });
+      const savedClipboardItem = globalThis.ClipboardItem;
+      vi.stubGlobal('ClipboardItem', undefined);
 
       try {
         renderWithContextMenu(ViewerColumn.Message);
         await openContextMenu();
         fireEvent.click(screen.getByText('Copy message (ANSI)'));
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('\x1b[31mERROR\x1b[0m: something failed');
+        expect(navigator.clipboard.write).not.toHaveBeenCalled();
       } finally {
-        globalWithOptionalClipboardItem.ClipboardItem = originalClipboardItem;
+        vi.stubGlobal('ClipboardItem', savedClipboardItem);
       }
+    });
+
+    it('falls back to writeText when clipboard.write is unavailable', async () => {
+      // Replace clipboard with one that only has writeText (no write)
+      Object.assign(navigator, {
+        clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+      });
+
+      renderWithContextMenu(ViewerColumn.Message);
+      await openContextMenu();
+      fireEvent.click(screen.getByText('Copy message (ANSI)'));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('\x1b[31mERROR\x1b[0m: something failed');
     });

--- a/dashboard-ui/src/pages/console/context-menu.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.tsx
@@ -35,6 +35,18 @@ function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
 }
 
+function copyAnsiToClipboard(text: string) {
+  if (typeof navigator.clipboard.write === 'function' && typeof ClipboardItem !== 'undefined') {
+    const item = new ClipboardItem({
+      'text/plain': new Blob([text], { type: 'text/plain' }),
+    });
+    navigator.clipboard.write([item]);
+    return;
+  }
+
+  navigator.clipboard.writeText(text);
+}
+
 function TimestampMenuContent({ record }: { record: LogRecord }) {
   const tsWithTZ = toZonedTime(record.timestamp, 'UTC');
   const displayed = format(tsWithTZ, 'LLL dd, y HH:mm:ss.SSS', { timeZone: 'UTC' });
@@ -67,7 +79,7 @@ function MessageMenuContent({ record }: { record: LogRecord }) {
   return (
     <>
       <ContextMenuItem onSelect={() => copyToClipboard(stripAnsi(record.message))}>Copy message</ContextMenuItem>
-      <ContextMenuItem onSelect={() => copyToClipboard(record.message)}>Copy message (ANSI)</ContextMenuItem>
+      <ContextMenuItem onSelect={() => copyAnsiToClipboard(record.message)}>Copy message (ANSI)</ContextMenuItem>
     </>
   );
 }

--- a/dashboard-ui/vitest.setup.ts
+++ b/dashboard-ui/vitest.setup.ts
@@ -32,7 +32,17 @@ class ResizeObserverMock {
   disconnect = vi.fn();
 }
 
+class ClipboardItemMock {
+  // Store incoming clipboard representations so tests can introspect if needed.
+  items: Record<string, Blob>;
+
+  constructor(items: Record<string, Blob>) {
+    this.items = items;
+  }
+}
+
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal('ClipboardItem', ClipboardItemMock);
 vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(callback, 0));
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
 


### PR DESCRIPTION
Closes #1076 

## Summary

Fix the console message copy behavior so "Copy message (ANSI)" preserves real ANSI escape bytes in clipboard output, instead of producing literal text like `[33m`.

## Key Changes

- Added `copyAnsiToClipboard()` in `dashboard-ui/src/pages/console/context-menu.tsx`.
- Switched "Copy message (ANSI)" to use `navigator.clipboard.write()` with `ClipboardItem` and `Blob` so raw escape bytes are preserved.
- Kept a safe fallback to `navigator.clipboard.writeText()` when `ClipboardItem`/`write` is unavailable.
- Extended tests in `dashboard-ui/src/pages/console/context-menu.test.tsx`:
  - verifies ANSI copy path uses `clipboard.write`
  - verifies fallback path uses `writeText` when `ClipboardItem` is unavailable

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
