### PR TITLE
✨ Harden cluster-api authentication and transport

### DIFF
--- a/config/default/cluster-api.yaml
+++ b/config/default/cluster-api.yaml
@@ -100,20 +100,6 @@ cluster-agent:
     #
     server-name: ""
 
-## csrf ##
-#
-# CSRF protection settings
-#
-csrf:
-
-  ## enabled ##
-  #
-  # Whether CSRF protection is enabled.
-  #
-  # Default value: true
-  #
-  enabled: true
-
 ## logging ##
 #
 # Configuration for the API server's logging output

--- a/modules/cluster-api/README.md
+++ b/modules/cluster-api/README.md
@@ -31,7 +31,6 @@ The Kubetail Cluster API executable can be configured using a configuration file
 | cluster-api.cluster-agent.tls.key-file            | string   | Path to tls key file                               | ""                                          | alpha  |  
 | cluster-api.cluster-agent.tls.ca-file             | string   | Path to tls CA bundle file                         | ""                                          | alpha  |
 | cluster-api.cluster-agent.tls.server-name         | string   | Server name for conection verification             | ""                                          | alpha  |
-| cluster-api.csrf.enabled                          | bool     | Enable CSRF protection                             | true                                        | stable |
 | cluster-api.logging.enabled                       | bool     | Enable logging                                     | true                                        | stable |
 | cluster-api.logging.level                         | string   | Log level                                          | "info"                                      | stable |
 | cluster-api.logging.format                        | string   | Log format (json, pretty)                          | "json"                                      | stable |

--- a/modules/cluster-api/cmd/main.go
+++ b/modules/cluster-api/cmd/main.go
@@ -94,11 +94,10 @@ func main() {
 
 			// Create server
 			server := &http.Server{
-				Addr:         cfg.Addr,
-				Handler:      app,
-				IdleTimeout:  1 * time.Minute,
-				ReadTimeout:  5 * time.Second,
-				WriteTimeout: 1 * time.Minute,
+				Addr:        cfg.Addr,
+				Handler:     app,
+				IdleTimeout: 1 * time.Minute,
+				ReadTimeout: 5 * time.Second,
 			}
 
 			// Register shutdown hook so long-lived connections are notified before

--- a/modules/cluster-api/graph/schema.resolvers.go
+++ b/modules/cluster-api/graph/schema.resolvers.go
@@ -28,6 +28,10 @@ import (
 
 // LogMetadataList is the resolver for the logMetadataList field.
 func (r *queryResolver) LogMetadataList(ctx context.Context, namespace *string) (*clusteragentpb.LogMetadataList, error) {
+	if _, err := r.getBearerTokenRequired(ctx); err != nil {
+		return nil, gqlerrors.ErrUnauthenticated
+	}
+
 	// Deref namespace
 	nsList, err := k8shelpers.DerefNamespaceToList(r.allowedNamespaces, namespace, metav1.NamespaceDefault)
 	if err != nil {
@@ -190,6 +194,10 @@ func (r *queryResolver) LogRecordsFetch(ctx context.Context, kubeContext *string
 
 // LogMetadataWatch is the resolver for the logMetadataWatch field.
 func (r *subscriptionResolver) LogMetadataWatch(ctx context.Context, namespace *string) (<-chan *clusteragentpb.LogMetadataWatchEvent, error) {
+	if _, err := r.getBearerTokenRequired(ctx); err != nil {
+		return nil, gqlerrors.ErrUnauthenticated
+	}
+
 	// Deref namespaces
 	nsList, err := k8shelpers.DerefNamespaceToList(r.allowedNamespaces, namespace, metav1.NamespaceDefault)
 	if err != nil {

--- a/modules/cluster-api/graph/schema.resolvers_test.go
+++ b/modules/cluster-api/graph/schema.resolvers_test.go
@@ -34,3 +34,15 @@ func TestLogRecordsFollowRequiresToken(t *testing.T) {
 	_, err := r.LogRecordsFollow(context.Background(), nil, nil, nil, nil, nil, nil)
 	assert.ErrorIs(t, gqlerrors.ErrUnauthenticated, err)
 }
+
+func TestLogMetadataListRequiresToken(t *testing.T) {
+	r := &queryResolver{}
+	_, err := r.LogMetadataList(context.Background(), nil)
+	assert.ErrorIs(t, gqlerrors.ErrUnauthenticated, err)
+}
+
+func TestLogMetadataWatchRequiresToken(t *testing.T) {
+	r := &subscriptionResolver{}
+	_, err := r.LogMetadataWatch(context.Background(), nil)
+	assert.ErrorIs(t, gqlerrors.ErrUnauthenticated, err)
+}

--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -17,6 +17,7 @@ package graph
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,6 +57,16 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 
 	// Init handler
 	h := handler.New(schema)
+
+	// SSE transport for browser-side subscriptions. Auth rides on the POST
+	// like any other GraphQL request (browsers can't set headers on a WS
+	// upgrade), so authenticationMiddleware-injected tokens reach resolvers
+	// the same way as for queries/mutations. Registered before POST so that
+	// requests with `Accept: text/event-stream` aren't claimed by the POST
+	// transport's broader media-type match.
+	h.AddTransport(transport.SSE{
+		KeepAlivePingInterval: 10 * time.Second,
+	})
 
 	// Add transports from NewDefaultServer()
 	h.AddTransport(transport.GET{})
@@ -114,14 +125,17 @@ func (s *Server) Close() error {
 }
 
 // ServeHTTP delegates to the underlying handler, tracking all active
-// requests so DrainWithContext can wait for them to finish. For WebSocket
-// upgrades the request context is also cancelled on shutdown, which
-// triggers gqlgen's closeOnCancel to cleanly close the connection.
+// requests so DrainWithContext can wait for them to finish. Long-lived
+// connections (WebSocket upgrades and SSE streams) also get their request
+// context cancelled on shutdown so gqlgen can close them cleanly.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	if r.Header.Get("Upgrade") != "" {
+	isLongLived := r.Header.Get("Upgrade") != "" ||
+		strings.Contains(r.Header.Get("Accept"), "text/event-stream")
+
+	if isLongLived {
 		ctx, cancel := context.WithCancel(r.Context())
 		defer cancel()
 		go func() {

--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -17,7 +17,6 @@ package graph
 import (
 	"context"
 	"net/http"
-	"slices"
 	"sync"
 	"time"
 
@@ -32,8 +31,6 @@ import (
 
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
-
-	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
 // Represents Server
@@ -44,12 +41,8 @@ type Server struct {
 	wg         sync.WaitGroup
 }
 
-// allowedSecFetchSite defines the secure values for the Sec-Fetch-Site header.
-// It's defined at the package level to avoid re-allocation on every WebSocket upgrade request.
-var allowedSecFetchSite = []string{"same-origin"}
-
 // Create new Server instance
-func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.Dispatcher, allowedNamespaces []string) *Server {
+func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.Dispatcher, allowedNamespaces []string) *Server {
 	// Init resolver
 	r := &Resolver{cm, grpcDispatcher, allowedNamespaces}
 
@@ -70,25 +63,15 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager, grpcDispatch
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	// Configure WebSocket (without CORS)
+	// Configure WebSocket. The cluster-api is intended for bot/programmatic
+	// clients, not browsers. Bots don't send Origin; browsers always do on a
+	// WebSocket upgrade. The dashboard's reverse proxy strips Origin before
+	// forwarding (after enforcing its own CSRF check), so its presence here
+	// indicates a direct browser connection — reject as CSWSH defense.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				// Allow all if CSRF protection is disabled
-				if !cfg.CSRF.Enabled {
-					return true
-				}
-
-				secFetchSite := r.Header.Get("Sec-Fetch-Site")
-
-				// If empty, request is from non-browser or legacy browser
-				if secFetchSite == "" {
-					return true
-				}
-
-				// Check the Sec-Fetch-Site header as our primary defense against
-				// Cross-Site WebSocket Hijacking (CSWSH)
-				return slices.Contains(allowedSecFetchSite, secFetchSite)
+				return r.Header.Get("Origin") == ""
 			},
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,

--- a/modules/cluster-api/graph/server_test.go
+++ b/modules/cluster-api/graph/server_test.go
@@ -22,10 +22,32 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 )
+
+func TestServerSSETransportServesQueries(t *testing.T) {
+	s := NewServer(nil, nil, []string{})
+
+	client := testutils.NewWebTestClient(t, s)
+	defer client.Teardown()
+
+	req := client.NewRequest("POST", "/graphql", strings.NewReader(`{"query":"{ __typename }"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp := client.Do(req)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/event-stream")
+
+	body := string(resp.Body)
+	assert.Contains(t, body, "event: next", "expected SSE next event")
+	assert.Contains(t, body, `"__typename":"Query"`, "expected query result in next event payload")
+	assert.Contains(t, body, "event: complete", "expected SSE complete event")
+}
 
 func TestServerWebSocketCheckOrigin(t *testing.T) {
 	tests := []struct {

--- a/modules/cluster-api/graph/server_test.go
+++ b/modules/cluster-api/graph/server_test.go
@@ -25,78 +25,43 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubetail-org/kubetail/modules/shared/testutils"
-
-	"github.com/kubetail-org/kubetail/modules/cluster-api/pkg/config"
 )
 
-func TestServer(t *testing.T) {
+func TestServerWebSocketCheckOrigin(t *testing.T) {
 	tests := []struct {
-		name           string
-		setCsrfEnabled bool
-		setHeader      http.Header
-		wantStatus     int
+		name       string
+		setHeader  http.Header
+		wantStatus int
 	}{
 		{
-			"csrf disabled, non-browser client",
-			false,
+			"bot client (no Origin) is accepted",
 			http.Header{},
 			http.StatusSwitchingProtocols,
 		},
 		{
-			"csrf disabled, same-origin request",
-			false,
-			http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf disabled, cross-site request",
-			false,
-			http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, non-browser client",
-			true,
-			http.Header{},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, same-origin request",
-			true,
-			http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
-			http.StatusSwitchingProtocols,
-		},
-		{
-			"csrf enabled, cross-site request",
-			true,
-			http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
+			"browser client (Origin set) is rejected",
+			http.Header{"Origin": []string{"https://evil.example.com"}},
 			http.StatusForbidden,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := config.DefaultConfig()
-			cfg.CSRF.Enabled = tt.setCsrfEnabled
-
-			graphqlServer := NewServer(cfg, nil, nil, []string{})
+			graphqlServer := NewServer(nil, nil, []string{})
 
 			client := testutils.NewWebTestClient(t, graphqlServer)
 			defer client.Teardown()
 
-			// init websocket connection
 			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
 			_, resp, _ := websocket.DefaultDialer.Dial(u, tt.setHeader)
 
-			// check status code
 			require.Equal(t, tt.wantStatus, resp.StatusCode)
 		})
 	}
 }
 
 func TestServerDrainWithContext_NoConnections(t *testing.T) {
-	cfg := config.DefaultConfig()
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -106,8 +71,7 @@ func TestServerDrainWithContext_NoConnections(t *testing.T) {
 }
 
 func TestServerDrainWithContext_CancelledContext(t *testing.T) {
-	cfg := config.DefaultConfig()
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	// Simulate an open connection that never finishes
 	s.wg.Add(1)
@@ -121,8 +85,7 @@ func TestServerDrainWithContext_CancelledContext(t *testing.T) {
 }
 
 func TestServerDrainWithContext_DeadlineExceeded(t *testing.T) {
-	cfg := config.DefaultConfig()
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	// Simulate an open connection that never finishes
 	s.wg.Add(1)
@@ -136,8 +99,7 @@ func TestServerDrainWithContext_DeadlineExceeded(t *testing.T) {
 }
 
 func TestServerDrainWithContext_WaitsForHTTPRequests(t *testing.T) {
-	cfg := config.DefaultConfig()
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	client := testutils.NewWebTestClient(t, s)
 	defer client.Teardown()
@@ -155,10 +117,7 @@ func TestServerDrainWithContext_WaitsForHTTPRequests(t *testing.T) {
 }
 
 func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.CSRF.Enabled = true
-
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	client := testutils.NewWebTestClient(t, s)
 	defer client.Teardown()
@@ -196,10 +155,7 @@ func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 }
 
 func TestServerNotifyShutdown_ClosesMultipleConnections(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.CSRF.Enabled = true
-
-	s := NewServer(cfg, nil, nil, []string{})
+	s := NewServer(nil, nil, []string{})
 
 	client := testutils.NewWebTestClient(t, s)
 	defer client.Teardown()

--- a/modules/cluster-api/internal/app/app.go
+++ b/modules/cluster-api/internal/app/app.go
@@ -126,7 +126,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 		dynamicRoutes.Use(authenticationMiddleware)
 
 		// GraphQL endpoint
-		app.graphqlServer = graph.NewServer(cfg, app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)
+		app.graphqlServer = graph.NewServer(app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)
 		dynamicRoutes.Any("/graphql", gin.WrapH(app.graphqlServer))
 
 		// Log download endpoint

--- a/modules/cluster-api/internal/app/app_test.go
+++ b/modules/cluster-api/internal/app/app_test.go
@@ -16,14 +16,17 @@ package app
 
 import (
 	"compress/gzip"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestID(t *testing.T) {
@@ -77,6 +80,41 @@ func TestGzip(t *testing.T) {
 	uncompressed, err := io.ReadAll(gzreader)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "ok", string(uncompressed))
+}
+
+func TestGraphQLRejectsUnauthenticatedSensitiveQuery(t *testing.T) {
+	app := NewTestApp(nil)
+
+	body := `{"query":"{ logRecordsFetch(sources: [\"default:pod/x\"]) { records { message } } }"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/graphql", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	var resp struct {
+		Errors []struct {
+			Message    string         `json:"message"`
+			Extensions map[string]any `json:"extensions"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Errors, "expected at least one GraphQL error, body=%q", w.Body.String())
+	assert.Equal(t, "KUBETAIL_UNAUTHENTICATED", resp.Errors[0].Extensions["code"])
+}
+
+func TestGraphQLAllowsUnauthenticatedIntrospection(t *testing.T) {
+	app := NewTestApp(nil)
+
+	body := `{"query":"{ __typename }"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/graphql", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	assert.Contains(t, w.Body.String(), `"__typename":"Query"`)
 }
 
 func TestHealthz(t *testing.T) {

--- a/modules/cluster-api/internal/app/testutils_test.go
+++ b/modules/cluster-api/internal/app/testutils_test.go
@@ -31,7 +31,6 @@ func NewTestConfig() *config.Config {
 	cfg := config.DefaultConfig()
 	cfg.BasePath = "/"
 	cfg.Logging.AccessLog.Enabled = false
-	cfg.CSRF.Enabled = false
 	return cfg
 }
 

--- a/modules/cluster-api/pkg/config/config.go
+++ b/modules/cluster-api/pkg/config/config.go
@@ -32,10 +32,6 @@ type Config struct {
 	GinMode  string `mapstructure:"gin-mode" validate:"omitempty,oneof=debug release"`
 	BasePath string `mapstructure:"base-path"`
 
-	CSRF struct {
-		Enabled bool
-	}
-
 	ClusterAgent struct {
 		DispatchUrl string `mapstructure:"dispatch-url"`
 		TLS         struct {
@@ -77,8 +73,6 @@ func DefaultConfig() *Config {
 	cfg.Addr = ":8080"
 	cfg.BasePath = "/"
 	cfg.GinMode = "release"
-
-	cfg.CSRF.Enabled = true
 
 	cfg.ClusterAgent.DispatchUrl = "kubernetes://kubetail-cluster-agent:50051"
 	cfg.ClusterAgent.TLS.Enabled = false

--- a/modules/cluster-api/static/graphiql.html
+++ b/modules/cluster-api/static/graphiql.html
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Kubetail API Playground</title>
     <style>
-      body {
-        height: 100%;
-        margin: 0;
-        width: 100%;
-      }
-
-      #graphiql {
-        height: 100vh;
-      }
+      html, body { height: 100%; margin: 0; }
+      #graphiql { height: 100vh; }
     </style>
+
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/graphiql@3.0.6/graphiql.min.css"
+      integrity="sha256-wTzfn13a+pLMB5rMeysPPR1hO7x0SwSeQI+cnw7VdbE="
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+
     <script
       src="https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js"
       integrity="sha256-S0lp+k7zWUMk2ixteM6HZvu8L9Eh//OVrt+ZfbCpmgY="
@@ -24,47 +28,88 @@
       integrity="sha256-IXWO0ITNDjfnNXIu5POVfqlgYoop36bDzhodR6LW5Pc="
       crossorigin="anonymous"
     ></script>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/graphiql@3.0.6/graphiql.min.css"
-      integrity="sha256-wTzfn13a+pLMB5rMeysPPR1hO7x0SwSeQI+cnw7VdbE="
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <div id="graphiql">Loading...</div>
-    <script 
+    <script
       src="https://cdn.jsdelivr.net/npm/graphiql@3.0.6/graphiql.min.js"
       integrity="sha256-eNxH+Ah7Z9up9aJYTQycgyNuy953zYZwE9Rqf5rH+r4="
       crossorigin="anonymous"
     ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/graphql-sse@2.6.0/umd/graphql-sse.min.js"
+      integrity="sha256-a+2EpA5Vqk6slVhDOndlnAW/kOEyOdRRho3jC/80c3U="
+      crossorigin="anonymous"
+    ></script>
+
     <script>
-      (async () => {
-        let basePath;
+      // Resolve the base path so this page works behind a `/proxy/` prefix.
+      function getBasePath() {
+        const match = window.location.pathname.match(/^.*?\/proxy\//);
+        return match ? match[0] : '/';
+      }
 
-        // get basePath
-        const pathname = window.location.pathname;
-        if (pathname.includes('/proxy/')) {
-          const m = pathname.match(/^(.*?)\/proxy\//);
-          if (m) basePath = m[0];
-        } else {
-          basePath = '/';
+      // Detect whether a GraphQL request is a subscription operation.
+      function isSubscription({ query, operationName }) {
+        try {
+          const doc = GraphiQL.GraphQL.parse(query);
+          const op = doc.definitions.find(
+            (d) => d.kind === 'OperationDefinition'
+              && (!operationName || d.name?.value === operationName),
+          );
+          return op?.operation === 'subscription';
+        } catch {
+          return false;
         }
+      }
 
-        // get graphql endpoint
-        const graphqlEndpoint = (new URL(basePath + 'graphql', window.location.origin)).toString();
-
-        // init fetcher
-        const fetcher = GraphiQL.createFetcher({
-          url: graphqlEndpoint,
-          subscriptionUrl: graphqlEndpoint.replace(/^(http)/, 'ws'),
+      // SSE fetcher — a fresh client is created per subscription so the latest
+      // headers from GraphiQL's editor are picked up each time.
+      function createSseFetcher(url) {
+        return (graphQLParams, opts) => ({
+          subscribe(sink) {
+            const client = graphqlSse.createClient({
+              url,
+              headers: opts?.headers ?? {},
+              singleConnection: false,
+              lazy: true,
+            });
+            const dispose = client.subscribe(graphQLParams, {
+              next: (val) => sink.next(val),
+              error: (err) => sink.error(err),
+              complete: () => sink.complete(),
+            });
+            return {
+              unsubscribe() {
+                dispose();
+                client.dispose();
+              },
+            };
+          },
         });
+      }
 
-        ReactDOM.render(
-          React.createElement(GraphiQL, { fetcher }),
-          document.getElementById('graphiql'),
-        );
-      })();
+      // Route queries/mutations over HTTP and subscriptions over SSE.
+      function createFetcher(url) {
+        const httpFetcher = GraphiQL.createFetcher({ url });
+        const sseFetcher = createSseFetcher(url);
+        return (graphQLParams, opts) =>
+          (isSubscription(graphQLParams) ? sseFetcher : httpFetcher)(graphQLParams, opts);
+      }
+
+      const graphqlEndpoint = new URL(
+        `${getBasePath()}graphql`,
+        window.location.origin,
+      ).toString();
+
+      ReactDOM.createRoot(document.getElementById('graphiql')).render(
+        React.createElement(GraphiQL, {
+          fetcher: createFetcher(graphqlEndpoint),
+          defaultHeaders: JSON.stringify(
+            { Authorization: 'Bearer <paste-token>' },
+            null,
+            2,
+          ),
+          defaultEditorToolsVisibility: true,
+        }),
+      );
     </script>
   </body>
 </html>

--- a/modules/dashboard/internal/cluster-api/proxy.go
+++ b/modules/dashboard/internal/cluster-api/proxy.go
@@ -139,6 +139,11 @@ func (p *DesktopProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Header.Add("X-Forwarded-Authorization", fmt.Sprintf("Bearer %s", token))
 
+	// Strip the browser-supplied Origin so the cluster-api can treat its
+	// presence as a CSWSH signal. Cross-site browser requests are already
+	// rejected by csrfProtectionMiddleware before reaching this proxy.
+	r.Header.Del("Origin")
+
 	// Passthrough upgrade requests, closing the hijacked connection on shutdown
 	if r.Header.Get("Upgrade") != "" {
 		hw := &hijackTrackingResponseWriter{ResponseWriter: w}
@@ -335,6 +340,11 @@ func newInClusterProxy(clusterAPIEndpoint string, pathPrefix string, transport h
 			if token, ok := r.Context().Value(k8shelpers.K8STokenCtxKey).(string); ok {
 				r.Header.Set("X-Forwarded-Authorization", fmt.Sprintf("Bearer %s", token))
 			}
+
+			// Strip the browser-supplied Origin so the cluster-api can treat its
+			// presence as a CSWSH signal. Cross-site browser requests are already
+			// rejected by csrfProtectionMiddleware before reaching this proxy.
+			r.Header.Del("Origin")
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			// Re-write cookie path

--- a/modules/dashboard/internal/cluster-api/proxy_test.go
+++ b/modules/dashboard/internal/cluster-api/proxy_test.go
@@ -24,9 +24,36 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
+
+func TestInClusterProxy_StripsOriginHeader(t *testing.T) {
+	var capturedOrigin string
+	var captured bool
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedOrigin = r.Header.Get("Origin")
+		captured = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
+	req.Header.Set("Origin", "https://browser.example.com")
+
+	proxy.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, captured, "backend was not called")
+	assert.Empty(t, capturedOrigin, "Origin header must be stripped before forwarding")
+}
 
 func TestInClusterProxy_XForwardedAuthorization(t *testing.T) {
 	tests := []struct {
@@ -217,6 +244,44 @@ func TestInClusterProxy_NotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 }
 
 // --- DesktopProxy drain/shutdown tests ---
+
+func TestDesktopProxy_StripsOriginHeader(t *testing.T) {
+	var capturedOrigin string
+	var captured bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedOrigin = r.Header.Get("Origin")
+		captured = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	clientset := fake.NewSimpleClientset()
+	clientset.Fake.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenRequest{
+			Status: authv1.TokenRequestStatus{
+				Token:               "fake-sat",
+				ExpirationTimestamp: metav1.NewTime(time.Now().Add(time.Hour)),
+			},
+		}, nil
+	})
+
+	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
+	sat, err := k8shelpers.NewServiceAccountToken(context.Background(), clientset, "ns", "sa", shutdownCh)
+	require.NoError(t, err)
+
+	proxy, err := NewDesktopProxy(nil, "/prefix")
+	require.NoError(t, err)
+	proxy.phCache["ctx"] = handler
+	proxy.satCache["ctx/ns"] = sat
+
+	req := httptest.NewRequest(http.MethodGet, "/prefix/ctx/ns/svc/relpath", nil)
+	req.Header.Set("Origin", "https://browser.example.com")
+
+	proxy.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, captured, "backend handler was not called")
+	assert.Empty(t, capturedOrigin, "Origin header must be stripped before forwarding")
+}
 
 func TestDesktopProxy_DrainWithContext_NoConnections(t *testing.T) {
 	proxy, err := NewDesktopProxy(nil, "/prefix")


### PR DESCRIPTION
## Summary

The cluster-api is intended for bot/programmatic clients, not browsers, so the previous `Sec-Fetch-Site` WebSocket check was the wrong primitive. This PR replaces that with strict per-resolver token enforcement and a CSWSH defense that leans on the dashboard's reverse proxy. It also adds an SSE transport so authenticated subscriptions work from a browser (which can't set headers on a WebSocket upgrade).

## Key Changes

- WebSocket `CheckOrigin` now accepts requests with no `Origin` (bots) and rejects when one is set (direct browser connections). The dashboard's proxy strips `Origin` after `csrfProtectionMiddleware` enforces same-origin, so legitimate dashboard-fronted traffic still passes.
- `LogMetadataList` and `LogMetadataWatch` now call `getBearerTokenRequired`, matching `LogRecordsFetch` and `LogRecordsFollow`.
- Remove `cfg.CSRF`, its yaml section, the README row, and the now-unused `cfg` arg to `graph.NewServer`.
- Register an SSE GraphQL transport so browsers can run subscriptions over authenticated POSTs; treat SSE streams as long-lived for graceful shutdown and drop the server `WriteTimeout` that would otherwise cut streams short.
- Update the GraphiQL playground to route subscriptions through `graphql-sse` while keeping queries and mutations on HTTP.
- Tests: app-level integration test confirms `/graphql` rejects an unauthenticated `logRecordsFetch` while introspection still passes; cluster-api tests cover `CheckOrigin` accept/reject and SSE transport delivery; dashboard proxy tests confirm `Origin` is stripped on both `InClusterProxy` and `DesktopProxy` paths.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused