### PR TITLE
🎣 Improve timestamp parsing for CLF and native date formats

### DIFF
--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
@@ -27,6 +27,13 @@ describe('parseTimestamp', () => {
     });
   });
 
+  describe('JS timestamps', () => {
+    it('should parse default JS timestamps without UTF offset', () => {
+      const d = parseTimestamp('Jan 2, 2006 15:04:05');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+  });
+
   describe('ISO 8601', () => {
     it('should parse full ISO 8601 with UTC offset', () => {
       const d = parseTimestamp('2006-01-02T15:04:05Z');
@@ -91,6 +98,16 @@ describe('parseTimestamp', () => {
       const d = parseTimestamp('02/Jan/2006:15:04:05');
       expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
     });
+
+    it('should parse CLF with numeric month', () => {
+      const d = parseTimestamp('02/01/2006:15:04:05');
+      expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
+    });
+  });
+
+  it('should parse Nginx ELF with timezone', () => {
+    const d = parseTimestamp('2006/01/02 15:04:05');
+    expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
   });
 
   describe('Unix timestamp (milliseconds)', () => {

--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
@@ -191,26 +191,26 @@ export function parseTimestamp(input: string): Date | undefined {
 
   // Try native Date parser (handles ISO 8601, RFC 2822, and common formats).
   // If the input has no explicit timezone, use fromZonedTime to interpret as UTC.
-  const hasTZ = TZ_RE.test(trimmed);
-  if (hasTZ) {
-    const nativeDate = new Date(trimmed);
-    if (isValidDate(nativeDate)) return nativeDate;
-  } else {
-    const nativeDate = fromZonedTime(trimmed, 'UTC');
-    if (isValidDate(nativeDate)) return nativeDate;
-  }
+  let nativeDate = new Date(trimmed);
+  if (!TZ_RE.test(trimmed)) nativeDate = fromZonedTime(nativeDate, 'UTC');
+  if (isValidDate(nativeDate)) return nativeDate;
 
   // RFC 2822 fallback (e.g. "Mon, 02 Jan 2006 15:04:05 -0700")
   const rfc2822Date = parseDate(trimmed, 'EEE, dd MMM yyyy HH:mm:ss xx', new Date());
   if (isValidDate(rfc2822Date)) return rfc2822Date;
 
-  // Apache CLF with timezone (e.g. "02/Jan/2006:15:04:05 -0700")
-  const clfTzDate = parseDate(trimmed, 'dd/MMM/yyyy:HH:mm:ss xx', new Date());
-  if (isValidDate(clfTzDate)) return clfTzDate;
-
-  // Apache CLF without timezone — assume UTC (e.g. "02/Jan/2006:15:04:05")
-  const clfDate = parseDate(`${trimmed} +0000`, 'dd/MMM/yyyy:HH:mm:ss xx', new Date());
-  if (isValidDate(clfDate)) return clfDate;
+  // Apache CLF — numeric month (dd/MM/…) and abbreviated month (dd/MMM/…)
+  const clfInput = TZ_RE.test(trimmed) ? trimmed : `${trimmed} +0000`;
+  let clfDate: Date | undefined;
+  ['dd/MM/yyyy:HH:mm:ss xx', 'dd/MMM/yyyy:HH:mm:ss xx'].some((fmt) => {
+    const d = parseDate(clfInput, fmt, new Date());
+    if (isValidDate(d)) {
+      clfDate = d;
+      return true;
+    }
+    return false;
+  });
+  if (clfDate) return clfDate;
 
   return undefined;
 }


### PR DESCRIPTION
## Summary

The `parseTimestamp()` function in the date range dropdown had separate code paths for native date parsing with and without timezones, and only supported Apache CLF timestamps with abbreviated month names. This PR consolidates the native date parsing logic and adds support for additional timestamp formats encountered in real-world logs.

## Key Changes

- Consolidate native `Date` parsing into a single code path instead of branching on timezone presence
- Add support for Apache CLF timestamps with numeric months (e.g., `02/01/2006:15:04:05`)
- Add support for Nginx Error Log Format timestamps (e.g., `2006/01/02 15:04:05`)
- Add corresponding test cases for the new formats

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused