### PR TITLE
🐋 Add user-selectable timezone for timestamp display

### DIFF
--- a/dashboard-ui/src/components/widgets/AdaptiveTimeAgo.test.tsx
+++ b/dashboard-ui/src/components/widgets/AdaptiveTimeAgo.test.tsx
@@ -1,0 +1,43 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+
+import { timezoneAtom } from '@/lib/timezone';
+
+import AdaptiveTimeAgo from './AdaptiveTimeAgo';
+
+describe('AdaptiveTimeAgo', () => {
+  it('shows UTC-formatted tooltip by default', () => {
+    const date = new Date('2024-06-15T10:30:00Z');
+    render(<AdaptiveTimeAgo date={date} />);
+    const el = screen.getByTitle(/Jun 15, 2024/);
+    expect(el.getAttribute('title')).toBe('Jun 15, 2024 10:30:00 (UTC)');
+  });
+
+  it('shows tooltip formatted in the selected timezone', () => {
+    const store = createStore();
+    store.set(timezoneAtom, 'America/New_York');
+
+    const date = new Date('2024-06-15T10:30:00Z');
+    render(
+      <Provider store={store}>
+        <AdaptiveTimeAgo date={date} />
+      </Provider>,
+    );
+    const el = screen.getByTitle(/Jun 15, 2024/);
+    expect(el.getAttribute('title')).toBe('Jun 15, 2024 06:30:00 (EDT)');
+  });
+});

--- a/dashboard-ui/src/components/widgets/AdaptiveTimeAgo.tsx
+++ b/dashboard-ui/src/components/widgets/AdaptiveTimeAgo.tsx
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect, useState } from 'react';
+import { format, toZonedTime } from 'date-fns-tz';
+import { useEffect, useMemo, useState } from 'react';
 
 import TimeAgo from 'react-timeago';
+
+import { useTimezone } from '@/lib/timezone';
 
 const useAdaptiveMinPeriod = (date: Date) => {
   const [minPeriod, setMinPeriod] = useState(10);
@@ -53,7 +56,12 @@ const useAdaptiveMinPeriod = (date: Date) => {
 
 const AdaptiveTimeAgo = ({ date }: { date: Date }) => {
   const minPeriod = useAdaptiveMinPeriod(date);
-  return <TimeAgo date={date} minPeriod={minPeriod} title={date.toUTCString()} />;
+  const [timezone] = useTimezone();
+  const title = useMemo(() => {
+    const zoned = toZonedTime(date, timezone);
+    return format(zoned, 'LLL dd, y HH:mm:ss (zzz)', { timeZone: timezone });
+  }, [date, timezone]);
+  return <TimeAgo date={date} minPeriod={minPeriod} title={title} />;
 };
 
 export default AdaptiveTimeAgo;

--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.test.tsx
@@ -32,6 +32,12 @@ describe('parseTimestamp', () => {
       const d = parseTimestamp('Jan 2, 2006 15:04:05');
       expect(d).toEqual(new Date('2006-01-02T15:04:05Z'));
     });
+
+    it('should interpret timezone-less input in the given timezone', () => {
+      const d = parseTimestamp('Jan 2, 2006 15:04:05', 'America/New_York');
+      // 15:04:05 EST = 20:04:05 UTC (January is EST, not EDT)
+      expect(d).toEqual(new Date('2006-01-02T20:04:05Z'));
+    });
   });
 
   describe('ISO 8601', () => {

--- a/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
+++ b/dashboard-ui/src/components/widgets/DateRangeDropdown.tsx
@@ -17,6 +17,8 @@ import { fromZonedTime } from 'date-fns-tz';
 import { Clock } from 'lucide-react';
 import { Fragment, useRef, useState } from 'react';
 
+import { useTimezone } from '@/lib/timezone';
+
 import { Alert, AlertDescription, AlertTitle } from '@kubetail/ui/elements/alert';
 import { Button } from '@kubetail/ui/elements/button';
 import { Input } from '@kubetail/ui/elements/input';
@@ -178,7 +180,7 @@ function isValidDate(d: Date): boolean {
 // Matches Z, ±HH:MM, ±HHMM, or ±HH at the end of a string
 const TZ_RE = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/i;
 
-export function parseTimestamp(input: string): Date | undefined {
+export function parseTimestamp(input: string, timezone = 'UTC'): Date | undefined {
   const trimmed = input.trim();
   if (!trimmed) return undefined;
 
@@ -190,9 +192,9 @@ export function parseTimestamp(input: string): Date | undefined {
   }
 
   // Try native Date parser (handles ISO 8601, RFC 2822, and common formats).
-  // If the input has no explicit timezone, use fromZonedTime to interpret as UTC.
+  // If the input has no explicit timezone, use fromZonedTime to interpret in the selected timezone.
   let nativeDate = new Date(trimmed);
-  if (!TZ_RE.test(trimmed)) nativeDate = fromZonedTime(nativeDate, 'UTC');
+  if (!TZ_RE.test(trimmed)) nativeDate = fromZonedTime(nativeDate, timezone);
   if (isValidDate(nativeDate)) return nativeDate;
 
   // RFC 2822 fallback (e.g. "Mon, 02 Jan 2006 15:04:05 -0700")
@@ -218,9 +220,10 @@ export function parseTimestamp(input: string): Date | undefined {
 const AbsoluteTimeForm = ({ onApply }: { onApply: (date: Date) => void }) => {
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
+  const [timezone] = useTimezone();
 
   const handleApply = () => {
-    const date = parseTimestamp(input);
+    const date = parseTimestamp(input, timezone);
     if (!date) {
       setError('Unable to parse timestamp');
       return;

--- a/dashboard-ui/src/components/widgets/SettingsPopover.test.tsx
+++ b/dashboard-ui/src/components/widgets/SettingsPopover.test.tsx
@@ -1,0 +1,61 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ThemeProvider } from '@/lib/theme';
+
+import { SettingsPopover } from './SettingsPopover';
+
+function renderSettingsPopover() {
+  return render(
+    <ThemeProvider>
+      <SettingsPopover>
+        <button type="button">Settings</button>
+      </SettingsPopover>
+    </ThemeProvider>,
+  );
+}
+
+describe('SettingsPopover', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+  });
+
+  it('renders a Timezone row when open', () => {
+    renderSettingsPopover();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+
+    expect(screen.getByText('Timezone')).toBeInTheDocument();
+  });
+
+  it('shows UTC as the default timezone value', () => {
+    renderSettingsPopover();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+
+    expect(screen.getByText('UTC')).toBeInTheDocument();
+  });
+});

--- a/dashboard-ui/src/components/widgets/SettingsPopover.tsx
+++ b/dashboard-ui/src/components/widgets/SettingsPopover.tsx
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState } from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@kubetail/ui/elements/popover';
 import {
@@ -25,30 +27,67 @@ import {
 } from '@kubetail/ui/elements/select';
 
 import { useTheme, UserPreference } from '@/lib/theme';
+import { formatTimezoneOffset, TIMEZONES, useTimezone } from '@/lib/timezone';
 
 const SettingsPopoverContent = () => {
   const { userPreference, setUserPreference } = useTheme();
+  const [timezone, setTimezone] = useTimezone();
 
-  const handleChange = (value: UserPreference) => {
+  const handleThemeChange = (value: UserPreference) => {
     setUserPreference(value);
   };
 
+  const handleTimezoneChange = (value: string) => {
+    setTimezone(value);
+  };
+
+  const offsets = useMemo(() => new Map(TIMEZONES.map((tz) => [tz, formatTimezoneOffset(tz)])), []);
+
   return (
     <PopoverContent side="top" className="mr-1 min-h-30">
-      <table className="w-full text-sm">
+      <table className="w-full border-separate border-spacing-y-2 text-sm">
         <tbody>
           <tr>
             <td>Theme</td>
             <td align="right">
-              <Select value={userPreference} onValueChange={handleChange}>
+              <Select value={userPreference} onValueChange={handleThemeChange}>
                 <SelectTrigger className="bg-secondary border-0">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-secondary">
                   <SelectGroup>
-                    <SelectItem value={UserPreference.System}>system</SelectItem>
-                    <SelectItem value={UserPreference.Dark}>dark</SelectItem>
-                    <SelectItem value={UserPreference.Light}>light</SelectItem>
+                    <SelectItem value={UserPreference.System}>System</SelectItem>
+                    <SelectItem value={UserPreference.Dark}>Dark</SelectItem>
+                    <SelectItem value={UserPreference.Light}>Light</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </td>
+          </tr>
+          <tr>
+            <td>Timezone</td>
+            <td align="right">
+              <Select value={timezone} onValueChange={handleTimezoneChange}>
+                <SelectTrigger className="bg-secondary border-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-secondary max-h-60">
+                  <SelectGroup>
+                    {TIMEZONES.map((tz) => (
+                      <SelectPrimitive.Item
+                        key={tz}
+                        value={tz}
+                        className="focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                      >
+                        <span className="absolute right-2 flex size-3.5 items-center justify-center">
+                          <SelectPrimitive.ItemIndicator>
+                            <CheckIcon className="size-4" />
+                          </SelectPrimitive.ItemIndicator>
+                        </span>
+                        <SelectPrimitive.ItemText>{tz}</SelectPrimitive.ItemText>
+                        <span className="text-muted-foreground ml-auto">{offsets.get(tz)}</span>
+                      </SelectPrimitive.Item>
+                    ))}
                   </SelectGroup>
                 </SelectContent>
               </Select>

--- a/dashboard-ui/src/lib/timezone.test.tsx
+++ b/dashboard-ui/src/lib/timezone.test.tsx
@@ -1,0 +1,83 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act, renderHook } from '@testing-library/react';
+
+import { formatTimezoneOffset, TIMEZONES, useTimezone } from './timezone';
+
+describe('useTimezone', () => {
+  it('defaults to UTC', () => {
+    const { result } = renderHook(() => useTimezone());
+    const [timezone] = result.current;
+    expect(timezone).toBe('UTC');
+  });
+
+  it('updates the timezone when setter is called', () => {
+    const { result } = renderHook(() => useTimezone());
+
+    act(() => {
+      const [, setTimezone] = result.current;
+      setTimezone('America/New_York');
+    });
+
+    const [timezone] = result.current;
+    expect(timezone).toBe('America/New_York');
+  });
+});
+
+describe('cross-tab sync', () => {
+  it('syncs timezone changes across hook instances via BroadcastChannel', () => {
+    const hook1 = renderHook(() => useTimezone());
+    const hook2 = renderHook(() => useTimezone());
+
+    act(() => {
+      const [, setTimezone] = hook1.result.current;
+      setTimezone('America/New_York');
+    });
+
+    const [tz1] = hook1.result.current;
+    const [tz2] = hook2.result.current;
+    expect(tz1).toBe('America/New_York');
+    expect(tz2).toBe('America/New_York');
+  });
+});
+
+describe('TIMEZONES', () => {
+  it('is a non-empty array of strings', () => {
+    expect(Array.isArray(TIMEZONES)).toBe(true);
+    expect(TIMEZONES.length).toBeGreaterThan(0);
+    expect(typeof TIMEZONES[0]).toBe('string');
+  });
+
+  it('includes UTC', () => {
+    expect(TIMEZONES).toContain('UTC');
+  });
+
+  it('includes common IANA timezones', () => {
+    expect(TIMEZONES).toContain('America/New_York');
+    expect(TIMEZONES).toContain('Europe/London');
+    expect(TIMEZONES).toContain('Asia/Tokyo');
+  });
+});
+
+describe('formatTimezoneOffset', () => {
+  it('returns "+00:00" for UTC', () => {
+    expect(formatTimezoneOffset('UTC')).toBe('+00:00');
+  });
+
+  it('returns a signed offset string for non-UTC timezones', () => {
+    const offset = formatTimezoneOffset('America/New_York');
+    expect(offset).toMatch(/^[+-]\d{2}:\d{2}$/);
+  });
+});

--- a/dashboard-ui/src/lib/timezone.ts
+++ b/dashboard-ui/src/lib/timezone.ts
@@ -1,0 +1,51 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { format, toZonedTime } from 'date-fns-tz';
+import { atom, getDefaultStore, useAtomValue } from 'jotai';
+import { useCallback } from 'react';
+
+const channelName = 'kubetail:timezone';
+const bcIn = new BroadcastChannel(channelName);
+const bcOut = new BroadcastChannel(channelName);
+
+export const timezoneAtom = atom<string>('UTC');
+
+// Listen for changes from other tabs (single global listener)
+bcIn.onmessage = (ev: MessageEvent<string>) => {
+  getDefaultStore().set(timezoneAtom, ev.data);
+};
+
+export function useTimezone(): [string, (tz: string) => void] {
+  const timezone = useAtomValue(timezoneAtom);
+
+  const setTimezone = useCallback((tz: string) => {
+    getDefaultStore().set(timezoneAtom, tz);
+    bcOut.postMessage(tz);
+  }, []);
+
+  return [timezone, setTimezone];
+}
+
+export function formatTimestamp(date: Date | string, timezone: string): string {
+  const zoned = toZonedTime(date, timezone);
+  return format(zoned, 'LLL dd, y HH:mm:ss.SSS', { timeZone: timezone });
+}
+
+export function formatTimezoneOffset(tz: string): string {
+  const now = new Date();
+  return format(toZonedTime(now, tz), 'xxx', { timeZone: tz });
+}
+
+export const TIMEZONES: string[] = ['UTC', ...Intl.supportedValuesOf('timeZone').filter((tz) => tz !== 'UTC')];

--- a/dashboard-ui/src/pages/console/context-menu.test.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.test.tsx
@@ -38,9 +38,9 @@ beforeEach(() => {
   });
 });
 
-function renderWithContextMenu(col: ViewerColumn, record: LogRecord = makeRecord()) {
+function renderWithContextMenu(col: ViewerColumn, record: LogRecord = makeRecord(), timezone = 'UTC') {
   render(
-    <CellContextMenu col={col} record={record}>
+    <CellContextMenu col={col} record={record} timezone={timezone}>
       <div>cell content</div>
     </CellContextMenu>,
   );
@@ -83,6 +83,14 @@ describe('CellContextMenu', () => {
       await openContextMenu();
       fireEvent.click(screen.getByText('Copy timestamp'));
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Jun 15, 2024 10:30:01.123');
+    });
+
+    it('copies timestamp in the selected timezone', async () => {
+      renderWithContextMenu(ViewerColumn.Timestamp, makeRecord(), 'America/New_York');
+      await openContextMenu();
+      fireEvent.click(screen.getByText('Copy timestamp'));
+      // 10:30 UTC = 06:30 EDT (June is DST)
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Jun 15, 2024 06:30:01.123');
     });
 
     it('shows timestamp format options in submenu', async () => {

--- a/dashboard-ui/src/pages/console/context-menu.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { format, toZonedTime } from 'date-fns-tz';
 import React from 'react';
 
 import {
@@ -27,6 +26,7 @@ import {
 import { stripAnsi } from 'fancy-ansi';
 
 import type { LogRecord } from '@/components/widgets/log-viewer';
+import { formatTimestamp } from '@/lib/timezone';
 
 import { getPlainAttribute } from './selection';
 import { ViewerColumn } from './shared';
@@ -35,9 +35,8 @@ function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
 }
 
-function TimestampMenuContent({ record }: { record: LogRecord }) {
-  const tsWithTZ = toZonedTime(record.timestamp, 'UTC');
-  const displayed = format(tsWithTZ, 'LLL dd, y HH:mm:ss.SSS', { timeZone: 'UTC' });
+function TimestampMenuContent({ record, timezone }: { record: LogRecord; timezone: string }) {
+  const displayed = formatTimestamp(record.timestamp, timezone);
 
   return (
     <>
@@ -72,28 +71,31 @@ function MessageMenuContent({ record }: { record: LogRecord }) {
   );
 }
 
-function DefaultMenuContent({ record, col }: { record: LogRecord; col: ViewerColumn }) {
-  return <ContextMenuItem onSelect={() => copyToClipboard(getPlainAttribute(record, col))}>Copy</ContextMenuItem>;
+function DefaultMenuContent({ record, col, timezone }: { record: LogRecord; col: ViewerColumn; timezone: string }) {
+  return (
+    <ContextMenuItem onSelect={() => copyToClipboard(getPlainAttribute(record, col, timezone))}>Copy</ContextMenuItem>
+  );
 }
 
 type CellContextMenuProps = {
   col: ViewerColumn;
   record: LogRecord;
+  timezone: string;
   children: React.ReactElement;
 };
 
-export function CellContextMenu({ col, record, children }: CellContextMenuProps) {
+export function CellContextMenu({ col, record, timezone, children }: CellContextMenuProps) {
   if (col === ViewerColumn.ColorDot) {
     return children;
   }
 
   let content: React.ReactNode;
   if (col === ViewerColumn.Timestamp) {
-    content = <TimestampMenuContent record={record} />;
+    content = <TimestampMenuContent record={record} timezone={timezone} />;
   } else if (col === ViewerColumn.Message) {
     content = <MessageMenuContent record={record} />;
   } else {
-    content = <DefaultMenuContent record={record} col={col} />;
+    content = <DefaultMenuContent record={record} col={col} timezone={timezone} />;
   }
 
   return (

--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -168,6 +168,60 @@ describe('Main', () => {
     });
   });
 
+  describe('RecordRow timestamp timezone', () => {
+    const mockRow: LogViewerVirtualRow = {
+      index: 0,
+      key: 0,
+      size: 20,
+      start: 0,
+      record: {
+        timestamp: '2024-06-15T10:30:01.123Z',
+        message: 'test message',
+        cursor: 'cursor-1',
+        source: {
+          metadata: { region: 'us-east-1', zone: 'us-east-1a', os: 'linux', arch: 'amd64', node: 'node-1' },
+          namespace: 'default',
+          podName: 'my-pod',
+          containerName: 'my-container',
+        },
+      },
+    };
+
+    const defaultProps = {
+      row: mockRow,
+      gridTemplate: 'auto 1fr',
+      visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      timezone: 'UTC',
+      isWrap: false,
+      isSelected: false,
+      isSelectionTop: false,
+      isSelectionBottom: false,
+      maxRowWidth: 500,
+      colWidths: new Map<ViewerColumn, number>(),
+      selectedCellCols: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
+      selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      isCursorText: true,
+      isCellTextSelectable: false,
+      measureElement: vi.fn(),
+      measureRowElement: vi.fn(),
+      measureCellElement: vi.fn(),
+      onRowMouseDown: vi.fn(),
+      onCellMouseDown: vi.fn(),
+    };
+
+    it('formats timestamps in UTC by default', () => {
+      render(<RecordRow {...defaultProps} />);
+      expect(screen.getByText('Jun 15, 2024 10:30:01.123')).toBeInTheDocument();
+    });
+
+    it('formats timestamps in the selected timezone', () => {
+      render(<RecordRow {...defaultProps} timezone="America/New_York" />);
+      // 10:30 UTC = 06:30 EDT (June is DST)
+      expect(screen.getByText('Jun 15, 2024 06:30:01.123')).toBeInTheDocument();
+    });
+  });
+
   describe('RecordRow click behavior', () => {
     const mockRow: LogViewerVirtualRow = {
       index: 0,
@@ -191,6 +245,7 @@ describe('Main', () => {
       row: mockRow,
       gridTemplate: 'auto 1fr',
       visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      timezone: 'UTC',
       isWrap: false,
       isSelected: false,
       isSelectionTop: false,
@@ -265,6 +320,7 @@ describe('Main', () => {
       row: mockRow,
       gridTemplate: 'auto 1fr',
       visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      timezone: 'UTC',
       isWrap: false,
       isSelected: false,
       isSelectionTop: false,
@@ -469,6 +525,7 @@ describe('Main', () => {
       row: mockRow,
       gridTemplate: 'auto auto 1fr',
       visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.Message]),
+      timezone: 'UTC',
       isWrap: false,
       isSelected: false,
       isSelectionTop: false,

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { format, toZonedTime } from 'date-fns-tz';
 import { useAtomValue } from 'jotai';
 import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -21,6 +20,7 @@ import { Spinner } from '@kubetail/ui/elements/spinner';
 import { stripAnsi } from 'fancy-ansi';
 import { AnsiHtml } from 'fancy-ansi/react';
 
+import { formatTimestamp, useTimezone } from '@/lib/timezone';
 import { cn, cssEncode } from '@/lib/util';
 import { LogViewer, useLogViewerState } from '@/components/widgets/log-viewer';
 import type {
@@ -340,12 +340,10 @@ const HeaderRow = ({
  * RecordRow component
  */
 
-const getAttribute = (record: LogRecord, col: ViewerColumn) => {
+const getAttribute = (record: LogRecord, col: ViewerColumn, timezone: string) => {
   switch (col) {
-    case ViewerColumn.Timestamp: {
-      const tsWithTZ = toZonedTime(record.timestamp, 'UTC');
-      return format(tsWithTZ, 'LLL dd, y HH:mm:ss.SSS', { timeZone: 'UTC' });
-    }
+    case ViewerColumn.Timestamp:
+      return formatTimestamp(record.timestamp, timezone);
     case ViewerColumn.ColorDot: {
       const k = cssEncode(`${record.source.namespace}/${record.source.podName}/${record.source.containerName}`);
       const el = <div className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: `var(--${k}-color)` }} />;
@@ -397,6 +395,7 @@ type RecordRowProps = {
   row: LogViewerVirtualRow;
   gridTemplate: string;
   visibleCols: Set<ViewerColumn>;
+  timezone: string;
   isWrap: boolean;
   isSelected: boolean;
   isSelectionTop: boolean;
@@ -420,6 +419,7 @@ export const RecordRow = memo(
     row,
     gridTemplate,
     visibleCols,
+    timezone,
     isWrap,
     isSelected,
     isSelectionTop,
@@ -533,7 +533,7 @@ export const RecordRow = memo(
       };
 
       els.push(
-        <CellContextMenu key={col} col={col} record={row.record}>
+        <CellContextMenu key={col} col={col} record={row.record} timezone={timezone}>
           <div
             ref={measureCellElement}
             data-col-id={col}
@@ -553,7 +553,7 @@ export const RecordRow = memo(
                   }
             }
           >
-            {getAttribute(row.record, col)}
+            {getAttribute(row.record, col, timezone)}
           </div>
         </CellContextMenu>,
       );
@@ -588,6 +588,7 @@ export const RecordRow = memo(
     if (prev.row.start !== next.row.start) return false;
     if (prev.gridTemplate !== next.gridTemplate) return false;
     if (prev.visibleCols !== next.visibleCols) return false;
+    if (prev.timezone !== next.timezone) return false;
     if (prev.isWrap !== next.isWrap) return false;
     if (prev.isSelected !== next.isSelected) return false;
     if (prev.isSelectionTop !== next.isSelectionTop) return false;
@@ -616,6 +617,7 @@ export const Main = () => {
 
   const follow = useAtomValue(isFollowAtom);
   const wrap = useAtomValue(isWrapAtom);
+  const [timezone] = useTimezone();
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const scrollElRef = useRef<HTMLDivElement>(null);
@@ -754,6 +756,7 @@ export const Main = () => {
                     measureElement={virtualizer.measureElement}
                     gridTemplate={gridTemplate}
                     visibleCols={visibleCols}
+                    timezone={timezone}
                     isWrap={wrap}
                     isSelected={selectedKeys.has(virtualRow.key)}
                     isSelectionTop={selectionTopKeys.has(virtualRow.key)}

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -17,6 +17,7 @@ import { createStore, Provider } from 'jotai';
 import { createRef } from 'react';
 
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
+import { timezoneAtom } from '@/lib/timezone';
 
 import {
   getPlainAttribute,
@@ -57,9 +58,15 @@ const makeRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
 describe('getPlainAttribute', () => {
   const record = makeRecord();
 
-  it('returns formatted timestamp', () => {
-    const result = getPlainAttribute(record, ViewerColumn.Timestamp);
+  it('returns formatted timestamp in UTC by default', () => {
+    const result = getPlainAttribute(record, ViewerColumn.Timestamp, 'UTC');
     expect(result).toBe('Jun 15, 2024 10:30:01.123');
+  });
+
+  it('returns formatted timestamp in the given timezone', () => {
+    const result = getPlainAttribute(record, ViewerColumn.Timestamp, 'America/New_York');
+    // 10:30 UTC = 06:30 EDT (June is DST)
+    expect(result).toBe('Jun 15, 2024 06:30:01.123');
   });
 
   it('returns empty string for ColorDot', () => {
@@ -2028,5 +2035,23 @@ describe('useSelectionKeyboard', () => {
     });
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('log message 0\nlog message 1');
+  });
+
+  it('copies timestamps in the selected timezone on Cmd+C', () => {
+    const { store } = renderKeyboard((s) => {
+      s.set(visibleColsAtom, new Set([ViewerColumn.Timestamp, ViewerColumn.Message]));
+      s.set(timezoneAtom, 'America/New_York');
+    });
+
+    act(() => {
+      store.set(selectedKeysAtom, new Set([0]));
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'c', metaKey: true });
+    });
+
+    // 10:30 UTC = 06:30 EDT (June is DST)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Jun 15, 2024 06:30:00.000\tlog message 0');
   });
 });

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { format, toZonedTime } from 'date-fns-tz';
 import { useAtom, useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { stripAnsi } from 'fancy-ansi';
+
+import { formatTimestamp, useTimezone } from '@/lib/timezone';
 
 import type { LogRecord, LogViewerVirtualizer } from '@/components/widgets/log-viewer';
 
@@ -35,12 +36,10 @@ import {
  * getPlainAttribute - Returns a plain text string for a given log record column.
  * This is the plain-text counterpart of getAttribute() in main.tsx (which returns JSX).
  */
-export function getPlainAttribute(record: LogRecord, col: ViewerColumn): string {
+export function getPlainAttribute(record: LogRecord, col: ViewerColumn, timezone = 'UTC'): string {
   switch (col) {
-    case ViewerColumn.Timestamp: {
-      const tsWithTZ = toZonedTime(record.timestamp, 'UTC');
-      return format(tsWithTZ, 'LLL dd, y HH:mm:ss.SSS', { timeZone: 'UTC' });
-    }
+    case ViewerColumn.Timestamp:
+      return formatTimestamp(record.timestamp, timezone);
     case ViewerColumn.ColorDot:
       return '';
     case ViewerColumn.Pod:
@@ -68,12 +67,17 @@ export function getPlainAttribute(record: LogRecord, col: ViewerColumn): string 
  * formatRow - Formats a single record as tab-separated column values.
  * ColorDot is skipped. When filter is provided, only matching columns are included.
  */
-function formatRow(record: LogRecord, visibleCols: Set<ViewerColumn>, filter?: Set<ViewerColumn>): string {
+function formatRow(
+  record: LogRecord,
+  visibleCols: Set<ViewerColumn>,
+  timezone: string,
+  filter?: Set<ViewerColumn>,
+): string {
   const parts: string[] = [];
   visibleCols.forEach((col) => {
     if (col === ViewerColumn.ColorDot) return;
     if (filter && !filter.has(col)) return;
-    parts.push(getPlainAttribute(record, col));
+    parts.push(getPlainAttribute(record, col, timezone));
   });
   return parts.join('\t');
 }
@@ -82,8 +86,8 @@ function formatRow(record: LogRecord, visibleCols: Set<ViewerColumn>, filter?: S
  * formatRowsForCopy - Formats an array of log records as copyable text.
  * Columns are tab-separated, rows are newline-separated. ColorDot is skipped.
  */
-export function formatRowsForCopy(records: LogRecord[], visibleCols: Set<ViewerColumn>): string {
-  return records.map((record) => formatRow(record, visibleCols)).join('\n');
+export function formatRowsForCopy(records: LogRecord[], visibleCols: Set<ViewerColumn>, timezone = 'UTC'): string {
+  return records.map((record) => formatRow(record, visibleCols, timezone)).join('\n');
 }
 
 /**
@@ -95,13 +99,14 @@ export function formatCellsForCopy(
   selectedCells: Map<number, Set<ViewerColumn>>,
   visibleCols: Set<ViewerColumn>,
   getRecord: (key: number) => LogRecord | undefined,
+  timezone = 'UTC',
 ): string {
   return [...selectedCells.keys()]
     .sort((a, b) => a - b)
     .map((rowKey) => {
       const record = getRecord(rowKey);
       if (!record) return null;
-      const text = formatRow(record, visibleCols, selectedCells.get(rowKey));
+      const text = formatRow(record, visibleCols, timezone, selectedCells.get(rowKey));
       return text || null;
     })
     .filter((line): line is string => line !== null)
@@ -542,6 +547,7 @@ export function useSelectionKeyboard(
   virtualizerRef: React.RefObject<LogViewerVirtualizer | null>,
 ) {
   const { visibleCols, selectedKeysRef, selectedCellsRef, clearSelection } = state;
+  const [timezone] = useTimezone();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -563,7 +569,7 @@ export function useSelectionKeyboard(
           e.preventDefault();
           const v = virtualizerRef.current;
           if (!v) return;
-          const text = formatCellsForCopy(cells, visibleCols, (k) => v.getRecord(k));
+          const text = formatCellsForCopy(cells, visibleCols, (k) => v.getRecord(k), timezone);
           navigator.clipboard.writeText(text);
           return;
         }
@@ -575,7 +581,7 @@ export function useSelectionKeyboard(
           if (!v) return;
           const sorted = [...selectedKeysRef.current].sort((a, b) => a - b);
           const records = sorted.map((k) => v.getRecord(k)).filter((r): r is LogRecord => r !== undefined);
-          const text = formatRowsForCopy(records, visibleCols);
+          const text = formatRowsForCopy(records, visibleCols, timezone);
           navigator.clipboard.writeText(text);
         }
       }
@@ -583,7 +589,7 @@ export function useSelectionKeyboard(
 
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [visibleCols, clearSelection, selectedKeysRef, selectedCellsRef, virtualizerRef]);
+  }, [visibleCols, timezone, clearSelection, selectedKeysRef, selectedCellsRef, virtualizerRef]);
 }
 
 export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {

--- a/dashboard-ui/tsconfig.app.json
+++ b/dashboard-ui/tsconfig.app.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2020",
+      "ES2022",
       "DOM",
       "DOM.Iterable"
     ],

--- a/dashboard-ui/vitest.setup.ts
+++ b/dashboard-ui/vitest.setup.ts
@@ -32,6 +32,32 @@ class ResizeObserverMock {
   disconnect = vi.fn();
 }
 
+class BroadcastChannelMock {
+  static instances: BroadcastChannelMock[] = [];
+
+  name: string;
+
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+
+  postMessage = vi.fn((data: unknown) => {
+    // Deliver to all other instances with the same channel name
+    BroadcastChannelMock.instances
+      .filter((instance) => instance !== this && instance.name === this.name && instance.onmessage)
+      .forEach((instance) => instance.onmessage!(new MessageEvent('message', { data })));
+  });
+
+  close = vi.fn(() => {
+    const idx = BroadcastChannelMock.instances.indexOf(this);
+    if (idx !== -1) BroadcastChannelMock.instances.splice(idx, 1);
+  });
+
+  constructor(name: string) {
+    this.name = name;
+    BroadcastChannelMock.instances.push(this);
+  }
+}
+
+vi.stubGlobal('BroadcastChannel', BroadcastChannelMock);
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(callback, 0));
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
@@ -57,5 +83,6 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  BroadcastChannelMock.instances.length = 0;
   vi.resetAllMocks();
 });


### PR DESCRIPTION
## Summary

Adds a user-configurable timezone for timestamp display across the dashboard. A new Timezone dropdown in the Settings popover lets users pick from the full list of IANA zones (with UTC offsets shown). The selection is shared across browser tabs via BroadcastChannel so behavior stays consistent when multiple tabs are open. Previously all timestamps were formatted in UTC only.

## Key Changes

- New `src/lib/timezone.ts` with a jotai atom, `useTimezone` hook, `formatTimestamp` and `formatTimezoneOffset` helpers, and cross-tab sync via `BroadcastChannel`.
- `SettingsPopover` gains a Timezone selector using Radix Select primitives to render each zone alongside its current UTC offset.
- `AdaptiveTimeAgo`, `DateRangeDropdown` (including `parseTimestamp`), and the console `main` / `selection` / `context-menu` modules now render and parse timestamps in the selected zone.
- `tsconfig.app.json` lib bumped to ES2022 for `Intl.supportedValuesOf`.
- `vitest.setup.ts` adds a `BroadcastChannel` mock; new tests cover the timezone library, settings popover, adaptive time ago, and related console behavior.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused