### PR TITLE
🎣 Honor Forwarded proto directive in same-origin scheme check

### DIFF
--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -87,16 +87,16 @@ func requestHost(r *http.Request) string {
 		return firstCommaValue(xfh)
 	}
 	if fwd := r.Header.Get("Forwarded"); fwd != "" {
-		if host := parseForwardedHost(firstCommaValue(fwd)); host != "" {
+		if host := parseForwardedValue(firstCommaValue(fwd), "host"); host != "" {
 			return host
 		}
 	}
 	return r.Host
 }
 
-// parseForwardedHost extracts the host directive from a single RFC 7239
+// parseForwardedValue extracts a directive from a single RFC 7239
 // forwarded-element (semicolon-separated key=value pairs).
-func parseForwardedHost(elem string) string {
+func parseForwardedValue(elem, key string) string {
 	for elem != "" {
 		var part string
 		if before, after, ok := strings.Cut(elem, ";"); ok {
@@ -105,7 +105,7 @@ func parseForwardedHost(elem string) string {
 			part, elem = elem, ""
 		}
 		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
-		if !ok || !strings.EqualFold(k, "host") {
+		if !ok || !strings.EqualFold(k, key) {
 			continue
 		}
 		v = strings.TrimSpace(v)
@@ -119,15 +119,20 @@ func parseForwardedHost(elem string) string {
 
 // requestScheme returns the scheme the client used to reach r, accounting
 // for TLS terminated at this process (r.TLS) or upstream (X-Forwarded-Proto
-// set by a trusted reverse proxy). Defaults to "http". Browsers cannot
-// override X-Forwarded-Proto on a WebSocket upgrade, so trusting it here
-// is safe for this gate.
+// or RFC 7239 Forwarded proto set by a trusted reverse proxy). Defaults to
+// "http". Browsers cannot override these headers on a WebSocket upgrade, so
+// trusting them here is safe for this gate.
 func requestScheme(r *http.Request) string {
 	if r.TLS != nil {
 		return "https"
 	}
 	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
 		return strings.ToLower(firstCommaValue(p))
+	}
+	if fwd := r.Header.Get("Forwarded"); fwd != "" {
+		if proto := parseForwardedValue(firstCommaValue(fwd), "proto"); proto != "" {
+			return strings.ToLower(proto)
+		}
 	}
 	return "http"
 }

--- a/modules/shared/httphelpers/httphelpers_test.go
+++ b/modules/shared/httphelpers/httphelpers_test.go
@@ -289,6 +289,42 @@ func TestIsSameOrigin(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Forwarded proto matches https",
+			host: "example.com",
+			headers: http.Header{
+				"Origin":    {"https://example.com"},
+				"Forwarded": {"proto=https"},
+			},
+			want: true,
+		},
+		{
+			name: "Forwarded quoted proto matches https",
+			host: "example.com",
+			headers: http.Header{
+				"Origin":    {"https://example.com"},
+				"Forwarded": {`proto="https"`},
+			},
+			want: true,
+		},
+		{
+			name: "Forwarded proto and host match https behind proxy",
+			host: "internal:8080",
+			headers: http.Header{
+				"Origin":    {"https://example.com"},
+				"Forwarded": {"for=1.2.3.4;host=example.com;proto=https"},
+			},
+			want: true,
+		},
+		{
+			name: "Forwarded proto takes first element",
+			host: "example.com",
+			headers: http.Header{
+				"Origin":    {"https://example.com"},
+				"Forwarded": {"proto=https, proto=http"},
+			},
+			want: true,
+		},
+		{
 			name: "Forwarded host takes first element",
 			host: "internal:8080",
 			headers: http.Header{
@@ -314,6 +350,16 @@ func TestIsSameOrigin(t *testing.T) {
 				"Origin":           {"http://example.com"},
 				"X-Forwarded-Host": {"example.com"},
 				"Forwarded":        {"host=other.com"},
+			},
+			want: true,
+		},
+		{
+			name: "X-Forwarded-Proto takes precedence over Forwarded proto",
+			host: "example.com",
+			headers: http.Header{
+				"Origin":            {"https://example.com"},
+				"X-Forwarded-Proto": {"https"},
+				"Forwarded":         {"proto=http"},
 			},
 			want: true,
 		},


### PR DESCRIPTION
## Summary

The `requestScheme()` helper previously only checked `X-Forwarded-Proto` when
determining the scheme a client used to reach the server. When a reverse proxy
forwards requests using the RFC 7239 `Forwarded` header with a `proto`
directive instead of `X-Forwarded-Proto`, `requestScheme()` would incorrectly
fall back to `"http"`, causing `IsSameOrigin` to fail for HTTPS connections
behind such proxies.

## Key Changes

- Generalize `parseForwardedHost` into `parseForwardedValue(elem, key string)`
  to support extracting any directive from a `Forwarded` header element.
- Extend `requestScheme()` to read the `proto` directive from the RFC 7239
  `Forwarded` header when `X-Forwarded-Proto` is absent.
- Add tests covering `Forwarded proto` matching, quoted values, combined
  host+proto directives, first-element precedence, and `X-Forwarded-Proto`
  taking precedence over `Forwarded proto`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused