### PR TITLE
✨ Avoid CodeQL superfluous-args warning in preferences test

### DIFF
--- a/dashboard-ui/src/lib/preferences.test.tsx
+++ b/dashboard-ui/src/lib/preferences.test.tsx
@@ -87,29 +87,26 @@ describe('LocalStoragePreferencesBackend', () => {
     expect(prefs).toEqual({ version: 1, theme: 'dark', timezone: 'Asia/Tokyo', timestampFormat: 'rfc3339' });
   });
 
+  function makeStorageEvent(key: string, newValue: string): StorageEvent {
+    const evt = new Event('storage') as StorageEvent;
+    Object.defineProperty(evt, 'key', { value: key });
+    Object.defineProperty(evt, 'newValue', { value: newValue });
+    return evt;
+  }
+
   it('subscribe notifies on cross-tab storage changes', () => {
     const callback = vi.fn();
     const unsubscribe = backend.subscribe(callback);
 
     const updatedPrefs = { version: 1, theme: 'dark', timezone: 'UTC', timestampFormat: 'iso8601' };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedPrefs));
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: STORAGE_KEY,
-        newValue: JSON.stringify(updatedPrefs),
-      }),
-    );
+    window.dispatchEvent(makeStorageEvent(STORAGE_KEY, JSON.stringify(updatedPrefs)));
 
     expect(callback).toHaveBeenCalledWith(updatedPrefs);
 
     unsubscribe();
 
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: STORAGE_KEY,
-        newValue: JSON.stringify({ version: 1, theme: 'light' }),
-      }),
-    );
+    window.dispatchEvent(makeStorageEvent(STORAGE_KEY, JSON.stringify({ version: 1, theme: 'light' })));
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -117,12 +114,7 @@ describe('LocalStoragePreferencesBackend', () => {
     const callback = vi.fn();
     backend.subscribe(callback);
 
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'some-other-key',
-        newValue: 'value',
-      }),
-    );
+    window.dispatchEvent(makeStorageEvent('some-other-key', 'value'));
 
     expect(callback).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Addresses a CodeQL "superfluous trailing arguments" warning on `new StorageEvent('storage', { ... })` in `preferences.test.tsx`. The event is now constructed from `new Event('storage')` with `key` and `newValue` assigned via `Object.defineProperty` before dispatch — preserving the subscriber test logic without the flagged constructor arguments.

## Key Changes

- Add a local `makeStorageEvent(key, newValue)` helper in the `LocalStoragePreferencesBackend` test suite that builds a generic `Event('storage')` and defines `key`/`newValue` on it
- Replace all three `new StorageEvent('storage', { ... })` call sites with the helper

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused