### PR TITLE
🐋 Enforce Sec-Fetch-Site CSRF check on all dashboard dynamic routes

### DIFF
--- a/config/default/dashboard.yaml
+++ b/config/default/dashboard.yaml
@@ -73,20 +73,6 @@ environment: desktop
 #
 gin-mode: release
 
-## csrf ##
-#
-# CSRF protection settings
-#
-csrf:
-
-  ## enabled ##
-  #
-  # Whether CSRF protection is enabled.
-  #
-  # Default value: true
-  #
-  enabled: true
-
 ## logging ##
 #
 # Configuration for the dashboard server's logging output

--- a/hack/tilt/kubetail-tokenauth.yaml
+++ b/hack/tilt/kubetail-tokenauth.yaml
@@ -26,8 +26,6 @@ data:
         secure: false
         http-only: true
         same-site: lax
-    csrf:
-      enabled: true
     logging:
       enabled: true
       level: debug

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -26,8 +26,6 @@ data:
         secure: false
         http-only: true
         same-site: lax
-    csrf:
-      enabled: true
     logging:
       enabled: true
       level: debug

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -34,7 +34,6 @@ The Kubetail Dashboard server can be configured using a configuration file writt
 | dashboard.cluster-api-endpoint                  | string   | Service url for Cluster API                          | ""           | experimental |
 | dashboard.environment                           | string   | Environment (desktop, cluster)                       | "desktop"    | experimental |
 | dashboard.gin-mode                              | string   | Gin mode (release, debug)                            | "release"    | stable       |
-| dashboard.csrf.enabled                          | bool     | Enable CSRF protection                               | true         | stable       |
 | dashboard.logging.enabled                       | bool     | Enable logging                                       | true         | stable       |
 | dashboard.logging.level                         | string   | Log level                                            | "info"       | stable       |
 | dashboard.logging.format                        | string   | Log format (json, pretty)                            | "json"       | stable       |

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -17,7 +17,6 @@ package graph
 import (
 	"context"
 	"net/http"
-	"slices"
 	"sync"
 	"time"
 
@@ -45,10 +44,6 @@ type Server struct {
 	shutdownCh chan struct{}
 	wg         sync.WaitGroup
 }
-
-// allowedSecFetchSite defines the secure values for the Sec-Fetch-Site header.
-// It's defined at the package level to avoid re-allocation on every WebSocket upgrade request.
-var allowedSecFetchSite = []string{"same-origin"}
 
 // Create new Server instance
 func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
@@ -87,25 +82,13 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	// Configure WebSocket (without CORS)
+	// Configure WebSocket. CSRF / CSWSH protection is enforced by the app-level
+	// Sec-Fetch-Site middleware before the request reaches this handler, so we
+	// allow all origins here.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				// Allow all if CSRF protection is disabled
-				if !cfg.CSRF.Enabled {
-					return true
-				}
-
-				secFetchSite := r.Header.Get("Sec-Fetch-Site")
-
-				// If empty, request is from non-browser or legacy browser
-				if secFetchSite == "" {
-					return true
-				}
-
-				// Check the Sec-Fetch-Site header as our primary defense against
-				// Cross-Site WebSocket Hijacking (CSWSH)
-				return slices.Contains(allowedSecFetchSite, secFetchSite)
+				return true
 			},
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -24,77 +24,10 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
-	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
-
-func TestServer(t *testing.T) {
-	tests := []struct {
-		name           string
-		setCsrfEnabled bool
-		setHeader      http.Header
-		wantStatus     int
-	}{
-		{
-			"csrf disabled, non-browser client",
-			false,
-			http.Header{},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf disabled, same-origin request",
-			false,
-			http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf disabled, cross-site request",
-			false,
-			http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, non-browser client",
-			true,
-			http.Header{},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, same-origin request",
-			true,
-			http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, cross-site request",
-			true,
-			http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
-			http.StatusForbidden,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := config.DefaultConfig()
-			cfg.Environment = sharedcfg.EnvironmentCluster
-			cfg.CSRF.Enabled = tt.setCsrfEnabled
-
-			graphqlServer := NewServer(cfg, nil)
-
-			client := testutils.NewWebTestClient(t, graphqlServer)
-			defer client.Teardown()
-
-			// init websocket connection
-			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
-			_, resp, _ := websocket.DefaultDialer.Dial(u, tt.setHeader)
-
-			// check status code
-			require.Equal(t, tt.wantStatus, resp.StatusCode)
-		})
-	}
-}
 
 func TestServerDrainWithContext_NoConnections(t *testing.T) {
 	cfg := config.DefaultConfig()
@@ -158,7 +91,6 @@ func TestServerDrainWithContext_WaitsForHTTPRequests(t *testing.T) {
 
 func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.CSRF.Enabled = true
 
 	s := NewServer(cfg, nil)
 
@@ -199,7 +131,6 @@ func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 
 func TestServerNotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.CSRF.Enabled = true
 
 	s := NewServer(cfg, nil)
 

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -177,6 +177,9 @@ func NewApp(cfg *config.Config) (*App, error) {
 			ContentTypeNosniff:    true,
 		}))
 
+		// Add CSRF protection middleware
+		dynamicRoutes.Use(csrfProtectionMiddleware())
+
 		// Add authentication middleware
 		dynamicRoutes.Use(authenticationMiddleware(cfg.AuthMode))
 

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -19,13 +19,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 )
 
 func TestRequestID(t *testing.T) {
@@ -137,6 +142,7 @@ func TestSessionCookieOptions(t *testing.T) {
 			// request
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", "/test", nil)
+			r.Header.Set("Sec-Fetch-Site", "same-origin")
 			app.ServeHTTP(w, r)
 
 			// check session cookie
@@ -164,6 +170,76 @@ func TestHealthz(t *testing.T) {
 	result := w.Result()
 	assert.Equal(t, http.StatusOK, result.StatusCode)
 	assert.Equal(t, "{\"status\":\"ok\"}", w.Body.String())
+}
+
+func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		path            string
+		setSecFetchSite string
+		wantForbidden   bool
+	}{
+		{"graphql blocks cross-site", "GET", "/graphql", "cross-site", true},
+		{"graphql allows same-origin", "GET", "/graphql", "same-origin", false},
+		{"graphql blocks non-browser", "GET", "/graphql", "", true},
+		{"login blocks cross-site", "POST", "/api/auth/login", "cross-site", true},
+		{"login allows same-origin", "POST", "/api/auth/login", "same-origin", false},
+		{"logout blocks cross-site", "POST", "/api/auth/logout", "cross-site", true},
+		{"session blocks cross-site", "GET", "/api/auth/session", "cross-site", true},
+		{"session allows same-origin", "GET", "/api/auth/session", "same-origin", false},
+		{"healthz ignores header (outside dynamic routes)", "GET", "/healthz", "cross-site", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newTestApp(nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(tt.method, tt.path, nil)
+			if tt.setSecFetchSite != "" {
+				r.Header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
+			}
+			app.ServeHTTP(w, r)
+
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+			} else {
+				assert.NotEqual(t, http.StatusForbidden, w.Result().StatusCode)
+			}
+		})
+	}
+}
+
+func TestCSRFProtectionOnWebSocketUpgrade(t *testing.T) {
+	tests := []struct {
+		name            string
+		setSecFetchSite string
+		wantStatusCode  int
+	}{
+		{"blocks cross-site upgrade", "cross-site", http.StatusForbidden},
+		{"blocks empty upgrade", "", http.StatusForbidden},
+		{"allows same-origin upgrade", "same-origin", http.StatusSwitchingProtocols},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newTestApp(nil)
+
+			client := testutils.NewWebTestClient(t, app)
+			defer client.Teardown()
+
+			header := http.Header{}
+			if tt.setSecFetchSite != "" {
+				header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
+			}
+
+			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+			_, resp, _ := websocket.DefaultDialer.Dial(u, header)
+			require.NotNil(t, resp)
+			require.Equal(t, tt.wantStatusCode, resp.StatusCode)
+		})
+	}
 }
 
 func TestClusterAPIProxyRouteWithBasePath(t *testing.T) {

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -17,6 +17,7 @@ package app
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gin-contrib/sessions"
@@ -25,6 +26,20 @@ import (
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
+
+// allowedSecFetchSite defines the secure values for the Sec-Fetch-Site header.
+var allowedSecFetchSite = []string{"same-origin"}
+
+func csrfProtectionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !slices.Contains(allowedSecFetchSite, c.GetHeader("Sec-Fetch-Site")) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		c.Next()
+	}
+}
 
 func authenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -40,8 +55,8 @@ func authenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 
 		// check Authorization header
 		header := c.GetHeader("Authorization")
-		if strings.HasPrefix(header, "Bearer ") {
-			token = strings.TrimPrefix(header, "Bearer ")
+		if after, ok := strings.CutPrefix(header, "Bearer "); ok {
+			token = after
 		}
 
 		// if present, add token to gin context

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -102,6 +102,37 @@ func TestAuthenticationMiddleware(t *testing.T) {
 	}
 }
 
+func TestCSRFProtectionMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		setHeader      http.Header
+		wantStatusCode int
+	}{
+		{"non-browser client", http.Header{}, http.StatusForbidden},
+		{"same-origin request", http.Header{"Sec-Fetch-Site": []string{"same-origin"}}, http.StatusOK},
+		{"cross-site request", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(csrfProtectionMiddleware())
+			router.GET("/", func(c *gin.Context) {
+				c.String(http.StatusOK, "ok")
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/", nil)
+			for k, v := range tt.setHeader {
+				r.Header[k] = v
+			}
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.wantStatusCode, w.Result().StatusCode)
+		})
+	}
+}
+
 func TestK8sTokenRequiredMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/modules/dashboard/pkg/app/testutils_test.go
+++ b/modules/dashboard/pkg/app/testutils_test.go
@@ -38,7 +38,6 @@ func newTestConfig() *config.Config {
 	cfg.Logging.AccessLog.Enabled = false
 	cfg.Session.Secret = "TESTSESSIONSECRET"
 	cfg.Session.Cookie.Name = "session"
-	cfg.CSRF.Enabled = false
 	return cfg
 }
 

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -56,11 +56,6 @@ type Config struct {
 	// When empty, features that require local storage are disabled.
 	LocalStorageDir string `mapstructure:"local-storage-dir"`
 
-	// csrf options
-	CSRF struct {
-		Enabled bool
-	}
-
 	// logging options
 	Logging struct {
 		Enabled bool
@@ -133,7 +128,6 @@ func DefaultConfig() *Config {
 	cfg.ClusterAPIEndpoint = ""
 	cfg.Environment = sharedcfg.EnvironmentCluster
 	cfg.GinMode = "release"
-	cfg.CSRF.Enabled = true
 	cfg.Logging.Enabled = true
 	cfg.Logging.Level = "info"
 	cfg.Logging.Format = "json"

--- a/modules/shared/testutils/testutils.go
+++ b/modules/shared/testutils/testutils.go
@@ -73,6 +73,12 @@ func (c *WebTestClient) PostForm(url string, form url.Values) WebTestResponse {
 
 // Execute request
 func (c *WebTestClient) Do(req *http.Request) WebTestResponse {
+	// Default to same-origin so CSRF middleware treats this as a legitimate
+	// browser request. Tests exercising CSRF set this explicitly.
+	if req.Header.Get("Sec-Fetch-Site") == "" {
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+	}
+
 	// execute request
 	resp, err := c.httpclient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Previously CSRF protection existed only for the GraphQL WebSocket
upgrade. This PR extends the Sec-Fetch-Site check to cover every
dashboard route that handles session cookies or cluster operations,
making protection uniform across HTTP and WebSocket transports and
eliminating the now-redundant check inside the GraphQL server.

## Key Changes

- Add `csrfProtectionMiddleware` on the `dynamicRoutes` group, covering
  `/graphql`, `/cluster-api-proxy/*`, and `/api/auth/*`. Requests that
  do not carry `Sec-Fetch-Site: same-origin` are rejected with `403`.
- Remove the duplicate Sec-Fetch-Site check in the GraphQL WebSocket
  upgrade — the app-level middleware runs before the upgrade handler,
  so there is a single enforcement point.
- Remove the `dashboard.csrf.enabled` config flag. The dashboard is
  browser-only; modern browsers always send `Sec-Fetch-Site`, and
  there is no supported scenario for disabling the check.
- Update the shared `WebTestClient.Do()` helper to default
  `Sec-Fetch-Site: same-origin` when unset, matching browser behavior.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused