### PR TITLE
✨ Rename CI workflow jobs and add display names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rust-build:
-    name: rust/build
+    name: Rust · Build
     strategy:
       matrix:
         os:
@@ -39,7 +39,7 @@ jobs:
         run: cargo build --release
 
   rust-lint:
-    name: rust/lint
+    name: Rust · Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   rust-vet:
-    name: rust/vet
+    name: Rust · Vet
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
         run: cargo clippy --all -- -D warnings
 
   rust-test:
-    name: rust/test
+    name: Rust · Test
     strategy:
       matrix:
         os:
@@ -93,7 +93,7 @@ jobs:
         run: cargo test
 
   go-vendor:
-    name: go/vendor
+    name: Go · Vendor
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -111,7 +111,7 @@ jobs:
           retention-days: 1
 
   go-lint:
-    name: go/lint
+    name: Go · Lint
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -130,7 +130,7 @@ jobs:
         run: test -z "$(gofmt -l .)"
 
   go-vet:
-    name: go/vet
+    name: Go · Vet
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -149,7 +149,7 @@ jobs:
         run: go vet ./...
 
   go-test:
-    name: go/test
+    name: Go · Test
     needs: go-vendor
     timeout-minutes: 20
     strategy:
@@ -212,7 +212,7 @@ jobs:
         run: go test -race -mod=vendor ./...
 
   typescript-lint:
-    name: typescript/lint
+    name: TypeScript · Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -227,7 +227,7 @@ jobs:
         run: pnpm lint
 
   typescript-test:
-    name: typescript/test
+    name: TypeScript · Test
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -242,7 +242,7 @@ jobs:
         run: pnpm test run
 
   typescript-build:
-    name: typescript/build
+    name: TypeScript · Build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -257,7 +257,7 @@ jobs:
         run: pnpm build
 
   docker-builds:
-    name: docker/build
+    name: Docker · Build
     needs:
       - rust-build
       - rust-lint
@@ -315,7 +315,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.target }}-${{ matrix.arch }}
 
   cli-builds:
-    name: cli/build
+    name: CLI · Build
     needs:
       - rust-build
       - rust-lint
@@ -382,7 +382,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
   alpine-builds:
-    name: alpine/build
+    name: Alpine · Build
     needs:
       - rust-build
       - rust-lint
@@ -453,6 +453,7 @@ jobs:
           ./bin/kubetail serve --test
 
   test-e2e:
+    name: E2E
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   rust-build:
+    name: rust/build
     strategy:
       matrix:
         os:
@@ -38,6 +39,7 @@ jobs:
         run: cargo build --release
 
   rust-lint:
+    name: rust/lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -50,6 +52,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   rust-vet:
+    name: rust/vet
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +65,7 @@ jobs:
         run: cargo clippy --all -- -D warnings
 
   rust-test:
+    name: rust/test
     strategy:
       matrix:
         os:
@@ -89,6 +93,7 @@ jobs:
         run: cargo test
 
   go-vendor:
+    name: go/vendor
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -106,6 +111,7 @@ jobs:
           retention-days: 1
 
   go-lint:
+    name: go/lint
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -124,6 +130,7 @@ jobs:
         run: test -z "$(gofmt -l .)"
 
   go-vet:
+    name: go/vet
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -142,6 +149,7 @@ jobs:
         run: go vet ./...
 
   go-test:
+    name: go/test
     needs: go-vendor
     timeout-minutes: 20
     strategy:
@@ -203,7 +211,8 @@ jobs:
         working-directory: ./modules/${{ matrix.module }}
         run: go test -race -mod=vendor ./...
 
-  dashboard-ui-lint:
+  typescript-lint:
+    name: typescript/lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -217,7 +226,8 @@ jobs:
         working-directory: ./dashboard-ui
         run: pnpm lint
 
-  dashboard-ui-test:
+  typescript-test:
+    name: typescript/test
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -231,7 +241,8 @@ jobs:
         working-directory: ./dashboard-ui
         run: pnpm test run
 
-  dashboard-ui-build:
+  typescript-build:
+    name: typescript/build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -246,6 +257,7 @@ jobs:
         run: pnpm build
 
   docker-builds:
+    name: docker/build
     needs:
       - rust-build
       - rust-lint
@@ -254,9 +266,9 @@ jobs:
       - go-lint
       - go-vet
       - go-test
-      - dashboard-ui-lint
-      - dashboard-ui-test
-      - dashboard-ui-build
+      - typescript-lint
+      - typescript-test
+      - typescript-build
     timeout-minutes: 20
     strategy:
       matrix:
@@ -303,6 +315,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.target }}-${{ matrix.arch }}
 
   cli-builds:
+    name: cli/build
     needs:
       - rust-build
       - rust-lint
@@ -311,9 +324,9 @@ jobs:
       - go-lint
       - go-vet
       - go-test
-      - dashboard-ui-lint
-      - dashboard-ui-test
-      - dashboard-ui-build
+      - typescript-lint
+      - typescript-test
+      - typescript-build
     strategy:
       matrix:
         os:
@@ -369,6 +382,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
   alpine-builds:
+    name: alpine/build
     needs:
       - rust-build
       - rust-lint
@@ -378,9 +392,9 @@ jobs:
       - go-lint
       - go-vet
       - go-test
-      - dashboard-ui-lint
-      - dashboard-ui-test
-      - dashboard-ui-build
+      - typescript-lint
+      - typescript-test
+      - typescript-build
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Rename CI workflow jobs to use consistent naming and add explicit `name` fields for better readability in the GitHub Actions UI.

## Key Changes

- Add human-readable `name` fields to all CI jobs (e.g., `rust/build`, `go/test`, `typescript/lint`, `docker/build`)
- Rename `dashboard-ui-lint`, `dashboard-ui-test`, and `dashboard-ui-build` job IDs to `typescript-lint`, `typescript-test`, and `typescript-build`
- Update dependency references (`needs`) to match the renamed job IDs

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused