### PR TITLE
🐋 Add cluster-api log download

### DIFF
--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -24,7 +24,7 @@ import toast from 'react-hot-toast';
 import appConfig from '@/app-config';
 import clusterAPI from '@/lib/graphql/cluster-api/__generated__/introspection-result.json';
 import dashboard from '@/lib/graphql/dashboard/__generated__/introspection-result.json';
-import { getBasename, joinPaths } from '@/lib/util';
+import { clusterAPIProxyPath, getBasename, joinPaths } from '@/lib/util';
 
 /**
  * Shared items
@@ -243,11 +243,11 @@ export const getClusterAPIClient = (context: ClusterAPIContext) => {
   let client = clusterAPIClientCache.get(k);
 
   if (!client) {
-    // Build basepath
-    let basepath = joinPaths(basename, 'cluster-api-proxy');
-    if (appConfig.environment === 'desktop') {
-      basepath = joinPaths(basepath, context.kubeContext, context.namespace, context.serviceName);
-    }
+    const basepath = clusterAPIProxyPath({
+      basename,
+      environment: appConfig.environment,
+      kubeContext: context.kubeContext,
+    });
 
     const { link } = createLink(basepath);
 

--- a/dashboard-ui/src/lib/util.ts
+++ b/dashboard-ui/src/lib/util.ts
@@ -169,6 +169,30 @@ export function getBasename() {
 }
 
 /**
+ * Cluster-API proxy URL helper. Mirrors the path layout the dashboard's
+ * cluster-api-proxy expects: in cluster mode requests pass through unchanged,
+ * in desktop mode they're keyed by kubeContext + namespace + service so the
+ * proxy can route to the right kubeconfig.
+ */
+
+export const CLUSTER_API_PROXY_NAMESPACE = 'kubetail-system';
+export const CLUSTER_API_PROXY_SERVICE = 'kubetail-cluster-api';
+
+export type ClusterAPIProxyPathInput = {
+  basename: string;
+  environment: string;
+  kubeContext: string;
+};
+
+export function clusterAPIProxyPath(input: ClusterAPIProxyPathInput, ...rest: string[]) {
+  let basepath = joinPaths(input.basename, 'cluster-api-proxy');
+  if (input.environment === 'desktop') {
+    basepath = joinPaths(basepath, input.kubeContext, CLUSTER_API_PROXY_NAMESPACE, CLUSTER_API_PROXY_SERVICE);
+  }
+  return joinPaths(basepath, ...rest);
+}
+
+/**
  * Find intersection of multiple sets
  */
 

--- a/dashboard-ui/src/pages/console/download.test.tsx
+++ b/dashboard-ui/src/pages/console/download.test.tsx
@@ -20,7 +20,13 @@ import type { ApolloClient } from '@apollo/client';
 import { createMockLogViewerHandle } from '@/components/widgets/log-viewer/mock';
 import { LogRecordsQueryMode } from '@/lib/graphql/dashboard/__generated__/graphql';
 
-import { DownloadDialog, buildDownloadArgs, normalizeTimeArg, submitLogDownload } from './download';
+import {
+  DownloadDialog,
+  buildDownloadArgs,
+  getDownloadActionURL,
+  normalizeTimeArg,
+  submitLogDownload,
+} from './download';
 import { LogServerClient } from './log-server-client';
 import { PageContext, ViewerColumn, viewerColumnToBackend } from './shared';
 
@@ -50,6 +56,52 @@ describe('normalizeTimeArg', () => {
 
   it('returns undefined on unparseable input', () => {
     expect(normalizeTimeArg('not-a-time', 'UTC')).toBeUndefined();
+  });
+});
+
+describe('getDownloadActionURL', () => {
+  it('routes to the dashboard endpoint when shouldUseClusterAPI is false', () => {
+    expect(
+      getDownloadActionURL({
+        basename: '/',
+        environment: 'desktop',
+        shouldUseClusterAPI: false,
+        kubeContext: 'ctx-1',
+      }),
+    ).toBe('/api/v1/download');
+  });
+
+  it('routes through the cluster-api proxy without context segments in cluster mode', () => {
+    expect(
+      getDownloadActionURL({
+        basename: '/',
+        environment: 'cluster',
+        shouldUseClusterAPI: true,
+        kubeContext: 'ctx-1',
+      }),
+    ).toBe('/cluster-api-proxy/api/v1/download');
+  });
+
+  it('appends kubeContext/namespace/service segments in desktop mode', () => {
+    expect(
+      getDownloadActionURL({
+        basename: '/',
+        environment: 'desktop',
+        shouldUseClusterAPI: true,
+        kubeContext: 'ctx-1',
+      }),
+    ).toBe('/cluster-api-proxy/ctx-1/kubetail-system/kubetail-cluster-api/api/v1/download');
+  });
+
+  it('honors a non-root basename', () => {
+    expect(
+      getDownloadActionURL({
+        basename: '/kubetail',
+        environment: 'cluster',
+        shouldUseClusterAPI: true,
+        kubeContext: 'ctx-1',
+      }),
+    ).toBe('/kubetail/cluster-api-proxy/api/v1/download');
   });
 });
 
@@ -223,8 +275,9 @@ describe('submitLogDownload', () => {
     document.body.innerHTML = '';
   });
 
-  it('POSTs to /api/logs/download targeting a distinct hidden iframe', () => {
+  it('POSTs to the given action URL targeting a distinct hidden iframe', () => {
     submitLogDownload(
+      '/x/api/v1/download',
       { kubeContext: 'ctx-1', sources: ['ns/pod/c'] },
       {
         mode: LogRecordsQueryMode.Head,
@@ -238,7 +291,7 @@ describe('submitLogDownload', () => {
 
     expect(submitSpy).toHaveBeenCalledTimes(1);
     expect(submittedForm!.method.toLowerCase()).toBe('post');
-    expect(submittedForm!.action).toMatch(/\/api\/logs\/download$/);
+    expect(submittedForm!.action).toMatch(/\/x\/api\/v1\/download$/);
     const iframe = document.querySelector<HTMLIFrameElement>(`iframe[name="${submittedForm!.target}"]`);
     expect(iframe).not.toBeNull();
     expect(iframe!.style.display).toBe('none');
@@ -246,6 +299,7 @@ describe('submitLogDownload', () => {
 
   it('emits filters + args as hidden fields with arrays repeated', () => {
     submitLogDownload(
+      '/api/v1/download',
       {
         kubeContext: 'ctx-1',
         sources: ['ns/pod-a/c1', 'ns/pod-b/c2'],
@@ -288,6 +342,7 @@ describe('submitLogDownload', () => {
 
   it('omits limit and columns when absent', () => {
     submitLogDownload(
+      '/api/v1/download',
       { kubeContext: '', sources: ['ns/pod/c'] },
       {
         mode: LogRecordsQueryMode.Head,
@@ -306,6 +361,7 @@ describe('submitLogDownload', () => {
   it('creates a distinct iframe per call so concurrent downloads do not cancel', () => {
     const call = () =>
       submitLogDownload(
+        '/api/v1/download',
         { kubeContext: 'ctx', sources: ['ns/pod/c'] },
         {
           mode: LogRecordsQueryMode.Head,
@@ -330,7 +386,7 @@ describe('submitLogDownload', () => {
  * Dialog component tests
  */
 
-const renderDialog = () => {
+const renderDialog = (overrides: { shouldUseClusterAPI?: boolean } = {}) => {
   const client = new LogServerClient({
     apolloClient: {} as ApolloClient,
     kubeContext: 'ctx-1',
@@ -341,7 +397,7 @@ const renderDialog = () => {
   const onOpenChange = vi.fn();
   const contextValue = {
     kubeContext: 'ctx-1',
-    shouldUseClusterAPI: undefined,
+    shouldUseClusterAPI: overrides.shouldUseClusterAPI,
     logServerClient: client,
     grep: 'ERROR',
     logViewerRef: { current: createMockLogViewerHandle() },
@@ -385,6 +441,8 @@ describe('DownloadDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Download$/ }));
 
     await waitFor(() => expect(submitSpy).toHaveBeenCalledTimes(1));
+    expect(submittedForm!.action).toMatch(/\/api\/v1\/download$/);
+    expect(submittedForm!.action).not.toMatch(/cluster-api-proxy/);
     const fields = readFormFields(submittedForm!);
     expect(fields).toEqual(
       expect.arrayContaining([
@@ -399,6 +457,15 @@ describe('DownloadDialog', () => {
       ]),
     );
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('routes through the cluster-api proxy when shouldUseClusterAPI is true', async () => {
+    renderDialog({ shouldUseClusterAPI: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Download$/ }));
+
+    await waitFor(() => expect(submitSpy).toHaveBeenCalledTimes(1));
+    expect(submittedForm!.action).toMatch(/\/cluster-api-proxy\/.*\/api\/v1\/download$/);
   });
 
   it('raw mode submits TEXT outputFormat and includeMetadata false', async () => {

--- a/dashboard-ui/src/pages/console/download.tsx
+++ b/dashboard-ui/src/pages/console/download.tsx
@@ -30,13 +30,16 @@ import { Input } from '@kubetail/ui/elements/input';
 import { Label } from '@kubetail/ui/elements/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@kubetail/ui/elements/tooltip';
 
+import appConfig from '@/app-config';
 import { parseTimestamp } from '@/components/widgets/DateRangeDropdown';
 import { LogRecordsQueryMode, LogSourceFilter } from '@/lib/graphql/dashboard/__generated__/graphql';
 import { useTimezone } from '@/lib/timezone';
-import { getBasename, joinPaths } from '@/lib/util';
+import { ClusterAPIProxyPathInput, clusterAPIProxyPath, getBasename, joinPaths } from '@/lib/util';
 
 import { PageContext, ViewerColumn, viewerColumnToBackend } from './shared';
 import { visibleColsAtom } from './state';
+
+const DOWNLOAD_PATH = 'api/v1/download';
 
 /**
  * Types
@@ -141,6 +144,19 @@ export function buildDownloadArgs(state: DialogState, visibleCols: Set<ViewerCol
 }
 
 /**
+ * getDownloadActionURL - Resolve the POST target for the download form.
+ */
+
+export type DownloadEndpointInput = ClusterAPIProxyPathInput & {
+  shouldUseClusterAPI: boolean;
+};
+
+export function getDownloadActionURL(input: DownloadEndpointInput): string {
+  if (input.shouldUseClusterAPI) return clusterAPIProxyPath(input, DOWNLOAD_PATH);
+  return joinPaths(input.basename, DOWNLOAD_PATH);
+}
+
+/**
  * submitLogDownload - POST an HTML form to the dashboard download endpoint,
  * targeting a fresh hidden iframe so the browser streams the response to disk
  * without navigating the current tab. A new iframe per submission prevents
@@ -163,12 +179,12 @@ function createDownloadIframe(): HTMLIFrameElement {
   return iframe;
 }
 
-export function submitLogDownload(filters: DownloadFilters, args: DownloadArgs): void {
+export function submitLogDownload(action: string, filters: DownloadFilters, args: DownloadArgs): void {
   const iframe = createDownloadIframe();
 
   const form = document.createElement('form');
   form.method = 'POST';
-  form.action = joinPaths(getBasename(), 'api/logs/download');
+  form.action = action;
   form.target = iframe.name;
   form.style.display = 'none';
 
@@ -223,7 +239,7 @@ type DownloadDialogProps = React.ComponentProps<typeof Dialog> & {
 
 export const DownloadDialog = (props: DownloadDialogProps) => {
   const { onOpenChange } = props;
-  const { logServerClient } = useContext(PageContext);
+  const { logServerClient, shouldUseClusterAPI, kubeContext } = useContext(PageContext);
   const visibleCols = useAtomValue(visibleColsAtom);
   const [timezone] = useTimezone();
 
@@ -245,13 +261,21 @@ export const DownloadDialog = (props: DownloadDialogProps) => {
       timezone,
     );
 
-    const { kubeContext, sources, sourceFilter, grep } = logServerClient;
-    const downloadSource = { kubeContext, sources, sourceFilter, grep };
-    submitLogDownload(downloadSource, args);
+    const { kubeContext: clientKubeContext, sources, sourceFilter, grep } = logServerClient;
+    const downloadSource = { kubeContext: clientKubeContext, sources, sourceFilter, grep };
+    const action = getDownloadActionURL({
+      basename: getBasename(),
+      environment: appConfig.environment,
+      shouldUseClusterAPI: !!shouldUseClusterAPI,
+      kubeContext: kubeContext ?? '',
+    });
+    submitLogDownload(action, downloadSource, args);
 
     onOpenChange(false);
   }, [
     logServerClient,
+    shouldUseClusterAPI,
+    kubeContext,
     rangeMode,
     firstN,
     lastN,

--- a/dashboard-ui/src/pages/console/index.tsx
+++ b/dashboard-ui/src/pages/console/index.tsx
@@ -25,6 +25,7 @@ import AuthRequired from '@/components/utils/AuthRequired';
 import type { LogViewerHandle } from '@/components/widgets/log-viewer';
 import type { LogSourceFilter } from '@/lib/graphql/dashboard/__generated__/graphql';
 import { useIsClusterAPIEnabled } from '@/lib/hooks';
+import { CLUSTER_API_PROXY_NAMESPACE, CLUSTER_API_PROXY_SERVICE } from '@/lib/util';
 
 import { Header } from './header';
 import { LogServerClient } from './log-server-client';
@@ -188,8 +189,8 @@ export default function Page() {
     if (shouldUseClusterAPI) {
       apolloClient = getClusterAPIClient({
         kubeContext: kubeContext ?? '',
-        namespace: 'kubetail-system',
-        serviceName: 'kubetail-cluster-api',
+        namespace: CLUSTER_API_PROXY_NAMESPACE,
+        serviceName: CLUSTER_API_PROXY_SERVICE,
       });
     } else {
       apolloClient = dashboardClient;

--- a/dashboard-ui/src/pages/home/log-metadata-provider.tsx
+++ b/dashboard-ui/src/pages/home/log-metadata-provider.tsx
@@ -21,6 +21,7 @@ import { CLUSTER_API_READY_WAIT } from '@/lib/graphql/dashboard/ops';
 import { LOG_METADATA_LIST_FETCH, LOG_METADATA_LIST_WATCH } from '@/lib/graphql/cluster-api/ops';
 import type { LogMetadataListFetchQuery, LogMetadataWatchEvent } from '@/lib/graphql/cluster-api/__generated__/graphql';
 import { useIsClusterAPIEnabled } from '@/lib/hooks';
+import { CLUSTER_API_PROXY_NAMESPACE, CLUSTER_API_PROXY_SERVICE } from '@/lib/util';
 
 import type { FileInfo, KubeContext } from './shared';
 import { logMetadataMapAtomFamily } from './state';
@@ -44,8 +45,8 @@ export const LogMetadataProvider = ({ kubeContext }: LogMetadataProviderProps) =
   const connectArgs = useMemo(
     () => ({
       kubeContext: kubeContext || '',
-      namespace: 'kubetail-system',
-      serviceName: 'kubetail-cluster-api',
+      namespace: CLUSTER_API_PROXY_NAMESPACE,
+      serviceName: CLUSTER_API_PROXY_SERVICE,
     }),
     [kubeContext],
   );

--- a/modules/cluster-api/cmd/main.go
+++ b/modules/cluster-api/cmd/main.go
@@ -98,7 +98,7 @@ func main() {
 				Handler:      app,
 				IdleTimeout:  1 * time.Minute,
 				ReadTimeout:  5 * time.Second,
-				WriteTimeout: 10 * time.Second,
+				WriteTimeout: 1 * time.Minute,
 			}
 
 			// Register shutdown hook so long-lived connections are notified before

--- a/modules/cluster-api/graph/resolver.go
+++ b/modules/cluster-api/graph/resolver.go
@@ -36,6 +36,10 @@ type Resolver struct {
 	allowedNamespaces []string
 }
 
+// getBearerTokenRequired returns the request-context bearer token, or an
+// error if none is set. Auth is enforced per-resolver (rather than via gin
+// middleware on the whole /graphql route) so graphiql can still issue
+// schema-introspection requests without authenticating.
 func (r *Resolver) getBearerTokenRequired(ctx context.Context) (string, error) {
 	var token string
 	if tokenValue, ok := ctx.Value(k8shelpers.K8STokenCtxKey).(string); ok {

--- a/modules/cluster-api/graph/resolver_test.go
+++ b/modules/cluster-api/graph/resolver_test.go
@@ -37,7 +37,7 @@ func TestGetBearerTokenRequired(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("rejects empty token", func(t *testing.T) {
+	t.Run("rejects whitespace-only token", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), k8shelpers.K8STokenCtxKey, " ")
 		_, err := r.getBearerTokenRequired(ctx)
 		assert.Error(t, err)

--- a/modules/cluster-api/graph/schema.resolvers.go
+++ b/modules/cluster-api/graph/schema.resolvers.go
@@ -71,7 +71,6 @@ func (r *queryResolver) LogMetadataList(ctx context.Context, namespace *string) 
 
 // LogRecordsFetch is the resolver for the logRecordsFetch field.
 func (r *queryResolver) LogRecordsFetch(ctx context.Context, kubeContext *string, sources []string, mode *model.LogRecordsQueryMode, since *string, until *string, after *string, before *string, grep *string, sourceFilter *model.LogSourceFilter, limit *int) (*model.LogRecordsQueryResponse, error) {
-	// Get bearer token
 	token, err := r.getBearerTokenRequired(ctx)
 	if err != nil {
 		return nil, gqlerrors.ErrUnauthenticated
@@ -261,7 +260,6 @@ func (r *subscriptionResolver) LogMetadataWatch(ctx context.Context, namespace *
 
 // LogRecordsFollow is the resolver for the logRecordsFollow field.
 func (r *subscriptionResolver) LogRecordsFollow(ctx context.Context, kubeContext *string, sources []string, since *string, after *string, grep *string, sourceFilter *model.LogSourceFilter) (<-chan *logs.LogRecord, error) {
-	// Get bearer token
 	token, err := r.getBearerTokenRequired(ctx)
 	if err != nil {
 		return nil, gqlerrors.ErrUnauthenticated

--- a/modules/cluster-api/internal/app/app.go
+++ b/modules/cluster-api/internal/app/app.go
@@ -119,12 +119,19 @@ func NewApp(cfg *config.Config) (*App, error) {
 			ContentTypeNosniff:    true,
 		}))
 
-		// authentication middleware
+		// authentication middleware (extracts the bearer token if present);
+		// individual routes decide whether absence is a 401 (e.g. /api/v1/download)
+		// or only a per-resolver concern (e.g. /graphql, where introspection
+		// must remain reachable for graphiql)
 		dynamicRoutes.Use(authenticationMiddleware)
 
 		// GraphQL endpoint
 		app.graphqlServer = graph.NewServer(cfg, app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)
 		dynamicRoutes.Any("/graphql", gin.WrapH(app.graphqlServer))
+
+		// Log download endpoint
+		dl := newDownloadHandlers(app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)
+		dynamicRoutes.POST("/api/v1/download", requireTokenMiddleware, dl.DownloadPOST)
 	}
 	app.dynamicRoutes = dynamicRoutes // for unit tests
 

--- a/modules/cluster-api/internal/app/download.go
+++ b/modules/cluster-api/internal/app/download.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	zlog "github.com/rs/zerolog/log"
 
 	grpcdispatcher "github.com/kubetail-org/grpc-dispatcher-go"
 
@@ -95,5 +96,10 @@ func (h *downloadHandlers) DownloadPOST(c *gin.Context) {
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, logs.DownloadFilename(req.Raw.OutputFormat, time.Now())))
 	c.Status(http.StatusOK)
 
-	_ = logs.WriteDownloadStream(ctx, c.Writer, req, stream)
+	if err := logs.WriteDownloadStream(ctx, c.Writer, req, stream); err != nil && ctx.Err() == nil {
+		// Status + headers were already sent so we can't change the response
+		// code; clients will see a truncated file. Log so operators can
+		// investigate. Skip when ctx is already cancelled (client-side abort).
+		zlog.Error().Err(err).Msg("download stream ended with error")
+	}
 }

--- a/modules/cluster-api/internal/app/download.go
+++ b/modules/cluster-api/internal/app/download.go
@@ -22,28 +22,34 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	grpcdispatcher "github.com/kubetail-org/grpc-dispatcher-go"
+
+	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 )
 
-// downloadHandlers wires the production log stream factory against the app's
-// connection manager and threads allowedNamespaces through from config.
+// downloadHandlers wires the download endpoint against the cluster-api log
+// stream factory. The stream is opened with the agent log fetcher so records
+// flow over gRPC from the cluster agents.
 type downloadHandlers struct {
-	*App
-	newLogStream      logs.NewDownloadStreamFn
+	cm                k8shelpers.ConnectionManager
+	grpcDispatcher    *grpcdispatcher.Dispatcher
 	allowedNamespaces []string
+	newLogStream      logs.NewDownloadStreamFn
 }
 
-func newDownloadHandlers(app *App) *downloadHandlers {
+func newDownloadHandlers(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.Dispatcher, allowedNamespaces []string) *downloadHandlers {
 	return &downloadHandlers{
-		App: app,
+		cm:                cm,
+		grpcDispatcher:    grpcDispatcher,
+		allowedNamespaces: allowedNamespaces,
 		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
-			return logs.NewStream(ctx, app.cm, sources, opts...)
+			return logs.NewStream(ctx, cm, sources, opts...)
 		},
-		allowedNamespaces: app.config.AllowedNamespaces,
 	}
 }
 
-// Log download endpoint
+// DownloadPOST handles POST /api/v1/download for the cluster-api server.
 func (h *downloadHandlers) DownloadPOST(c *gin.Context) {
 	var form logs.DownloadForm
 	if err := c.ShouldBind(&form); err != nil {
@@ -62,7 +68,15 @@ func (h *downloadHandlers) DownloadPOST(c *gin.Context) {
 		return
 	}
 
-	opts := logs.BuildDownloadStreamOptions(req, c.GetString(k8sTokenGinKey), h.allowedNamespaces)
+	token, _ := c.Request.Context().Value(k8shelpers.K8STokenCtxKey).(string)
+
+	// The cluster-api operates on its in-cluster config; per-request
+	// kubeContext is a dashboard concept that InClusterConnectionManager
+	// rejects outright. Ignore whatever the form carried.
+	req.Raw.KubeContext = ""
+
+	opts := logs.BuildDownloadStreamOptions(req, token, h.allowedNamespaces)
+	opts = append(opts, logs.WithLogFetcher(logs.NewAgentLogFetcher(h.grpcDispatcher)))
 
 	ctx := c.Request.Context()
 	stream, err := h.newLogStream(ctx, req.Raw.Sources, opts...)

--- a/modules/cluster-api/internal/app/download_test.go
+++ b/modules/cluster-api/internal/app/download_test.go
@@ -189,4 +189,3 @@ func TestDownloadAppliesAllowedNamespaces(t *testing.T) {
 	// allowedNamespaces adds exactly one option (WithAllowedNamespaces).
 	assert.Equal(t, withoutCount+1, withCount)
 }
-

--- a/modules/cluster-api/internal/app/download_test.go
+++ b/modules/cluster-api/internal/app/download_test.go
@@ -1,0 +1,192 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubetail-org/kubetail/modules/shared/logs"
+)
+
+// fakeDownloadStreamer emits canned LogRecords through the Records channel.
+type fakeDownloadStreamer struct {
+	records []logs.LogRecord
+	ch      chan logs.LogRecord
+}
+
+func (f *fakeDownloadStreamer) Start(ctx context.Context) error {
+	go func() {
+		defer close(f.ch)
+		for _, r := range f.records {
+			select {
+			case <-ctx.Done():
+				return
+			case f.ch <- r:
+			}
+		}
+	}()
+	return nil
+}
+
+func (f *fakeDownloadStreamer) Records() <-chan logs.LogRecord { return f.ch }
+func (f *fakeDownloadStreamer) Err() error                     { return nil }
+func (f *fakeDownloadStreamer) Close()                         {}
+
+func newTestDownloadHandlers(records []logs.LogRecord, captured *[]logs.Option) *downloadHandlers {
+	return &downloadHandlers{
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
+			if captured != nil {
+				*captured = opts
+			}
+			return &fakeDownloadStreamer{records: records, ch: make(chan logs.LogRecord, len(records))}, nil
+		},
+	}
+}
+
+func mountDownloadHandler(h *downloadHandlers) *gin.Engine {
+	r := gin.New()
+	r.Use(authenticationMiddleware)
+	r.Use(requireTokenMiddleware)
+	r.POST("/api/v1/download", h.DownloadPOST)
+	return r
+}
+
+func baseDownloadForm() url.Values {
+	return url.Values{
+		"sources":         {"default:pod/my-pod"},
+		"mode":            {"HEAD"},
+		"outputFormat":    {"TSV"},
+		"messageFormat":   {"TEXT"},
+		"includeMetadata": {"true"},
+		"columns":         {"timestamp", "message"},
+	}
+}
+
+func postDownload(engine *gin.Engine, form url.Values, withBearer bool) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/download", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if withBearer {
+		r.Header.Set("Authorization", "Bearer test-token")
+	}
+	engine.ServeHTTP(w, r)
+	return w
+}
+
+func TestDownloadRequiresBearerToken(t *testing.T) {
+	engine := mountDownloadHandler(newTestDownloadHandlers(nil, nil))
+	w := postDownload(engine, baseDownloadForm(), false)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestDownloadHappyPathTSV(t *testing.T) {
+	records := []logs.LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "hello",
+			Source:    logs.LogSource{Namespace: "default", PodName: "p1", ContainerName: "c1"},
+		},
+	}
+	engine := mountDownloadHandler(newTestDownloadHandlers(records, nil))
+
+	form := baseDownloadForm()
+	form.Del("columns")
+	form["columns"] = []string{"timestamp", "pod", "message"}
+
+	w := postDownload(engine, form, true)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/tab-separated-values; charset=utf-8", w.Header().Get("Content-Type"))
+	cd := w.Header().Get("Content-Disposition")
+	assert.True(t, strings.HasPrefix(cd, `attachment; filename="logs-`), "Content-Disposition: %q", cd)
+	assert.True(t, strings.HasSuffix(cd, `.tsv"`), "Content-Disposition: %q", cd)
+
+	want := "timestamp\tpod\tmessage\n" +
+		"2026-04-01T00:00:00Z\tp1\thello\n"
+	assert.Equal(t, want, w.Body.String())
+}
+
+func TestDownloadInvalidFormFails(t *testing.T) {
+	engine := mountDownloadHandler(newTestDownloadHandlers(nil, nil))
+	form := baseDownloadForm()
+	form.Set("mode", "INVALID")
+	w := postDownload(engine, form, true)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+// The cluster-api server runs against its in-cluster config, so it can't
+// honor a per-request kubeContext (InClusterConnectionManager rejects any
+// non-empty kubeContext with a 500). The handler must drop that form field
+// before building stream options.
+func TestDownloadIgnoresKubeContextFromForm(t *testing.T) {
+	var withCount, withoutCount int
+	with := &downloadHandlers{
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
+			withCount = len(opts)
+			return &fakeDownloadStreamer{ch: make(chan logs.LogRecord)}, nil
+		},
+	}
+	without := &downloadHandlers{
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
+			withoutCount = len(opts)
+			return &fakeDownloadStreamer{ch: make(chan logs.LogRecord)}, nil
+		},
+	}
+
+	formWith := baseDownloadForm()
+	formWith.Set("kubeContext", "some-ctx")
+
+	w1 := postDownload(mountDownloadHandler(with), formWith, true)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	w2 := postDownload(mountDownloadHandler(without), baseDownloadForm(), true)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	assert.Equal(t, withoutCount, withCount, "kubeContext form field must not add a WithKubeContext option")
+}
+
+func TestDownloadAppliesAllowedNamespaces(t *testing.T) {
+	var withCount, withoutCount int
+	with := &downloadHandlers{
+		allowedNamespaces: []string{"ns1"},
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
+			withCount = len(opts)
+			return &fakeDownloadStreamer{ch: make(chan logs.LogRecord)}, nil
+		},
+	}
+	without := &downloadHandlers{
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
+			withoutCount = len(opts)
+			return &fakeDownloadStreamer{ch: make(chan logs.LogRecord)}, nil
+		},
+	}
+
+	w1 := postDownload(mountDownloadHandler(with), baseDownloadForm(), true)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	w2 := postDownload(mountDownloadHandler(without), baseDownloadForm(), true)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	// allowedNamespaces adds exactly one option (WithAllowedNamespaces).
+	assert.Equal(t, withoutCount+1, withCount)
+}
+

--- a/modules/cluster-api/internal/app/middleware.go
+++ b/modules/cluster-api/internal/app/middleware.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -37,6 +38,11 @@ func authenticationMiddleware(c *gin.Context) {
 		token = strings.TrimPrefix(header, "Bearer ")
 	}
 
+	// Trim at the trust boundary so consumers can rely on a simple `token == ""`
+	// presence check; otherwise a whitespace-only bearer header would slip past
+	// any gate that doesn't itself trim.
+	token = strings.TrimSpace(token)
+
 	// Add to context for kubernetes requests
 	if token != "" {
 		ctx := context.WithValue(c.Request.Context(), k8shelpers.K8STokenCtxKey, token)
@@ -50,5 +56,17 @@ func authenticationMiddleware(c *gin.Context) {
 	}
 
 	// Continue
+	c.Next()
+}
+
+// requireTokenMiddleware aborts with 401 when no bearer token reached the
+// request context. Pair with authenticationMiddleware (which extracts the
+// token from headers) so all dynamic routes share a single auth check.
+func requireTokenMiddleware(c *gin.Context) {
+	token, _ := c.Request.Context().Value(k8shelpers.K8STokenCtxKey).(string)
+	if strings.TrimSpace(token) == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
 	c.Next()
 }

--- a/modules/cluster-api/internal/app/middleware_test.go
+++ b/modules/cluster-api/internal/app/middleware_test.go
@@ -67,6 +67,13 @@ func TestAuthenticationMiddleware(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"whitespace-only bearer is treated as absent",
+			map[string]string{
+				"Authorization": "Bearer    ",
+			},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -207,7 +207,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 
 			// Log download endpoint
 			dl := newDownloadHandlers(app)
-			protectedRoutes.POST("/api/logs/download", dl.DownloadPOST)
+			protectedRoutes.POST("/api/v1/download", dl.DownloadPOST)
 		}
 	}
 	app.dynamicRoutes = dynamicRoutes

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -239,21 +239,21 @@ func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
 		{
 			"download blocks cross-site",
 			"POST",
-			"/api/logs/download",
+			"/api/v1/download",
 			"cross-site",
 			true,
 		},
 		{
 			"download blocks non-browser",
 			"POST",
-			"/api/logs/download",
+			"/api/v1/download",
 			"",
 			true,
 		},
 		{
 			"download allows same-origin",
 			"POST",
-			"/api/logs/download",
+			"/api/v1/download",
 			"same-origin",
 			false,
 		},
@@ -323,7 +323,7 @@ func TestDownloadRequiresAuthInTokenMode(t *testing.T) {
 	app := newTestApp(cfg)
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/api/logs/download", nil)
+	r := httptest.NewRequest("POST", "/api/v1/download", nil)
 	r.Header.Set("Sec-Fetch-Site", "same-origin")
 	app.ServeHTTP(w, r)
 

--- a/modules/dashboard/pkg/app/download.go
+++ b/modules/dashboard/pkg/app/download.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	zlog "github.com/rs/zerolog/log"
 
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 )
@@ -81,5 +82,10 @@ func (h *downloadHandlers) DownloadPOST(c *gin.Context) {
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, logs.DownloadFilename(req.Raw.OutputFormat, time.Now())))
 	c.Status(http.StatusOK)
 
-	_ = logs.WriteDownloadStream(ctx, c.Writer, req, stream)
+	if err := logs.WriteDownloadStream(ctx, c.Writer, req, stream); err != nil && ctx.Err() == nil {
+		// Status + headers were already sent so we can't change the response
+		// code; clients will see a truncated file. Log so operators can
+		// investigate. Skip when ctx is already cancelled (client-side abort).
+		zlog.Error().Err(err).Msg("download stream ended with error")
+	}
 }

--- a/modules/dashboard/pkg/app/download_test.go
+++ b/modules/dashboard/pkg/app/download_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -30,11 +29,10 @@ import (
 )
 
 // fakeStreamer emits a pre-populated slice of LogRecords through the Records
-// channel. Ignores options; use only for output-path assertions.
+// channel. Ignores options; use only for handler-level assertions.
 type fakeStreamer struct {
 	records []logs.LogRecord
 	ch      chan logs.LogRecord
-	err     error
 }
 
 func (f *fakeStreamer) Start(ctx context.Context) error {
@@ -52,7 +50,7 @@ func (f *fakeStreamer) Start(ctx context.Context) error {
 }
 
 func (f *fakeStreamer) Records() <-chan logs.LogRecord { return f.ch }
-func (f *fakeStreamer) Err() error                     { return f.err }
+func (f *fakeStreamer) Err() error                     { return nil }
 func (f *fakeStreamer) Close()                         {}
 
 // newTestDownloadHandlers builds a downloadHandlers wired to a fake stream
@@ -60,7 +58,7 @@ func (f *fakeStreamer) Close()                         {}
 // not use it directly, only via h.newLogStream.
 func newTestDownloadHandlers(records []logs.LogRecord) *downloadHandlers {
 	return &downloadHandlers{
-		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logStreamer, error) {
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
 			return &fakeStreamer{records: records, ch: make(chan logs.LogRecord, len(records))}, nil
 		},
 	}
@@ -71,7 +69,7 @@ func newTestDownloadHandlers(records []logs.LogRecord) *downloadHandlers {
 // separately in app_test.go.
 func mountDownloadHandler(h *downloadHandlers) *gin.Engine {
 	r := gin.New()
-	r.POST("/api/logs/download", h.DownloadPOST)
+	r.POST("/api/v1/download", h.DownloadPOST)
 	return r
 }
 
@@ -88,31 +86,17 @@ func baseDownloadForm() url.Values {
 
 func postDownload(engine *gin.Engine, form url.Values) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/api/logs/download", strings.NewReader(form.Encode()))
+	r := httptest.NewRequest("POST", "/api/v1/download", strings.NewReader(form.Encode()))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	engine.ServeHTTP(w, r)
 	return w
-}
-
-func TestBuildStreamOptionsAllowedNamespaces(t *testing.T) {
-	req := &downloadRequest{raw: downloadForm{Mode: downloadModeHead}}
-
-	without := buildStreamOptions(req, "", nil)
-	withEmpty := buildStreamOptions(req, "", []string{})
-	withNs := buildStreamOptions(req, "", []string{"ns1", "ns2"})
-
-	// nil/empty allowedNamespaces produce the same option count.
-	assert.Equal(t, len(without), len(withEmpty))
-
-	// non-empty allowedNamespaces appends exactly one extra option.
-	assert.Equal(t, len(without)+1, len(withNs))
 }
 
 func TestDownloadForwardsAllowedNamespaces(t *testing.T) {
 	var capturedOptCount int
 	h := &downloadHandlers{
 		allowedNamespaces: []string{"allowed-ns"},
-		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logStreamer, error) {
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
 			capturedOptCount = len(opts)
 			return &fakeStreamer{ch: make(chan logs.LogRecord)}, nil
 		},
@@ -126,7 +110,7 @@ func TestDownloadForwardsAllowedNamespaces(t *testing.T) {
 	// difference must be exactly one option (WithAllowedNamespaces).
 	var baselineOptCount int
 	baseline := &downloadHandlers{
-		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logStreamer, error) {
+		newLogStream: func(ctx context.Context, sources []string, opts ...logs.Option) (logs.DownloadStreamer, error) {
 			baselineOptCount = len(opts)
 			return &fakeStreamer{ch: make(chan logs.LogRecord)}, nil
 		},
@@ -137,7 +121,7 @@ func TestDownloadForwardsAllowedNamespaces(t *testing.T) {
 	assert.Equal(t, baselineOptCount+1, capturedOptCount)
 }
 
-func TestDownloadFormValidation(t *testing.T) {
+func TestDownloadFormBindingValidation(t *testing.T) {
 	tests := []struct {
 		name       string
 		mutate     func(url.Values)
@@ -158,41 +142,11 @@ func TestDownloadFormValidation(t *testing.T) {
 			wantStatus: http.StatusUnprocessableEntity,
 		},
 		{
-			name:       "invalid outputFormat",
-			mutate:     func(f url.Values) { f.Set("outputFormat", "XML") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "invalid messageFormat",
-			mutate:     func(f url.Values) { f.Set("messageFormat", "XYZ") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "invalid since",
-			mutate:     func(f url.Values) { f.Set("since", "not-a-time") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "invalid until",
-			mutate:     func(f url.Values) { f.Set("until", "not-a-time") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "unknown column",
-			mutate:     func(f url.Values) { f.Add("columns", "bogus") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
 			name: "csv requires metadata",
 			mutate: func(f url.Values) {
 				f.Set("outputFormat", "CSV")
 				f.Set("includeMetadata", "false")
 			},
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "tsv requires metadata",
-			mutate:     func(f url.Values) { f.Set("includeMetadata", "false") },
 			wantStatus: http.StatusUnprocessableEntity,
 		},
 		{
@@ -205,22 +159,7 @@ func TestDownloadFormValidation(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:       "duration since",
-			mutate:     func(f url.Values) { f.Set("since", "PT1M") },
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "rfc3339 since",
-			mutate:     func(f url.Values) { f.Set("since", "2026-04-01T00:00:00Z") },
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "negative limit",
-			mutate:     func(f url.Values) { f.Set("limit", "-5") },
-			wantStatus: http.StatusUnprocessableEntity,
-		},
-		{
-			name:       "non-numeric limit",
+			name:       "non-numeric limit (gin binding error)",
 			mutate:     func(f url.Values) { f.Set("limit", "abc") },
 			wantStatus: http.StatusUnprocessableEntity,
 		},
@@ -241,229 +180,13 @@ func TestDownloadFormValidation(t *testing.T) {
 	}
 }
 
-func TestDownloadTSVOutput(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "hello",
-			Source:    logs.LogSource{Namespace: "default", PodName: "p1", ContainerName: "c1"},
-		},
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC),
-			Message:   "world",
-			Source:    logs.LogSource{Namespace: "default", PodName: "p1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "pod", "container", "message"}
-
-	w := postDownload(engine, form)
+func TestDownloadResponseHeaders(t *testing.T) {
+	engine := mountDownloadHandler(newTestDownloadHandlers(nil))
+	w := postDownload(engine, baseDownloadForm())
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "text/tab-separated-values; charset=utf-8", w.Header().Get("Content-Type"))
 	cd := w.Header().Get("Content-Disposition")
 	assert.True(t, strings.HasPrefix(cd, `attachment; filename="logs-`), "Content-Disposition: %q", cd)
 	assert.True(t, strings.HasSuffix(cd, `.tsv"`), "Content-Disposition: %q", cd)
-
-	wantBody := "timestamp\tpod\tcontainer\tmessage\n" +
-		"2026-04-01T00:00:00Z\tp1\tc1\thello\n" +
-		"2026-04-01T00:00:01Z\tp1\tc1\tworld\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadCSVOutput(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   `a,b "quoted" c`,
-			Source:    logs.LogSource{PodName: "p1", ContainerName: "c1"},
-		},
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC),
-			Message:   "multi\nline",
-			Source:    logs.LogSource{PodName: "p1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("outputFormat", "CSV")
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "pod", "message"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "text/csv; charset=utf-8", w.Header().Get("Content-Type"))
-	cd := w.Header().Get("Content-Disposition")
-	assert.True(t, strings.HasSuffix(cd, `.csv"`), "Content-Disposition: %q", cd)
-
-	// encoding/csv with UseCRLF normalizes LF inside quoted fields to CRLF.
-	wantBody := "timestamp,pod,message\r\n" +
-		`2026-04-01T00:00:00Z,p1,"a,b ""quoted"" c"` + "\r\n" +
-		`2026-04-01T00:00:01Z,p1,"multi` + "\r\n" + `line"` + "\r\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadTextOutput_StripAnsi(t *testing.T) {
-	records := []logs.LogRecord{
-		{Message: "\x1b[31mred\x1b[0m normal"},
-		{Message: "plain line"},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("outputFormat", "TEXT")
-	form.Set("messageFormat", "TEXT")
-	form.Set("includeMetadata", "false")
-	form.Del("columns")
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
-	cd := w.Header().Get("Content-Disposition")
-	assert.True(t, strings.HasSuffix(cd, `.txt"`), "Content-Disposition: %q", cd)
-	assert.Equal(t, "red normal\nplain line\n", w.Body.String())
-}
-
-func TestDownloadTextOutput_KeepAnsi(t *testing.T) {
-	records := []logs.LogRecord{
-		{Message: "\x1b[31mred\x1b[0m normal"},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("outputFormat", "TEXT")
-	form.Set("messageFormat", "ANSI")
-	form.Set("includeMetadata", "false")
-	form.Del("columns")
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "\x1b[31mred\x1b[0m normal\n", w.Body.String())
-}
-
-func TestDownloadTSVOutput_StripAnsi(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "\x1b[31mred\x1b[0m normal",
-			Source:    logs.LogSource{PodName: "p1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("messageFormat", "TEXT")
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "message"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	wantBody := "timestamp\tmessage\n" +
-		"2026-04-01T00:00:00Z\tred normal\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadTSVOutput_KeepAnsi(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "\x1b[31mred\x1b[0m normal",
-			Source:    logs.LogSource{PodName: "p1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("messageFormat", "ANSI")
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "message"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	wantBody := "timestamp\tmessage\n" +
-		"2026-04-01T00:00:00Z\t\x1b[31mred\x1b[0m normal\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadCSVOutput_StripAnsi(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "\x1b[31mred\x1b[0m normal",
-			Source:    logs.LogSource{PodName: "p1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Set("outputFormat", "CSV")
-	form.Set("messageFormat", "TEXT")
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "message"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	wantBody := "timestamp,message\r\n" +
-		"2026-04-01T00:00:00Z,red normal\r\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadColumnOrderAndSubset(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "hello",
-			Source: logs.LogSource{
-				PodName:       "p1",
-				ContainerName: "c1",
-				Metadata:      logs.LogSourceMetadata{Region: "us-east-1", Node: "n1"},
-			},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Del("columns")
-	// Deliberately out-of-order + subset (skip container, pod, zone, os, arch).
-	form["columns"] = []string{"message", "region", "node", "timestamp"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	wantBody := "message\tregion\tnode\ttimestamp\n" +
-		"hello\tus-east-1\tn1\t2026-04-01T00:00:00Z\n"
-	assert.Equal(t, wantBody, w.Body.String())
-}
-
-func TestDownloadTSVEscapesTabsAndNewlines(t *testing.T) {
-	records := []logs.LogRecord{
-		{
-			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-			Message:   "a\tb\nc",
-			Source:    logs.LogSource{PodName: "p\t1", ContainerName: "c1"},
-		},
-	}
-	engine := mountDownloadHandler(newTestDownloadHandlers(records))
-
-	form := baseDownloadForm()
-	form.Del("columns")
-	form["columns"] = []string{"timestamp", "pod", "container", "message"}
-
-	w := postDownload(engine, form)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	// tabs and newlines in fields are replaced with spaces so rows/columns stay aligned
-	wantBody := "timestamp\tpod\tcontainer\tmessage\n" +
-		"2026-04-01T00:00:00Z\tp 1\tc1\ta b c\n"
-	assert.Equal(t, wantBody, w.Body.String())
 }

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -59,6 +59,12 @@ func authenticationMiddleware(mode config.AuthMode) gin.HandlerFunc {
 			token = after
 		}
 
+		// Trim before deciding presence — without this, a whitespace-only
+		// bearer header (e.g. "Authorization: Bearer    ") would bypass the
+		// AuthModeToken gate downstream, since k8sAuthenticationMiddleware
+		// only checks `token == ""`.
+		token = strings.TrimSpace(token)
+
 		// if present, add token to gin context
 		if token != "" {
 			// Add to gin context

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -102,6 +102,24 @@ func TestAuthenticationMiddleware(t *testing.T) {
 	}
 }
 
+// A whitespace-only bearer header must not pass the AuthModeToken gate.
+// k8sAuthenticationMiddleware only checks `token == ""`, so the upstream
+// authenticationMiddleware has to normalize before storing in the gin context.
+func TestAuthenticationMiddlewareRejectsWhitespaceToken(t *testing.T) {
+	router := gin.New()
+	router.Use(sessions.Sessions("session", cookie.NewStore([]byte("xx"))))
+	router.Use(authenticationMiddleware(config.AuthModeToken))
+	router.Use(k8sAuthenticationMiddleware(config.AuthModeToken))
+	router.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer    ")
+	router.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+}
+
 func TestCSRFProtectionMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/modules/shared/logs/download.go
+++ b/modules/shared/logs/download.go
@@ -1,0 +1,420 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Matches the ANSI escape sequences that show up in practice in container
+// logs: CSI (cursor/erase + SGR colors) and OSC (incl. hyperlinks). Uses
+// ESC-introduced forms only — 8-bit C1 introducers aren't valid standalone
+// UTF-8 and don't appear in real-world container output.
+var ansiRe = regexp.MustCompile(
+	`\x1b[[\]()#;?]*` +
+		`(?:` +
+		`(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?(?:\x07|\x1b\\))` +
+		`|` +
+		`(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])` +
+		`)`,
+)
+
+// StripAnsi removes ANSI escape sequences from s.
+func StripAnsi(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// Supported download form enum values.
+const (
+	DownloadModeHead = "HEAD"
+	DownloadModeTail = "TAIL"
+
+	DownloadOutputTSV  = "TSV"
+	DownloadOutputCSV  = "CSV"
+	DownloadOutputText = "TEXT"
+
+	DownloadMsgText = "TEXT"
+	DownloadMsgAnsi = "ANSI"
+)
+
+// allowedDownloadColumns lists backend column names accepted in the form's
+// `columns[]` field. Mirrors dashboard-ui/src/pages/console/shared.ts.
+var allowedDownloadColumns = map[string]struct{}{
+	"timestamp": {},
+	"pod":       {},
+	"container": {},
+	"region":    {},
+	"zone":      {},
+	"os":        {},
+	"arch":      {},
+	"node":      {},
+	"message":   {},
+}
+
+// DownloadStreamer is the subset of *Stream used by download handlers. It
+// lets tests inject fakes without standing up a real cluster.
+type DownloadStreamer interface {
+	Start(ctx context.Context) error
+	Records() <-chan LogRecord
+	Err() error
+	Close()
+}
+
+// NewDownloadStreamFn opens a download stream against the given sources.
+type NewDownloadStreamFn func(ctx context.Context, sources []string, opts ...Option) (DownloadStreamer, error)
+
+// DownloadForm is the raw form as submitted by the dashboard's download
+// dialog. Bound by gin's form binder via the struct tags.
+type DownloadForm struct {
+	KubeContext     string   `form:"kubeContext"`
+	Sources         []string `form:"sources"`
+	Grep            string   `form:"grep"`
+	Regions         []string `form:"sourceFilter.region"`
+	Zones           []string `form:"sourceFilter.zone"`
+	OSes            []string `form:"sourceFilter.os"`
+	Arches          []string `form:"sourceFilter.arch"`
+	Nodes           []string `form:"sourceFilter.node"`
+	Containers      []string `form:"sourceFilter.container"`
+	Mode            string   `form:"mode"`
+	Limit           *int     `form:"limit"`
+	Since           string   `form:"since"`
+	Until           string   `form:"until"`
+	OutputFormat    string   `form:"outputFormat"`
+	MessageFormat   string   `form:"messageFormat"`
+	IncludeMetadata bool     `form:"includeMetadata"`
+	Columns         []string `form:"columns"`
+}
+
+// DownloadRequest is a parsed and validated download form ready for use.
+type DownloadRequest struct {
+	Raw   DownloadForm
+	Since time.Time
+	Until time.Time
+}
+
+// DownloadValidationError reports a specific form field that failed validation.
+type DownloadValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *DownloadValidationError) Error() string { return e.Message }
+
+// Validate checks the form and returns a parsed DownloadRequest, or a
+// DownloadValidationError naming the offending field.
+func (f DownloadForm) Validate() (*DownloadRequest, *DownloadValidationError) {
+	verr := func(field, msg string) (*DownloadRequest, *DownloadValidationError) {
+		return nil, &DownloadValidationError{Field: field, Message: msg}
+	}
+
+	if len(f.Sources) == 0 {
+		return verr("sources", "at least one source is required")
+	}
+
+	switch f.Mode {
+	case DownloadModeHead, DownloadModeTail:
+	default:
+		return verr("mode", fmt.Sprintf("must be one of %s, %s", DownloadModeHead, DownloadModeTail))
+	}
+
+	switch f.OutputFormat {
+	case DownloadOutputTSV, DownloadOutputCSV, DownloadOutputText:
+	default:
+		return verr("outputFormat", fmt.Sprintf("must be one of %s, %s, %s", DownloadOutputTSV, DownloadOutputCSV, DownloadOutputText))
+	}
+
+	switch f.MessageFormat {
+	case DownloadMsgText, DownloadMsgAnsi:
+	default:
+		return verr("messageFormat", fmt.Sprintf("must be one of %s, %s", DownloadMsgText, DownloadMsgAnsi))
+	}
+
+	// Tabular formats require the metadata flag — otherwise the request is
+	// ambiguous (rows with no columns).
+	if (f.OutputFormat == DownloadOutputCSV || f.OutputFormat == DownloadOutputTSV) && !f.IncludeMetadata {
+		return verr("includeMetadata", "must be true for CSV/TSV")
+	}
+
+	for _, c := range f.Columns {
+		if _, ok := allowedDownloadColumns[c]; !ok {
+			return verr("columns", fmt.Sprintf("unknown column: %s", c))
+		}
+	}
+
+	if f.Limit != nil && *f.Limit < 0 {
+		return verr("limit", "must be non-negative")
+	}
+
+	since, err := ParseTimeArg(f.Since)
+	if err != nil {
+		return verr("since", err.Error())
+	}
+	until, err := ParseTimeArg(f.Until)
+	if err != nil {
+		return verr("until", err.Error())
+	}
+
+	return &DownloadRequest{Raw: f, Since: since, Until: until}, nil
+}
+
+// BuildDownloadStreamOptions turns a parsed request into the []Option slice
+// to pass to NewStream. allowedNamespaces, when non-empty, restricts the
+// stream to those namespaces.
+func BuildDownloadStreamOptions(req *DownloadRequest, bearerToken string, allowedNamespaces []string) []Option {
+	// Up to ~14 conditional appends below; pre-size to avoid reallocs.
+	opts := make([]Option, 0, 14)
+	if req.Raw.KubeContext != "" {
+		opts = append(opts, WithKubeContext(req.Raw.KubeContext))
+	}
+	if bearerToken != "" {
+		opts = append(opts, WithBearerToken(bearerToken))
+	}
+	if len(allowedNamespaces) > 0 {
+		opts = append(opts, WithAllowedNamespaces(allowedNamespaces))
+	}
+	if !req.Since.IsZero() {
+		opts = append(opts, WithSince(req.Since))
+	}
+	if !req.Until.IsZero() {
+		opts = append(opts, WithUntil(req.Until))
+	}
+	if req.Raw.Grep != "" {
+		opts = append(opts, WithGrep(req.Raw.Grep))
+	}
+	if len(req.Raw.Regions) > 0 {
+		opts = append(opts, WithRegions(req.Raw.Regions))
+	}
+	if len(req.Raw.Zones) > 0 {
+		opts = append(opts, WithZones(req.Raw.Zones))
+	}
+	if len(req.Raw.OSes) > 0 {
+		opts = append(opts, WithOSes(req.Raw.OSes))
+	}
+	if len(req.Raw.Arches) > 0 {
+		opts = append(opts, WithArches(req.Raw.Arches))
+	}
+	if len(req.Raw.Nodes) > 0 {
+		opts = append(opts, WithNodes(req.Raw.Nodes))
+	}
+	if len(req.Raw.Containers) > 0 {
+		opts = append(opts, WithContainers(req.Raw.Containers))
+	}
+
+	switch req.Raw.Mode {
+	case DownloadModeHead:
+		if req.Raw.Limit != nil && *req.Raw.Limit > 0 {
+			opts = append(opts, WithHead(int64(*req.Raw.Limit)))
+		} else {
+			opts = append(opts, WithAll())
+		}
+	case DownloadModeTail:
+		if req.Raw.Limit != nil && *req.Raw.Limit > 0 {
+			opts = append(opts, WithTail(int64(*req.Raw.Limit)))
+		} else {
+			opts = append(opts, WithAll())
+		}
+	}
+
+	return opts
+}
+
+// DownloadContentType returns the response Content-Type for an output format.
+func DownloadContentType(outputFormat string) string {
+	switch outputFormat {
+	case DownloadOutputCSV:
+		return "text/csv; charset=utf-8"
+	case DownloadOutputText:
+		return "text/plain; charset=utf-8"
+	default:
+		return "text/tab-separated-values; charset=utf-8"
+	}
+}
+
+// DownloadExt returns the filename extension for an output format.
+func DownloadExt(outputFormat string) string {
+	switch outputFormat {
+	case DownloadOutputCSV:
+		return "csv"
+	case DownloadOutputText:
+		return "txt"
+	default:
+		return "tsv"
+	}
+}
+
+// DownloadFilename returns a default filename for a download response.
+func DownloadFilename(outputFormat string, now time.Time) string {
+	return fmt.Sprintf("logs-%s.%s",
+		now.UTC().Format("2006-01-02_15-04-05"),
+		DownloadExt(outputFormat),
+	)
+}
+
+// downloadFieldValue returns the string representation of a column for a
+// record. When stripAnsiCodes is true the "message" column has ANSI escape
+// sequences removed so plain-text downloads don't leak terminal control codes.
+func downloadFieldValue(r LogRecord, column string, stripAnsiCodes bool) string {
+	switch column {
+	case "timestamp":
+		return r.Timestamp.UTC().Format(time.RFC3339Nano)
+	case "pod":
+		return r.Source.PodName
+	case "container":
+		return r.Source.ContainerName
+	case "region":
+		return r.Source.Metadata.Region
+	case "zone":
+		return r.Source.Metadata.Zone
+	case "os":
+		return r.Source.Metadata.OS
+	case "arch":
+		return r.Source.Metadata.Arch
+	case "node":
+		return r.Source.Metadata.Node
+	case "message":
+		if stripAnsiCodes {
+			return StripAnsi(r.Message)
+		}
+		return r.Message
+	}
+	return ""
+}
+
+// DownloadRecordWriter writes a stream of log records in a specific output format.
+type DownloadRecordWriter interface {
+	WriteHeader() error
+	WriteRecord(LogRecord) error
+}
+
+// tsvWriter emits a tab-separated header + data rows. Tabs and newlines in
+// field values are replaced with spaces so row/column boundaries stay intact.
+type tsvWriter struct {
+	w         io.Writer
+	columns   []string
+	stripAnsi bool
+}
+
+func (tw *tsvWriter) WriteHeader() error {
+	_, err := io.WriteString(tw.w, strings.Join(tw.columns, "\t")+"\n")
+	return err
+}
+
+func (tw *tsvWriter) WriteRecord(r LogRecord) error {
+	vals := make([]string, len(tw.columns))
+	for i, col := range tw.columns {
+		vals[i] = tsvEscape(downloadFieldValue(r, col, tw.stripAnsi))
+	}
+	_, err := io.WriteString(tw.w, strings.Join(vals, "\t")+"\n")
+	return err
+}
+
+func tsvEscape(s string) string {
+	return strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
+}
+
+// csvWriter emits RFC 4180 CSV via encoding/csv. It flushes after each record
+// so the response streams rather than buffering.
+type csvWriter struct {
+	cw        *csv.Writer
+	columns   []string
+	stripAnsi bool
+}
+
+func (cw *csvWriter) WriteHeader() error {
+	if err := cw.cw.Write(cw.columns); err != nil {
+		return err
+	}
+	cw.cw.Flush()
+	return cw.cw.Error()
+}
+
+func (cw *csvWriter) WriteRecord(r LogRecord) error {
+	vals := make([]string, len(cw.columns))
+	for i, col := range cw.columns {
+		vals[i] = downloadFieldValue(r, col, cw.stripAnsi)
+	}
+	if err := cw.cw.Write(vals); err != nil {
+		return err
+	}
+	cw.cw.Flush()
+	return cw.cw.Error()
+}
+
+// textWriter emits one message per line. Message format TEXT strips ANSI
+// escape sequences; ANSI leaves them intact.
+type textWriter struct {
+	w         io.Writer
+	stripAnsi bool
+}
+
+func (tw *textWriter) WriteHeader() error { return nil }
+
+func (tw *textWriter) WriteRecord(r LogRecord) error {
+	msg := r.Message
+	if tw.stripAnsi {
+		msg = StripAnsi(msg)
+	}
+	_, err := io.WriteString(tw.w, msg+"\n")
+	return err
+}
+
+// NewDownloadRecordWriter picks an encoder for the given request.
+func NewDownloadRecordWriter(w io.Writer, req *DownloadRequest) DownloadRecordWriter {
+	stripAnsiCodes := req.Raw.MessageFormat == DownloadMsgText
+	switch req.Raw.OutputFormat {
+	case DownloadOutputCSV:
+		cw := csv.NewWriter(w)
+		cw.UseCRLF = true
+		return &csvWriter{cw: cw, columns: req.Raw.Columns, stripAnsi: stripAnsiCodes}
+	case DownloadOutputText:
+		return &textWriter{w: w, stripAnsi: stripAnsiCodes}
+	default:
+		return &tsvWriter{w: w, columns: req.Raw.Columns, stripAnsi: stripAnsiCodes}
+	}
+}
+
+// WriteDownloadStream writes the column header (if any) and each stream record
+// to w. If w implements an interface with `Flush()`, it flushes after the
+// header and after each record so the response streams to the client. Returns
+// the first encountered write or context error.
+func WriteDownloadStream(ctx context.Context, w io.Writer, req *DownloadRequest, stream DownloadStreamer) error {
+	rw := NewDownloadRecordWriter(w, req)
+	if err := rw.WriteHeader(); err != nil {
+		return err
+	}
+	flusher, _ := w.(interface{ Flush() })
+	if flusher != nil {
+		flusher.Flush()
+	}
+
+	for rec := range stream.Records() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := rw.WriteRecord(rec); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	return nil
+}

--- a/modules/shared/logs/download.go
+++ b/modules/shared/logs/download.go
@@ -393,8 +393,13 @@ func NewDownloadRecordWriter(w io.Writer, req *DownloadRequest) DownloadRecordWr
 
 // WriteDownloadStream writes the column header (if any) and each stream record
 // to w. If w implements an interface with `Flush()`, it flushes after the
-// header and after each record so the response streams to the client. Returns
-// the first encountered write or context error.
+// header and after each record so the response streams to the client.
+//
+// After the records channel closes the stream's terminal error is returned so
+// callers can distinguish a truncated download (e.g. an upstream agent
+// disconnect mid-stream) from a clean finish. The HTTP status has already been
+// sent by then, so handlers can't change the response code, but they should
+// log the failure rather than treat it as success.
 func WriteDownloadStream(ctx context.Context, w io.Writer, req *DownloadRequest, stream DownloadStreamer) error {
 	rw := NewDownloadRecordWriter(w, req)
 	if err := rw.WriteHeader(); err != nil {
@@ -416,5 +421,5 @@ func WriteDownloadStream(ctx context.Context, w io.Writer, req *DownloadRequest,
 			flusher.Flush()
 		}
 	}
-	return nil
+	return stream.Err()
 }

--- a/modules/shared/logs/download_test.go
+++ b/modules/shared/logs/download_test.go
@@ -1,0 +1,408 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeDownloadStreamer emits a pre-populated slice of LogRecords through the
+// Records channel. Ignores options; use only for output-path assertions.
+type fakeDownloadStreamer struct {
+	records []LogRecord
+	ch      chan LogRecord
+	err     error
+}
+
+func newFakeStreamer(records []LogRecord) *fakeDownloadStreamer {
+	return &fakeDownloadStreamer{records: records, ch: make(chan LogRecord, len(records))}
+}
+
+func (f *fakeDownloadStreamer) Start(ctx context.Context) error {
+	go func() {
+		defer close(f.ch)
+		for _, r := range f.records {
+			select {
+			case <-ctx.Done():
+				return
+			case f.ch <- r:
+			}
+		}
+	}()
+	return nil
+}
+
+func (f *fakeDownloadStreamer) Records() <-chan LogRecord { return f.ch }
+func (f *fakeDownloadStreamer) Err() error                { return f.err }
+func (f *fakeDownloadStreamer) Close()                    {}
+
+func intPtr(i int) *int { return &i }
+
+func baseDownloadRequest() *DownloadRequest {
+	return &DownloadRequest{
+		Raw: DownloadForm{
+			Sources:         []string{"default:pod/my-pod"},
+			Mode:            DownloadModeHead,
+			OutputFormat:    DownloadOutputTSV,
+			MessageFormat:   DownloadMsgText,
+			IncludeMetadata: true,
+			Columns:         []string{"timestamp", "message"},
+		},
+	}
+}
+
+// runStream wires a fake streamer into WriteDownloadStream and returns the
+// resulting body so format-level tests can compare bytes directly.
+func runStream(t *testing.T, req *DownloadRequest, records []LogRecord) string {
+	t.Helper()
+	stream := newFakeStreamer(records)
+	if err := stream.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := WriteDownloadStream(context.Background(), &buf, req, stream); err != nil {
+		t.Fatalf("WriteDownloadStream: %v", err)
+	}
+	return buf.String()
+}
+
+func TestDownloadFormValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*DownloadForm)
+		wantField string
+	}{
+		{
+			name:      "valid form",
+			wantField: "",
+		},
+		{
+			name:      "empty sources",
+			mutate:    func(f *DownloadForm) { f.Sources = nil },
+			wantField: "sources",
+		},
+		{
+			name:      "invalid mode",
+			mutate:    func(f *DownloadForm) { f.Mode = "XYZ" },
+			wantField: "mode",
+		},
+		{
+			name:      "invalid outputFormat",
+			mutate:    func(f *DownloadForm) { f.OutputFormat = "XML" },
+			wantField: "outputFormat",
+		},
+		{
+			name:      "invalid messageFormat",
+			mutate:    func(f *DownloadForm) { f.MessageFormat = "XYZ" },
+			wantField: "messageFormat",
+		},
+		{
+			name:      "invalid since",
+			mutate:    func(f *DownloadForm) { f.Since = "not-a-time" },
+			wantField: "since",
+		},
+		{
+			name:      "invalid until",
+			mutate:    func(f *DownloadForm) { f.Until = "not-a-time" },
+			wantField: "until",
+		},
+		{
+			name:      "unknown column",
+			mutate:    func(f *DownloadForm) { f.Columns = append(f.Columns, "bogus") },
+			wantField: "columns",
+		},
+		{
+			name: "csv requires metadata",
+			mutate: func(f *DownloadForm) {
+				f.OutputFormat = DownloadOutputCSV
+				f.IncludeMetadata = false
+			},
+			wantField: "includeMetadata",
+		},
+		{
+			name:      "tsv requires metadata",
+			mutate:    func(f *DownloadForm) { f.IncludeMetadata = false },
+			wantField: "includeMetadata",
+		},
+		{
+			name: "text allows metadata false",
+			mutate: func(f *DownloadForm) {
+				f.OutputFormat = DownloadOutputText
+				f.IncludeMetadata = false
+				f.Columns = nil
+			},
+			wantField: "",
+		},
+		{
+			name:      "duration since",
+			mutate:    func(f *DownloadForm) { f.Since = "PT1M" },
+			wantField: "",
+		},
+		{
+			name:      "rfc3339 since",
+			mutate:    func(f *DownloadForm) { f.Since = "2026-04-01T00:00:00Z" },
+			wantField: "",
+		},
+		{
+			name:      "negative limit",
+			mutate:    func(f *DownloadForm) { f.Limit = intPtr(-5) },
+			wantField: "limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := baseDownloadRequest().Raw
+			if tt.mutate != nil {
+				tt.mutate(&f)
+			}
+			req, verr := f.Validate()
+			if tt.wantField == "" {
+				assert.Nil(t, verr)
+				assert.NotNil(t, req)
+			} else {
+				assert.NotNil(t, verr)
+				if verr != nil {
+					assert.Equal(t, tt.wantField, verr.Field)
+				}
+				assert.Nil(t, req)
+			}
+		})
+	}
+}
+
+func TestBuildDownloadStreamOptionsAllowedNamespaces(t *testing.T) {
+	req := &DownloadRequest{Raw: DownloadForm{Mode: DownloadModeHead}}
+
+	without := BuildDownloadStreamOptions(req, "", nil)
+	withEmpty := BuildDownloadStreamOptions(req, "", []string{})
+	withNs := BuildDownloadStreamOptions(req, "", []string{"ns1", "ns2"})
+
+	assert.Equal(t, len(without), len(withEmpty))
+	assert.Equal(t, len(without)+1, len(withNs))
+}
+
+func TestBuildDownloadStreamOptionsBearerToken(t *testing.T) {
+	req := &DownloadRequest{Raw: DownloadForm{Mode: DownloadModeHead}}
+
+	without := BuildDownloadStreamOptions(req, "", nil)
+	with := BuildDownloadStreamOptions(req, "tok", nil)
+
+	assert.Equal(t, len(without)+1, len(with))
+}
+
+func TestDownloadContentTypeAndExt(t *testing.T) {
+	cases := []struct {
+		format       string
+		wantType     string
+		wantExt      string
+		wantFilename string
+	}{
+		{DownloadOutputTSV, "text/tab-separated-values; charset=utf-8", "tsv", "logs-2026-04-01_00-00-00.tsv"},
+		{DownloadOutputCSV, "text/csv; charset=utf-8", "csv", "logs-2026-04-01_00-00-00.csv"},
+		{DownloadOutputText, "text/plain; charset=utf-8", "txt", "logs-2026-04-01_00-00-00.txt"},
+	}
+	now := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	for _, tt := range cases {
+		t.Run(tt.format, func(t *testing.T) {
+			assert.Equal(t, tt.wantType, DownloadContentType(tt.format))
+			assert.Equal(t, tt.wantExt, DownloadExt(tt.format))
+			assert.Equal(t, tt.wantFilename, DownloadFilename(tt.format, now))
+		})
+	}
+}
+
+func TestWriteDownloadStream_TSV(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.Columns = []string{"timestamp", "pod", "container", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "hello",
+			Source:    LogSource{Namespace: "default", PodName: "p1", ContainerName: "c1"},
+		},
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC),
+			Message:   "world",
+			Source:    LogSource{Namespace: "default", PodName: "p1", ContainerName: "c1"},
+		},
+	}
+
+	body := runStream(t, req, records)
+	want := "timestamp\tpod\tcontainer\tmessage\n" +
+		"2026-04-01T00:00:00Z\tp1\tc1\thello\n" +
+		"2026-04-01T00:00:01Z\tp1\tc1\tworld\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_CSV(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.OutputFormat = DownloadOutputCSV
+	req.Raw.Columns = []string{"timestamp", "pod", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   `a,b "quoted" c`,
+			Source:    LogSource{PodName: "p1", ContainerName: "c1"},
+		},
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC),
+			Message:   "multi\nline",
+			Source:    LogSource{PodName: "p1", ContainerName: "c1"},
+		},
+	}
+
+	body := runStream(t, req, records)
+	want := "timestamp,pod,message\r\n" +
+		`2026-04-01T00:00:00Z,p1,"a,b ""quoted"" c"` + "\r\n" +
+		`2026-04-01T00:00:01Z,p1,"multi` + "\r\n" + `line"` + "\r\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_TextStripAnsi(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.OutputFormat = DownloadOutputText
+	req.Raw.IncludeMetadata = false
+	req.Raw.Columns = nil
+
+	records := []LogRecord{
+		{Message: "\x1b[31mred\x1b[0m normal"},
+		{Message: "plain line"},
+	}
+
+	body := runStream(t, req, records)
+	assert.Equal(t, "red normal\nplain line\n", body)
+}
+
+func TestWriteDownloadStream_TextKeepAnsi(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.OutputFormat = DownloadOutputText
+	req.Raw.MessageFormat = DownloadMsgAnsi
+	req.Raw.IncludeMetadata = false
+	req.Raw.Columns = nil
+
+	records := []LogRecord{
+		{Message: "\x1b[31mred\x1b[0m normal"},
+	}
+	body := runStream(t, req, records)
+	assert.Equal(t, "\x1b[31mred\x1b[0m normal\n", body)
+}
+
+func TestWriteDownloadStream_TSVStripAnsi(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.Columns = []string{"timestamp", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "\x1b[31mred\x1b[0m normal",
+			Source:    LogSource{PodName: "p1", ContainerName: "c1"},
+		},
+	}
+	body := runStream(t, req, records)
+	want := "timestamp\tmessage\n" +
+		"2026-04-01T00:00:00Z\tred normal\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_TSVKeepAnsi(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.MessageFormat = DownloadMsgAnsi
+	req.Raw.Columns = []string{"timestamp", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "\x1b[31mred\x1b[0m normal",
+			Source:    LogSource{PodName: "p1", ContainerName: "c1"},
+		},
+	}
+	body := runStream(t, req, records)
+	want := "timestamp\tmessage\n" +
+		"2026-04-01T00:00:00Z\t\x1b[31mred\x1b[0m normal\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_CSVStripAnsi(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.OutputFormat = DownloadOutputCSV
+	req.Raw.Columns = []string{"timestamp", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "\x1b[31mred\x1b[0m normal",
+			Source:    LogSource{PodName: "p1", ContainerName: "c1"},
+		},
+	}
+	body := runStream(t, req, records)
+	want := "timestamp,message\r\n" +
+		"2026-04-01T00:00:00Z,red normal\r\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_ColumnOrderAndSubset(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.Columns = []string{"message", "region", "node", "timestamp"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "hello",
+			Source: LogSource{
+				PodName:       "p1",
+				ContainerName: "c1",
+				Metadata:      LogSourceMetadata{Region: "us-east-1", Node: "n1"},
+			},
+		},
+	}
+	body := runStream(t, req, records)
+	want := "message\tregion\tnode\ttimestamp\n" +
+		"hello\tus-east-1\tn1\t2026-04-01T00:00:00Z\n"
+	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_TSVEscapesTabsAndNewlines(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.Columns = []string{"timestamp", "pod", "container", "message"}
+
+	records := []LogRecord{
+		{
+			Timestamp: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Message:   "a\tb\nc",
+			Source:    LogSource{PodName: "p\t1", ContainerName: "c1"},
+		},
+	}
+	body := runStream(t, req, records)
+	want := "timestamp\tpod\tcontainer\tmessage\n" +
+		"2026-04-01T00:00:00Z\tp 1\tc1\ta b c\n"
+	assert.Equal(t, want, body)
+}
+
+func TestStripAnsi(t *testing.T) {
+	assert.Equal(t, "red", StripAnsi("\x1b[31mred\x1b[0m"))
+	assert.Equal(t, "plain", StripAnsi("plain"))
+	// OSC hyperlink (ESC ] ... ST)
+	assert.Equal(t, "click", StripAnsi("\x1b]8;;https://example.com\x1b\\click\x1b]8;;\x1b\\"))
+	assert.True(t, strings.Contains(StripAnsi("hello \x1b[1mworld\x1b[0m"), "hello world"))
+}

--- a/modules/shared/logs/download_test.go
+++ b/modules/shared/logs/download_test.go
@@ -17,6 +17,7 @@ package logs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -397,6 +398,29 @@ func TestWriteDownloadStream_TSVEscapesTabsAndNewlines(t *testing.T) {
 	want := "timestamp\tpod\tcontainer\tmessage\n" +
 		"2026-04-01T00:00:00Z\tp 1\tc1\ta b c\n"
 	assert.Equal(t, want, body)
+}
+
+func TestWriteDownloadStream_PropagatesStreamErr(t *testing.T) {
+	req := baseDownloadRequest()
+	req.Raw.OutputFormat = DownloadOutputText
+	req.Raw.IncludeMetadata = false
+	req.Raw.Columns = nil
+
+	wantErr := errors.New("agent disconnected mid-stream")
+	stream := &fakeDownloadStreamer{
+		records: []LogRecord{{Message: "partial"}},
+		ch:      make(chan LogRecord, 1),
+		err:     wantErr,
+	}
+	if err := stream.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err := WriteDownloadStream(context.Background(), &buf, req, stream)
+	assert.ErrorIs(t, err, wantErr)
+	// Records emitted before the error should still have been written.
+	assert.Equal(t, "partial\n", buf.String())
 }
 
 func TestStripAnsi(t *testing.T) {


### PR DESCRIPTION
## Summary

The download feature added in #1090 only worked when the dashboard
fetched logs through the Kubernetes API. When the frontend was configured
to use the cluster-api for log fetching (the `shouldUseClusterAPI` path),
downloads still hit the dashboard endpoint and missed the cluster-api's
gRPC log fetcher and `allowedNamespaces` enforcement. This PR aligns
both backends on `POST /api/v1/download`, adds the matching endpoint to
the cluster-api server, and routes the frontend through the cluster-api
proxy when that mode is active.

## Key Changes

- Extract the format-agnostic download core (form binding, validation,
  TSV/CSV/text writers, ANSI stripping, stream-options builder) to
  `modules/shared/logs` so the dashboard and cluster-api handlers share
  it instead of duplicating ~450 lines.
- Rename the dashboard route from `/api/logs/download` to
  `/api/v1/download`. Add the same route on the cluster-api server,
  wired with the gRPC agent log fetcher and configured allowed
  namespaces.
- Frontend `download.tsx` now resolves the form action via a new
  `getDownloadActionURL` helper. When `shouldUseClusterAPI` is true the
  request goes through `cluster-api-proxy/api/v1/download` (in cluster
  mode) or `cluster-api-proxy/<ctx>/<ns>/<svc>/api/v1/download` (in
  desktop mode); otherwise it goes to the dashboard endpoint.
- New `clusterAPIProxyPath` helper plus `CLUSTER_API_PROXY_NAMESPACE` /
  `CLUSTER_API_PROXY_SERVICE` constants in `lib/util.ts` unify the
  proxy basepath logic that was previously duplicated across
  `apollo-client.ts`, `download.tsx`, `console/index.tsx`, and
  `log-metadata-provider.tsx`.
- Bump the cluster-api server `WriteTimeout` from 10s to 1m so streamed
  downloads aren't truncated, mirroring the dashboard bump from #1090.
- Apply `requireTokenMiddleware` to the cluster-api `/api/v1/download`
  route only. `/graphql` keeps the per-resolver token check so graphiql
  introspection remains unauthenticated.
- Harden the bearer-token presence check in both backends'
  `authenticationMiddleware`: trim at the trust boundary so a
  whitespace-only `Authorization: Bearer    ` header is treated as
  absent. Kubernetes always rejected such tokens at the API call, but
  the dashboard's `AuthModeToken` gate was failing open and letting
  requests reach handler code first.
- Cluster-api download handler ignores any `kubeContext` carried in the
  form, since `InClusterConnectionManager` rejects non-empty
  `kubeContext` values outright.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any (none)
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused