### PR TITLE
✨ Harden WebSocket security with same-origin checks

### DIFF
--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -83,9 +83,10 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	// Configure WebSocket. The app-level Sec-Fetch-Site middleware also gates
-	// this route, but Chrome does not send Sec-Fetch-Site on WebSocket upgrade
-	// requests, so we additionally enforce a same-origin Origin check here.
+	// Configure WebSocket. The app-level Sec-Fetch-Site CSRF middleware does
+	// not gate WebSocket upgrades (safe methods are skipped, since Chrome
+	// does not send Sec-Fetch-Site on upgrade requests), so CSWSH defense
+	// happens here via a same-origin Origin check.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
 			CheckOrigin:       httphelpers.IsSameOrigin,

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/versioncheck"
 
@@ -82,14 +83,12 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
-	// Configure WebSocket. CSRF / CSWSH protection is enforced by the app-level
-	// Sec-Fetch-Site middleware before the request reaches this handler, so we
-	// allow all origins here.
+	// Configure WebSocket. The app-level Sec-Fetch-Site middleware also gates
+	// this route, but Chrome does not send Sec-Fetch-Site on WebSocket upgrade
+	// requests, so we additionally enforce a same-origin Origin check here.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				return true
-			},
+			CheckOrigin:       httphelpers.IsSameOrigin,
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
 			EnableCompression: true,

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -40,6 +40,50 @@ func TestServerDrainWithContext_NoConnections(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestServerWebSocketCheckOrigin(t *testing.T) {
+	cfg := config.DefaultConfig()
+	s := NewServer(cfg, nil)
+
+	client := testutils.NewWebTestClient(t, s)
+	defer client.Teardown()
+
+	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+	httpHost := strings.TrimPrefix(client.Server.URL, "http://")
+
+	tests := []struct {
+		name       string
+		setOrigin  string
+		wantStatus int
+	}{
+		{
+			"no Origin is rejected",
+			"",
+			http.StatusForbidden,
+		},
+		{
+			"same-origin Origin is accepted",
+			"http://" + httpHost,
+			http.StatusSwitchingProtocols,
+		},
+		{
+			"cross-origin Origin is rejected",
+			"https://evil.example.com",
+			http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			if tt.setOrigin != "" {
+				header.Set("Origin", tt.setOrigin)
+			}
+			_, resp, _ := websocket.DefaultDialer.Dial(wsURL, header)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
 func TestServerDrainWithContext_CancelledContext(t *testing.T) {
 	cfg := config.DefaultConfig()
 	s := NewServer(cfg, nil)
@@ -100,7 +144,7 @@ func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 	// Dial WebSocket with graphql-transport-ws subprotocol
 	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
 	dialer := websocket.Dialer{Subprotocols: []string{"graphql-transport-ws"}}
-	conn, _, err := dialer.Dial(wsURL, nil)
+	conn, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{client.Server.URL}})
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -145,7 +189,7 @@ func TestServerNotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 
 	// Open multiple WebSocket connections
 	for i := range numConns {
-		conn, _, err := dialer.Dial(wsURL, nil)
+		conn, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{client.Server.URL}})
 		require.NoError(t, err)
 		defer conn.Close()
 

--- a/modules/dashboard/internal/cluster-api/proxy.go
+++ b/modules/dashboard/internal/cluster-api/proxy.go
@@ -149,8 +149,9 @@ func (p *DesktopProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Header.Add("X-Forwarded-Authorization", fmt.Sprintf("Bearer %s", token))
 
 	// Strip the browser-supplied Origin so the cluster-api can treat its
-	// presence as a CSWSH signal. Cross-site browser requests are already
-	// rejected by csrfProtectionMiddleware before reaching this proxy.
+	// presence as a CSWSH signal. Cross-origin browser upgrades are already
+	// rejected by the same-origin gate above; cross-site non-upgrade browser
+	// requests are rejected by csrfProtectionMiddleware before reaching here.
 	r.Header.Del("Origin")
 
 	// Passthrough upgrade requests, closing the hijacked connection on shutdown
@@ -359,8 +360,10 @@ func newInClusterProxy(clusterAPIEndpoint string, pathPrefix string, transport h
 			}
 
 			// Strip the browser-supplied Origin so the cluster-api can treat its
-			// presence as a CSWSH signal. Cross-site browser requests are already
-			// rejected by csrfProtectionMiddleware before reaching this proxy.
+			// presence as a CSWSH signal. Cross-origin browser upgrades are
+			// already rejected by the same-origin gate; cross-site non-upgrade
+			// browser requests are rejected by csrfProtectionMiddleware before
+			// reaching here.
 			r.Header.Del("Origin")
 		},
 		ModifyResponse: func(resp *http.Response) error {

--- a/modules/dashboard/internal/cluster-api/proxy.go
+++ b/modules/dashboard/internal/cluster-api/proxy.go
@@ -30,6 +30,7 @@ import (
 
 	"k8s.io/kubectl/pkg/proxy"
 
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
@@ -94,6 +95,14 @@ func (p *DesktopProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Track connections for graceful shutdown
 	p.wg.Add(1)
 	defer p.wg.Done()
+
+	// CSWSH defense for WebSocket upgrades. Chrome does not send
+	// Sec-Fetch-Site on upgrade requests, so the app-level CSRF middleware
+	// can't gate them; check Origin directly here instead.
+	if r.Header.Get("Upgrade") != "" && !httphelpers.IsSameOrigin(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 
 	origPath := r.URL.Path
 
@@ -281,6 +290,14 @@ type InClusterProxy struct {
 func (p *InClusterProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.wg.Add(1)
 	defer p.wg.Done()
+
+	// CSWSH defense for WebSocket upgrades. Chrome does not send
+	// Sec-Fetch-Site on upgrade requests, so the app-level CSRF middleware
+	// can't gate them; check Origin directly here instead.
+	if r.Header.Get("Upgrade") != "" && !httphelpers.IsSameOrigin(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 
 	if r.Header.Get("Upgrade") != "" {
 		hw := &hijackTrackingResponseWriter{ResponseWriter: w}

--- a/modules/dashboard/internal/cluster-api/proxy_test.go
+++ b/modules/dashboard/internal/cluster-api/proxy_test.go
@@ -47,12 +47,50 @@ func TestInClusterProxy_StripsOriginHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
-	req.Header.Set("Origin", "https://browser.example.com")
+	// httptest.NewRequest uses example.com as the request Host
+	req.Header.Set("Origin", "https://example.com")
 
 	proxy.ServeHTTP(httptest.NewRecorder(), req)
 
 	require.True(t, captured, "backend was not called")
 	assert.Empty(t, capturedOrigin, "Origin header must be stripped before forwarding")
+}
+
+func TestInClusterProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+	}{
+		{"cross-origin Origin", "https://evil.example.com"},
+		{"missing Origin", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured bool
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
+			req.Header.Set("Upgrade", "websocket")
+			req.Header.Set("Connection", "Upgrade")
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			rec := httptest.NewRecorder()
+			proxy.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			assert.False(t, captured, "backend must not be reached on cross-origin upgrade")
+		})
+	}
 }
 
 func TestInClusterProxy_XForwardedAuthorization(t *testing.T) {
@@ -164,6 +202,12 @@ func newWSBackend(t *testing.T) (*httptest.Server, <-chan struct{}) {
 	return backend, connected
 }
 
+// wsOriginHeader returns an Origin header matching the given server URL, so
+// a WebSocket dial passes the proxy's same-origin gate.
+func wsOriginHeader(serverURL string) http.Header {
+	return http.Header{"Origin": []string{serverURL}}
+}
+
 // waitConnected waits for the backend to accept a connection or fails the test.
 func waitConnected(t *testing.T, connected <-chan struct{}) {
 	t.Helper()
@@ -185,7 +229,7 @@ func TestInClusterProxy_NotifyShutdown_ClosesConnections(t *testing.T) {
 
 	// Dial WebSocket through the proxy
 	wsURL := "ws" + proxyServer.URL[4:] + "/prefix/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsOriginHeader(proxyServer.URL))
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -220,7 +264,7 @@ func TestInClusterProxy_NotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 	conns := make([]*websocket.Conn, numConns)
 
 	for i := range numConns {
-		conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsOriginHeader(proxyServer.URL))
 		require.NoError(t, err)
 		defer conn.Close()
 		waitConnected(t, connected)
@@ -275,12 +319,50 @@ func TestDesktopProxy_StripsOriginHeader(t *testing.T) {
 	proxy.satCache["ctx/ns"] = sat
 
 	req := httptest.NewRequest(http.MethodGet, "/prefix/ctx/ns/svc/relpath", nil)
-	req.Header.Set("Origin", "https://browser.example.com")
+	// httptest.NewRequest uses example.com as the request Host
+	req.Header.Set("Origin", "https://example.com")
 
 	proxy.ServeHTTP(httptest.NewRecorder(), req)
 
 	require.True(t, captured, "backend handler was not called")
 	assert.Empty(t, capturedOrigin, "Origin header must be stripped before forwarding")
+}
+
+func TestDesktopProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+	}{
+		{"cross-origin Origin", "https://evil.example.com"},
+		{"missing Origin", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured bool
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			proxy, err := NewDesktopProxy(nil, "/prefix")
+			require.NoError(t, err)
+			proxy.phCache["ctx"] = handler
+
+			req := httptest.NewRequest(http.MethodGet, "/prefix/ctx/ns/svc/relpath", nil)
+			req.Header.Set("Upgrade", "websocket")
+			req.Header.Set("Connection", "Upgrade")
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			rec := httptest.NewRecorder()
+			proxy.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			assert.False(t, captured, "backend handler must not be reached on cross-origin upgrade")
+		})
+	}
 }
 
 func TestDesktopProxy_DrainWithContext_NoConnections(t *testing.T) {

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -308,6 +308,9 @@ func TestCSRFProtectionOnWebSocketUpgrade(t *testing.T) {
 			if tt.setSecFetchSite != "" {
 				header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
 			}
+			// Set a same-origin Origin so the WebSocket same-origin gate
+			// (which sits below CSRF) doesn't reject before this test runs.
+			header.Set("Origin", client.Server.URL)
 
 			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
 			_, resp, _ := websocket.DefaultDialer.Dial(u, header)

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -180,26 +180,29 @@ func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
 		setSecFetchSite string
 		wantForbidden   bool
 	}{
+		// CSRF only applies to unsafe methods. Safe-method routes
+		// (GraphQL queries via GET, /api/auth/session) bypass the check;
+		// SOP and same-origin WS gating cover those paths.
 		{
-			"graphql blocks cross-site",
+			"graphql GET cross-site is allowed",
 			"GET",
 			"/graphql",
 			"cross-site",
-			true,
+			false,
 		},
 		{
-			"graphql allows same-origin",
+			"graphql GET allows same-origin",
 			"GET",
 			"/graphql",
 			"same-origin",
 			false,
 		},
 		{
-			"graphql blocks non-browser",
+			"graphql GET non-browser is allowed",
 			"GET",
 			"/graphql",
 			"",
-			true,
+			false,
 		},
 		{
 			"login blocks cross-site",
@@ -223,11 +226,11 @@ func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
 			true,
 		},
 		{
-			"session blocks cross-site",
+			"session GET cross-site is allowed",
 			"GET",
 			"/api/auth/session",
 			"cross-site",
-			true,
+			false,
 		},
 		{
 			"session allows same-origin",
@@ -286,15 +289,17 @@ func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
 	}
 }
 
-func TestCSRFProtectionOnWebSocketUpgrade(t *testing.T) {
+func TestWebSocketUpgradeBypassesCSRF(t *testing.T) {
+	// CSRF middleware skips safe methods, so a WebSocket upgrade (GET) is
+	// not subject to Sec-Fetch-Site — Chrome doesn't send it on upgrades.
+	// Authorization is handled by the WebSocket same-origin gate instead.
 	tests := []struct {
 		name            string
 		setSecFetchSite string
-		wantStatusCode  int
 	}{
-		{"blocks cross-site upgrade", "cross-site", http.StatusForbidden},
-		{"blocks empty upgrade", "", http.StatusForbidden},
-		{"allows same-origin upgrade", "same-origin", http.StatusSwitchingProtocols},
+		{"missing Sec-Fetch-Site upgrades", ""},
+		{"cross-site Sec-Fetch-Site upgrades", "cross-site"},
+		{"same-origin Sec-Fetch-Site upgrades", "same-origin"},
 	}
 
 	for _, tt := range tests {
@@ -308,14 +313,13 @@ func TestCSRFProtectionOnWebSocketUpgrade(t *testing.T) {
 			if tt.setSecFetchSite != "" {
 				header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
 			}
-			// Set a same-origin Origin so the WebSocket same-origin gate
-			// (which sits below CSRF) doesn't reject before this test runs.
+			// Same-origin Origin to satisfy the WebSocket same-origin gate.
 			header.Set("Origin", client.Server.URL)
 
 			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
 			_, resp, _ := websocket.DefaultDialer.Dial(u, header)
 			require.NotNil(t, resp)
-			require.Equal(t, tt.wantStatusCode, resp.StatusCode)
+			require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 		})
 	}
 }

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -30,8 +30,20 @@ import (
 // allowedSecFetchSite defines the secure values for the Sec-Fetch-Site header.
 var allowedSecFetchSite = []string{"same-origin"}
 
+// safeMethods are HTTP methods that don't change state, so they don't need
+// CSRF protection. Cross-origin reads are blocked by the Same-Origin Policy,
+// and skipping them lets WebSocket upgrades through (Chrome does not send
+// Sec-Fetch-Site on upgrade requests, which the WebSocket same-origin gate
+// handles instead).
+var safeMethods = []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+
 func csrfProtectionMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if slices.Contains(safeMethods, c.Request.Method) {
+			c.Next()
+			return
+		}
+
 		if !slices.Contains(allowedSecFetchSite, c.GetHeader("Sec-Fetch-Site")) {
 			c.AbortWithStatus(http.StatusForbidden)
 			return

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -123,24 +123,32 @@ func TestAuthenticationMiddlewareRejectsWhitespaceToken(t *testing.T) {
 func TestCSRFProtectionMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string
+		method         string
 		setHeader      http.Header
 		wantStatusCode int
 	}{
-		{"non-browser client", http.Header{}, http.StatusForbidden},
-		{"same-origin request", http.Header{"Sec-Fetch-Site": []string{"same-origin"}}, http.StatusOK},
-		{"cross-site request", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
+		// Safe methods bypass the check (no state change to protect).
+		{"GET without Sec-Fetch-Site is allowed", "GET", http.Header{}, http.StatusOK},
+		{"GET cross-site is allowed", "GET", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusOK},
+		{"HEAD without Sec-Fetch-Site is allowed", "HEAD", http.Header{}, http.StatusOK},
+		{"OPTIONS without Sec-Fetch-Site is allowed", "OPTIONS", http.Header{}, http.StatusOK},
+		// Unsafe methods enforce same-origin Sec-Fetch-Site.
+		{"POST without Sec-Fetch-Site is blocked", "POST", http.Header{}, http.StatusForbidden},
+		{"POST same-origin is allowed", "POST", http.Header{"Sec-Fetch-Site": []string{"same-origin"}}, http.StatusOK},
+		{"POST cross-site is blocked", "POST", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
+		{"DELETE cross-site is blocked", "DELETE", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := gin.New()
 			router.Use(csrfProtectionMiddleware())
-			router.GET("/", func(c *gin.Context) {
+			router.Any("/", func(c *gin.Context) {
 				c.String(http.StatusOK, "ok")
 			})
 
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "/", nil)
+			r := httptest.NewRequest(tt.method, "/", nil)
 			for k, v := range tt.setHeader {
 				r.Header[k] = v
 			}

--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -16,6 +16,7 @@
 package httphelpers
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,6 +25,12 @@ import (
 // IsSameOrigin reports whether r's Origin header is present and matches
 // the request's scheme and host (per the WebSocket spec's same-origin
 // rule). A missing Origin returns false.
+//
+// Host comparison is case-insensitive and normalizes the effective port,
+// so https://example.com matches a request Host of example.com:443 (and
+// likewise http://example.com matches example.com:80). This avoids
+// false rejections from ingress/reverse proxies that forward an explicit
+// default port in Host.
 //
 // Intended for use on WebSocket upgrade requests, where browsers always
 // send Origin (so its absence indicates a non-browser client, which has
@@ -35,10 +42,41 @@ func IsSameOrigin(r *http.Request) bool {
 		return false
 	}
 	u, err := url.Parse(origin)
-	if err != nil {
+	if err != nil || u.Host == "" {
 		return false
 	}
-	return u.Host == r.Host && u.Scheme == requestScheme(r)
+	scheme := requestScheme(r)
+	if !strings.EqualFold(u.Scheme, scheme) {
+		return false
+	}
+	originHost, originPort := splitHostPort(u.Host, u.Scheme)
+	reqHost, reqPort := splitHostPort(r.Host, scheme)
+	return strings.EqualFold(originHost, reqHost) && originPort == reqPort
+}
+
+// splitHostPort returns the host and effective port for a host[:port]
+// string, falling back to scheme's default port when no port is present.
+// IPv6 brackets are stripped so bracketed and unbracketed literals compare
+// equal.
+func splitHostPort(host, scheme string) (string, string) {
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		return h, p
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return host, defaultPort(scheme)
+}
+
+// defaultPort returns the well-known port for an HTTP-family scheme.
+func defaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	}
+	return ""
 }
 
 // requestScheme returns the scheme the client used to reach r, accounting

--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httphelpers provides shared utilities for working with net/http.
+package httphelpers
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// IsSameOrigin reports whether r's Origin header is present and matches
+// the request's scheme and host (per the WebSocket spec's same-origin
+// rule). A missing Origin returns false.
+//
+// Intended for use on WebSocket upgrade requests, where browsers always
+// send Origin (so its absence indicates a non-browser client, which has
+// no ambient browser credentials to abuse). Do not use on plain HTTP
+// requests: browsers omit Origin on same-origin safe-method fetches.
+func IsSameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host && u.Scheme == requestScheme(r)
+}
+
+// requestScheme returns the scheme the client used to reach r, accounting
+// for TLS terminated at this process (r.TLS) or upstream (X-Forwarded-Proto
+// set by a trusted reverse proxy). Defaults to "http". Browsers cannot
+// override X-Forwarded-Proto on a WebSocket upgrade, so trusting it here
+// is safe for this gate.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
+		if i := strings.IndexByte(p, ','); i >= 0 {
+			p = p[:i]
+		}
+		return strings.ToLower(strings.TrimSpace(p))
+	}
+	return "http"
+}

--- a/modules/shared/httphelpers/httphelpers_test.go
+++ b/modules/shared/httphelpers/httphelpers_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httphelpers
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSameOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		tls    bool
+		xfp    string
+		want   bool
+	}{
+		{"missing Origin is rejected", "example.com", "", false, "", false},
+		{"http same-origin matches", "example.com", "http://example.com", false, "", true},
+		{"https same-origin via TLS termination", "example.com", "https://example.com", true, "", true},
+		{"https same-origin via X-Forwarded-Proto", "example.com", "https://example.com", false, "https", true},
+		{"https Origin on plain http request is rejected", "example.com", "https://example.com", false, "", false},
+		{"http Origin on https request is rejected", "example.com", "http://example.com", true, "", false},
+		{"http Origin on https-by-proxy request is rejected", "example.com", "http://example.com", false, "https", false},
+		{"same-host same-port matches", "example.com:8080", "http://example.com:8080", false, "", true},
+		{"different host is rejected", "example.com", "http://evil.example.com", false, "", false},
+		{"different port is rejected", "example.com:8080", "http://example.com:9090", false, "", false},
+		{"malformed Origin is rejected", "example.com", "://not a url", false, "", false},
+		{"X-Forwarded-Proto list takes first value", "example.com", "https://example.com", false, "https, http", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{
+				Host:   tt.host,
+				Header: http.Header{},
+			}
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			if tt.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if tt.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", tt.xfp)
+			}
+			assert.Equal(t, tt.want, IsSameOrigin(r))
+		})
+	}
+}

--- a/modules/shared/httphelpers/httphelpers_test.go
+++ b/modules/shared/httphelpers/httphelpers_test.go
@@ -43,6 +43,16 @@ func TestIsSameOrigin(t *testing.T) {
 		{"different port is rejected", "example.com:8080", "http://example.com:9090", false, "", false},
 		{"malformed Origin is rejected", "example.com", "://not a url", false, "", false},
 		{"X-Forwarded-Proto list takes first value", "example.com", "https://example.com", false, "https, http", true},
+		{"https default port in Host matches Origin without port", "example.com:443", "https://example.com", true, "", true},
+		{"http default port in Host matches Origin without port", "example.com:80", "http://example.com", false, "", true},
+		{"https default port in Origin matches Host without port", "example.com", "https://example.com:443", true, "", true},
+		{"http default port in Origin matches Host without port", "example.com", "http://example.com:80", false, "", true},
+		{"default port via X-Forwarded-Proto matches", "example.com:443", "https://example.com", false, "https", true},
+		{"non-default port mismatch is rejected even with default normalization", "example.com:8443", "https://example.com", true, "", false},
+		{"host comparison is case-insensitive", "Example.COM", "http://example.com", false, "", true},
+		{"Origin without host is rejected", "example.com", "http://", false, "", false},
+		{"IPv6 same host matches", "[::1]:8080", "http://[::1]:8080", false, "", true},
+		{"IPv6 default port matches", "[::1]:80", "http://[::1]", false, "", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Chrome does not send `Sec-Fetch-Site` on WebSocket upgrade requests, which both blocked legitimate same-origin upgrades from Chrome and left CSWSH protection thin (the dashboard's `Sec-Fetch-Site` middleware was the only CSRF/CSWSH gate). This PR moves CSWSH defense to where the browser actually emits a reliable signal — the `Origin` header on the upgrade — and scopes the `Sec-Fetch-Site` check to the requests that actually need it.

## Key Changes

- Add `modules/shared/httphelpers/IsSameOrigin`: strict same-origin check requiring `Origin` to be present and to match the request's scheme + host. Scheme is determined from `r.TLS` or `X-Forwarded-Proto` so it works behind a TLS-terminating reverse proxy.
- Wire `IsSameOrigin` into the dashboard GraphQL WebSocket `CheckOrigin`, replacing the previous always-true callback.
- Apply `IsSameOrigin` at the entry of cluster-api proxy upgrade requests (both `InClusterProxy` and `DesktopProxy`), rejecting cross-origin and origin-less upgrades before the request is forwarded.
- Scope `csrfProtectionMiddleware` to unsafe HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`). Safe methods (`GET`, `HEAD`, `OPTIONS`) bypass the check, which is what unblocks Chrome's WebSocket upgrades; cross-origin reads remain blocked by SOP and `SameSite=Lax`.
- Update tests across `httphelpers`, `dashboard/graph`, `dashboard/internal/cluster-api`, and `dashboard/pkg/app` to cover the new behavior, including a dedicated test verifying that WebSocket upgrades are no longer subject to `Sec-Fetch-Site`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused