### PR TITLE
🎣 Gate WebSocket reconnection with HTTP health check

### DIFF
--- a/dashboard-ui/src/apollo-client.test.ts
+++ b/dashboard-ui/src/apollo-client.test.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { k8sPagination } from './apollo-client';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { k8sPagination, waitUntilOnline, waitUntilVisible } from './apollo-client';
 
 describe('k8sPagination merge logic', () => {
   let mergeFunction: ReturnType<typeof k8sPagination>['merge'];
@@ -79,5 +79,64 @@ describe('k8sPagination merge logic', () => {
     const result = mergeFunction(existing, incoming, { args: { options: { continue: 'differentToken' } } });
 
     expect(result).toEqual(existing);
+  });
+});
+
+describe('waitUntilVisible', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves immediately when the document is already visible', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+
+    await expect(waitUntilVisible()).resolves.toBeUndefined();
+  });
+
+  it('resolves when visibility transitions to visible', async () => {
+    const stateSpy = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+
+    const pending = waitUntilVisible();
+
+    stateSpy.mockReturnValue('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('does not resolve while the document remains hidden', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+
+    let resolved = false;
+    waitUntilVisible().then(() => {
+      resolved = true;
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+
+    expect(resolved).toBe(false);
+  });
+});
+
+describe('waitUntilOnline', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves immediately when navigator is online', async () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+
+    await expect(waitUntilOnline()).resolves.toBeUndefined();
+  });
+
+  it('resolves when an online event fires', async () => {
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+
+    const pending = waitUntilOnline();
+
+    window.dispatchEvent(new Event('online'));
+
+    await expect(pending).resolves.toBeUndefined();
   });
 });

--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -32,6 +32,40 @@ import { getBasename, joinPaths } from '@/lib/util';
 
 const basename = getBasename();
 
+/**
+ * Helper function to poll healthz endpoint until server is available.
+ * Uses recursion instead of a while loop to satisfy ESLint no-await-in-loop rule.
+ */
+const waitForHealthyServer = (basepath: string): Promise<void> => {
+  const healthzUrl = new URL(joinPaths(basepath, 'healthz'), window.location.origin).toString();
+
+  const poll = (): Promise<void> =>
+    fetch(healthzUrl)
+      .then((response) => {
+        if (response.ok) {
+          // Server is up, allow WebSocket reconnection
+          return;
+        }
+        // Server returned non-OK, wait and retry
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            resolve(poll());
+          }, 3000);
+        });
+      })
+      .catch(
+        () =>
+          // Server is down, wait and retry
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              resolve(poll());
+            }, 3000);
+          }),
+      );
+
+  return poll();
+};
+
 const wsClientOptions: ClientOptions = {
   url: '',
   lazy: true,
@@ -39,10 +73,7 @@ const wsClientOptions: ClientOptions = {
   keepAlive: 3000,
   retryAttempts: Infinity,
   shouldRetry: () => true,
-  retryWait: () =>
-    new Promise((resolve) => {
-      setTimeout(resolve, 3000);
-    }),
+  retryWait: () => waitForHealthyServer(basename),
 };
 
 const errorLink = new ErrorLink(({ error }) => {
@@ -197,13 +228,13 @@ export class DashboardCustomCache extends InMemoryCache {
 
 const { link: dashboardLink, wsClient: dashboardWSClient } = createLink(basename);
 
+export { dashboardWSClient };
+
 export const dashboardClient = new ApolloClient({
   cache: new DashboardCustomCache(),
   link: dashboardLink,
   queryDeduplication: false,
 });
-
-export { dashboardWSClient };
 
 /**
  * Cluster API client

--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -24,7 +24,69 @@ import toast from 'react-hot-toast';
 import appConfig from '@/app-config';
 import clusterAPI from '@/lib/graphql/cluster-api/__generated__/introspection-result.json';
 import dashboard from '@/lib/graphql/dashboard/__generated__/introspection-result.json';
-import { getBasename, joinPaths } from '@/lib/util';
+import { getBasename, joinPaths, sleep } from '@/lib/util';
+
+const HEALTHZ_RETRY_DELAY_MS = 3000;
+const HEALTHZ_TIMEOUT_MS = 2000;
+const WS_RETRY_BACKOFF_MS = 1000;
+const WS_RETRY_BACKOFF_JITTER_MS = 1000;
+
+/**
+ * Helper methods
+ */
+
+export const waitUntilVisible = (): Promise<void> => {
+  if (document.visibilityState === 'visible') return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const handler = () => {
+      if (document.visibilityState === 'visible') {
+        document.removeEventListener('visibilitychange', handler);
+        resolve();
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+  });
+};
+
+export const waitUntilOnline = (): Promise<void> => {
+  if (navigator.onLine) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    window.addEventListener('online', () => resolve(), { once: true });
+  });
+};
+
+const createRetryWait = (basepath: string) => {
+  const healthzUrl = new URL(joinPaths(basepath, 'healthz'), window.location.origin).toString();
+
+  // Retry HTTP health endpoint every three seconds until healthy
+  return async () => {
+    let healthy = false;
+    while (!healthy) {
+      // eslint-disable-next-line no-await-in-loop
+      await waitUntilVisible();
+
+      // eslint-disable-next-line no-await-in-loop
+      await waitUntilOnline();
+
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await fetch(healthzUrl, { signal: AbortSignal.timeout(HEALTHZ_TIMEOUT_MS) });
+        if (response.ok) healthy = true;
+      } catch {
+        // ignore
+      }
+
+      if (!healthy) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(HEALTHZ_RETRY_DELAY_MS);
+      }
+    }
+
+    // Always back off before reconnecting, even when healthy
+    const backoff = WS_RETRY_BACKOFF_MS + Math.random() * WS_RETRY_BACKOFF_JITTER_MS; // 3–5s jitter
+    await sleep(backoff);
+  };
+};
 
 /**
  * Shared items
@@ -32,49 +94,15 @@ import { getBasename, joinPaths } from '@/lib/util';
 
 const basename = getBasename();
 
-/**
- * Helper function to poll healthz endpoint until server is available.
- * Uses recursion instead of a while loop to satisfy ESLint no-await-in-loop rule.
- */
-const waitForHealthyServer = (basepath: string): Promise<void> => {
-  const healthzUrl = new URL(joinPaths(basepath, 'healthz'), window.location.origin).toString();
-
-  const poll = (): Promise<void> =>
-    fetch(healthzUrl)
-      .then((response) => {
-        if (response.ok) {
-          // Server is up, allow WebSocket reconnection
-          return;
-        }
-        // Server returned non-OK, wait and retry
-        return new Promise<void>((resolve) => {
-          setTimeout(() => {
-            resolve(poll());
-          }, 3000);
-        });
-      })
-      .catch(
-        () =>
-          // Server is down, wait and retry
-          new Promise<void>((resolve) => {
-            setTimeout(() => {
-              resolve(poll());
-            }, 3000);
-          }),
-      );
-
-  return poll();
-};
-
-const wsClientOptions: ClientOptions = {
+const wsClientOptions = (basepath: string): ClientOptions => ({
   url: '',
   lazy: true,
   connectionAckWaitTimeout: 3000,
   keepAlive: 3000,
   retryAttempts: Infinity,
   shouldRetry: () => true,
-  retryWait: () => waitForHealthyServer(basename),
-};
+  retryWait: createRetryWait(basepath),
+});
 
 const errorLink = new ErrorLink(({ error }) => {
   if (CombinedGraphQLErrors.is(error)) {
@@ -115,7 +143,7 @@ const createLink = (basepath: string) => {
 
   // Create wsClient
   const wsClient = createClient({
-    ...wsClientOptions,
+    ...wsClientOptions(basepath),
     url: uri.replace(/^(http)/, 'ws'),
   });
 

--- a/dashboard-ui/src/lib/util.ts
+++ b/dashboard-ui/src/lib/util.ts
@@ -18,6 +18,15 @@ import { twMerge } from 'tailwind-merge';
 import { config } from '@/app-config';
 
 /**
+ * Sleep method
+ */
+
+export const sleep = async (timeoutMs: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, timeoutMs);
+  });
+
+/**
  * Python-like counter class
  */
 

--- a/dashboard-ui/vite.config.ts
+++ b/dashboard-ui/vite.config.ts
@@ -49,6 +49,9 @@ export default ({ mode }: { mode: string }) => {
           target: backendTarget,
           ws: true,
         },
+        '^/healthz': {
+          target: backendTarget,
+        },
       },
     },
     build: {


### PR DESCRIPTION
Closes #1068

## Summary

Fix slow WebSocket reconnection in Firefox after server restart. Firefox applies an exponential backoff penalty based on the number of failed WebSocket connection attempts, not timing. This caused the dashboard to take a long time to reconnect after the server came back up.

## Key Changes

- Add `waitForHealthyServer()` helper function that polls the `/healthz` endpoint every 3 seconds
- Modify `retryWait` in `wsClientOptions` to use HTTP health check gating instead of a simple timeout
- Export `dashboardWSClient` for use by the WebSocket-based status monitoring in `server-status.ts`

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
