### PR TITLE
🎣 Disable WebSocket per-message compression in GraphQL servers

### DIFF
--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -86,7 +86,7 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 			},
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
-			EnableCompression: true,
+			EnableCompression: false,
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})

--- a/modules/cluster-api/graph/server_test.go
+++ b/modules/cluster-api/graph/server_test.go
@@ -82,6 +82,21 @@ func TestServerWebSocketCheckOrigin(t *testing.T) {
 	}
 }
 
+func TestServerWebSocketCompressionDisabled(t *testing.T) {
+	graphqlServer := NewServer(nil, nil, []string{})
+
+	client := testutils.NewWebTestClient(t, graphqlServer)
+	defer client.Teardown()
+
+	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+	dialer := websocket.Dialer{EnableCompression: true}
+	conn, resp, err := dialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Empty(t, resp.Header.Get("Sec-WebSocket-Extensions"))
+}
+
 func TestServerDrainWithContext_NoConnections(t *testing.T) {
 	s := NewServer(nil, nil, []string{})
 

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -92,7 +92,7 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 			CheckOrigin:       httphelpers.IsSameOrigin,
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
-			EnableCompression: true,
+			EnableCompression: false,
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -84,6 +84,22 @@ func TestServerWebSocketCheckOrigin(t *testing.T) {
 	}
 }
 
+func TestServerWebSocketCompressionDisabled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	s := NewServer(cfg, nil)
+
+	client := testutils.NewWebTestClient(t, s)
+	defer client.Teardown()
+
+	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+	dialer := websocket.Dialer{EnableCompression: true}
+	conn, resp, err := dialer.Dial(wsURL, http.Header{"Origin": []string{client.Server.URL}})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Empty(t, resp.Header.Get("Sec-WebSocket-Extensions"))
+}
+
 func TestServerDrainWithContext_CancelledContext(t *testing.T) {
 	cfg := config.DefaultConfig()
 	s := NewServer(cfg, nil)


### PR DESCRIPTION
## Summary

Disables per-message WebSocket compression (`permessage-deflate`) in both the dashboard and cluster-api GraphQL servers by setting `EnableCompression: false` in the WebSocket upgrader as per [OWASP WebSocket security recommendations](https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html#websocket-protocol-configuration). This prevents the server from negotiating compression extensions during the WebSocket handshake.

## Key Changes

- Set `EnableCompression: false` in the WebSocket upgrader for the dashboard GraphQL server
- Set `EnableCompression: false` in the WebSocket upgrader for the cluster-api GraphQL server
- Add `TestServerWebSocketCompressionDisabled` tests in both modules to assert that `Sec-WebSocket-Extensions` is absent from server responses

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused