### PR TITLE
✨ Align timestamp copy-as menu with shared format list

### DIFF
--- a/dashboard-ui/src/lib/timestamp-format.test.tsx
+++ b/dashboard-ui/src/lib/timestamp-format.test.tsx
@@ -15,7 +15,7 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { PreferencesProvider } from './preferences';
-import { TimestampFormat, formatTimestamp, useTimestampFormat } from './timestamp-format';
+import { TIMESTAMP_FORMAT_OPTIONS, TimestampFormat, formatTimestamp, useTimestampFormat } from './timestamp-format';
 
 function wrapper({ children }: React.PropsWithChildren) {
   return <PreferencesProvider>{children}</PreferencesProvider>;
@@ -32,6 +32,25 @@ describe('TimestampFormat', () => {
     expect(TimestampFormat.RFC_1123).toBe('rfc1123');
     expect(TimestampFormat.UNIX).toBe('unix');
     expect(TimestampFormat.UNIX_MS).toBe('unix_ms');
+  });
+});
+
+describe('TIMESTAMP_FORMAT_OPTIONS', () => {
+  it('has a hint field for every option', () => {
+    TIMESTAMP_FORMAT_OPTIONS.forEach((opt) => {
+      expect(typeof opt.hint).toBe('string');
+      expect(opt.hint.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('contains exactly the five supported formats in order', () => {
+    expect(TIMESTAMP_FORMAT_OPTIONS.map((o: { value: string }) => o.value)).toEqual([
+      'iso8601',
+      'rfc3339',
+      'rfc1123',
+      'unix',
+      'unix_ms',
+    ]);
   });
 });
 

--- a/dashboard-ui/src/lib/timestamp-format.ts
+++ b/dashboard-ui/src/lib/timestamp-format.ts
@@ -27,12 +27,12 @@ export const TimestampFormat = {
 
 export type TimestampFormatValue = (typeof TimestampFormat)[keyof typeof TimestampFormat];
 
-export const TIMESTAMP_FORMAT_OPTIONS: { value: TimestampFormatValue; label: string }[] = [
-  { value: TimestampFormat.ISO_8601, label: 'ISO 8601' },
-  { value: TimestampFormat.RFC_3339, label: 'RFC 3339' },
-  { value: TimestampFormat.RFC_1123, label: 'RFC 1123' },
-  { value: TimestampFormat.UNIX, label: 'Unix seconds' },
-  { value: TimestampFormat.UNIX_MS, label: 'Unix milliseconds' },
+export const TIMESTAMP_FORMAT_OPTIONS: { value: TimestampFormatValue; label: string; hint: string }[] = [
+  { value: TimestampFormat.ISO_8601, label: 'ISO 8601', hint: '2006-01-02T15:04:05.000+00:00' },
+  { value: TimestampFormat.RFC_3339, label: 'RFC 3339', hint: '2006-01-02 15:04:05.000+00:00' },
+  { value: TimestampFormat.RFC_1123, label: 'RFC 1123', hint: 'Mon, 02 Jan 2006 15:04:05 +0000' },
+  { value: TimestampFormat.UNIX, label: 'Unix seconds', hint: '1136214245' },
+  { value: TimestampFormat.UNIX_MS, label: 'Unix milliseconds', hint: '1136214245000' },
 ];
 
 const PATTERNS: Record<TimestampFormatValue, string> = {

--- a/dashboard-ui/src/pages/console/context-menu.test.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.test.tsx
@@ -111,9 +111,22 @@ describe('CellContextMenu', () => {
       fireEvent.click(screen.getByText('Copy as...'));
       await waitFor(() => {
         expect(screen.getByText('ISO 8601')).toBeInTheDocument();
-        expect(screen.getByText('Unix (seconds)')).toBeInTheDocument();
-        expect(screen.getByText('Unix (milliseconds)')).toBeInTheDocument();
-        expect(screen.getByText('Local time')).toBeInTheDocument();
+        expect(screen.getByText('RFC 3339')).toBeInTheDocument();
+        expect(screen.getByText('RFC 1123')).toBeInTheDocument();
+        expect(screen.getByText('Unix seconds')).toBeInTheDocument();
+        expect(screen.getByText('Unix milliseconds')).toBeInTheDocument();
+        expect(screen.queryByText('Local time')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows a hint next to each format option', async () => {
+      renderWithContextMenu(ViewerColumn.Timestamp);
+      await openContextMenu();
+      fireEvent.click(screen.getByText('Copy as...'));
+      await waitFor(() => {
+        expect(screen.getByText(/^2006-01-02T/)).toBeInTheDocument();
+        expect(screen.getByText(/^2006-01-02 /)).toBeInTheDocument();
+        expect(screen.getByText(/^Mon, 02 Jan/)).toBeInTheDocument();
       });
     });
 
@@ -123,15 +136,33 @@ describe('CellContextMenu', () => {
       fireEvent.click(screen.getByText('Copy as...'));
       await waitFor(() => expect(screen.getByText('ISO 8601')).toBeInTheDocument());
       fireEvent.click(screen.getByText('ISO 8601'));
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('2024-06-15T10:30:01.123Z');
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('2024-06-15T10:30:01.123+00:00');
+    });
+
+    it('copies RFC 3339 format', async () => {
+      renderWithContextMenu(ViewerColumn.Timestamp);
+      await openContextMenu();
+      fireEvent.click(screen.getByText('Copy as...'));
+      await waitFor(() => expect(screen.getByText('RFC 3339')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('RFC 3339'));
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('2024-06-15 10:30:01.123+00:00');
+    });
+
+    it('copies RFC 1123 format', async () => {
+      renderWithContextMenu(ViewerColumn.Timestamp);
+      await openContextMenu();
+      fireEvent.click(screen.getByText('Copy as...'));
+      await waitFor(() => expect(screen.getByText('RFC 1123')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('RFC 1123'));
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Sat, 15 Jun 2024 10:30:01 +0000');
     });
 
     it('copies Unix seconds', async () => {
       renderWithContextMenu(ViewerColumn.Timestamp);
       await openContextMenu();
       fireEvent.click(screen.getByText('Copy as...'));
-      await waitFor(() => expect(screen.getByText('Unix (seconds)')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Unix (seconds)'));
+      await waitFor(() => expect(screen.getByText('Unix seconds')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('Unix seconds'));
       const expected = String(Math.floor(new Date('2024-06-15T10:30:01.123Z').getTime() / 1000));
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
     });
@@ -140,8 +171,8 @@ describe('CellContextMenu', () => {
       renderWithContextMenu(ViewerColumn.Timestamp);
       await openContextMenu();
       fireEvent.click(screen.getByText('Copy as...'));
-      await waitFor(() => expect(screen.getByText('Unix (milliseconds)')).toBeInTheDocument());
-      fireEvent.click(screen.getByText('Unix (milliseconds)'));
+      await waitFor(() => expect(screen.getByText('Unix milliseconds')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('Unix milliseconds'));
       const expected = String(new Date('2024-06-15T10:30:01.123Z').getTime());
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
     });

--- a/dashboard-ui/src/pages/console/context-menu.tsx
+++ b/dashboard-ui/src/pages/console/context-menu.tsx
@@ -26,7 +26,7 @@ import {
 import { stripAnsi } from 'fancy-ansi';
 
 import type { LogRecord } from '@/components/widgets/log-viewer';
-import { formatTimestamp } from '@/lib/timestamp-format';
+import { TIMESTAMP_FORMAT_OPTIONS, formatTimestamp } from '@/lib/timestamp-format';
 
 import { getPlainAttribute } from './selection';
 import { ViewerColumn } from './shared';
@@ -52,18 +52,15 @@ function TimestampMenuContent({
       <ContextMenuSub>
         <ContextMenuSubTrigger>Copy as...</ContextMenuSubTrigger>
         <ContextMenuSubContent>
-          <ContextMenuItem onSelect={() => copyToClipboard(record.timestamp)}>ISO 8601</ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() => copyToClipboard(String(Math.floor(new Date(record.timestamp).getTime() / 1000)))}
-          >
-            Unix (seconds)
-          </ContextMenuItem>
-          <ContextMenuItem onSelect={() => copyToClipboard(String(new Date(record.timestamp).getTime()))}>
-            Unix (milliseconds)
-          </ContextMenuItem>
-          <ContextMenuItem onSelect={() => copyToClipboard(new Date(record.timestamp).toLocaleString())}>
-            Local time
-          </ContextMenuItem>
+          {TIMESTAMP_FORMAT_OPTIONS.map(({ value, label, hint }) => (
+            <ContextMenuItem
+              key={value}
+              onSelect={() => copyToClipboard(formatTimestamp(record.timestamp, timezone, value))}
+            >
+              <span>{label}</span>
+              <span className="text-muted-foreground ml-auto pl-4 text-xs">{hint}</span>
+            </ContextMenuItem>
+          ))}
         </ContextMenuSubContent>
       </ContextMenuSub>
     </>


### PR DESCRIPTION
## Summary

The timestamp "Copy as..." submenu in the log viewer's context menu had drifted from the shared `TIMESTAMP_FORMAT_OPTIONS` list used by the display-preference picker. It offered four hand-coded entries (ISO 8601, Unix seconds, Unix milliseconds, Local time) while the preferences picker offers five (ISO 8601, RFC 3339, RFC 1123, Unix seconds, Unix milliseconds). This PR unifies the two so users can copy a timestamp in the same set of formats they can display it in.

## Key Changes

- Drive the "Copy as..." submenu from `TIMESTAMP_FORMAT_OPTIONS` instead of hand-written items, and use `formatTimestamp` (which respects the current timezone) for the copied value.
- Add a `hint` field to each entry in `TIMESTAMP_FORMAT_OPTIONS` showing the format pattern (e.g. `2006-01-02T15:04:05.000+00:00`) and render it next to the label in the submenu.
- Drop the redundant "Local time" entry, since the locale-formatted output is a display concern, not a copy target.
- Update unit tests for the new options, hints, and formatted outputs.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused