### PR TITLE
🐋 Add CSRF protection to dashboard and cluster-api

### DIFF
--- a/config/default/dashboard.yaml
+++ b/config/default/dashboard.yaml
@@ -133,14 +133,20 @@ logging:
 #
 session:
 
-  ## secret ##
+  ## key-pairs ##
   #
-  # The secret key used to sign session tokens.
-  # If empty, a random secret is generated on startup.
+  # One or more signing/encryption key pairs for session cookies. The first
+  # pair is used for new cookies; additional pairs are accepted for reading
+  # only, enabling zero-downtime key rotation.
   #
-  # Default value: ""
+  # Each pair has:
+  #   signing-key    (required) — hex-encoded HMAC signing key; 32 or 64 raw bytes recommended
+  #   encryption-key (optional) — hex-encoded AES encryption key; 16, 24, or 32 raw bytes
   #
-  secret: ""
+  # When empty and a local-storage-dir is configured, a random pair is
+  # generated and persisted to disk on first startup.
+  #
+  key-pairs: []
 
   ## cookie ##
   #

--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -103,6 +103,10 @@ const wsClientOptions = (basepath: string): ClientOptions => ({
   retryAttempts: Infinity,
   shouldRetry: () => true,
   retryWait: createRetryWait(basepath),
+  connectionParams: async () => {
+    await waitForCsrfToken();
+    return { csrfToken: getCsrfToken() };
+  },
 });
 
 const errorLink = new ErrorLink(({ error }) => {

--- a/dashboard-ui/src/apollo-client.ts
+++ b/dashboard-ui/src/apollo-client.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from '@apollo/client';
+import { ApolloClient, ApolloLink, HttpLink, InMemoryCache, Observable } from '@apollo/client';
 import { CombinedGraphQLErrors, CombinedProtocolErrors } from '@apollo/client/errors';
 import { ErrorLink } from '@apollo/client/link/error';
 import { RetryLink } from '@apollo/client/link/retry';
@@ -22,6 +22,7 @@ import { getOperationAST, OperationTypeNode } from 'graphql';
 import toast from 'react-hot-toast';
 
 import appConfig from '@/app-config';
+import { waitForCsrfToken, getCsrfToken, resetCsrfToken } from '@/lib/auth';
 import clusterAPI from '@/lib/graphql/cluster-api/__generated__/introspection-result.json';
 import dashboard from '@/lib/graphql/dashboard/__generated__/introspection-result.json';
 import { clusterAPIProxyPath, getBasename, joinPaths, sleep } from '@/lib/util';
@@ -119,6 +120,43 @@ const errorLink = new ErrorLink(({ error }) => {
   }
 });
 
+const csrfLink = new ApolloLink((operation, forward) => {
+  const setHeader = (tok: string) => {
+    operation.setContext(({ headers = {} }: { headers?: Record<string, string> }) => ({
+      headers: { ...headers, 'X-CSRF-Token': tok },
+    }));
+  };
+
+  const token = getCsrfToken();
+  if (token) {
+    setHeader(token);
+    return forward(operation);
+  }
+
+  // No token yet — wait for the session fetch before sending the request so
+  // the first GraphQL POST reaches the server with the CSRF header already set.
+  return new Observable((subscriber) => {
+    let cancelled = false;
+    let innerSub: { unsubscribe(): void } | null = null;
+
+    waitForCsrfToken()
+      .then(() => {
+        if (cancelled) return;
+        const tok = getCsrfToken();
+        if (tok) setHeader(tok);
+        innerSub = forward(operation).subscribe(subscriber);
+      })
+      .catch((err) => {
+        if (!cancelled) subscriber.error(err);
+      });
+
+    return () => {
+      cancelled = true;
+      innerSub?.unsubscribe();
+    };
+  });
+});
+
 const retryLink = new RetryLink({
   delay: {
     initial: 1000,
@@ -128,6 +166,12 @@ const retryLink = new RetryLink({
   attempts: {
     max: Infinity,
     retryIf: (error, operation) => {
+      if ((error as { statusCode?: number })?.statusCode === 403) {
+        // Session key changed (e.g. server restart) — wipe the cached token so
+        // csrfLink fetches a fresh one before the next attempt.
+        resetCsrfToken();
+        return true;
+      }
       const msg = `[NetworkError] ${error.message} (${operation.operationName})`;
       toast(msg, { id: `${error.name}|${operation.operationName}` });
       return true;
@@ -157,7 +201,7 @@ const createLink = (basepath: string) => {
       return op?.operation === OperationTypeNode.SUBSCRIPTION;
     },
     wsLink,
-    ApolloLink.from([errorLink, retryLink, httpLink]),
+    ApolloLink.from([errorLink, retryLink, csrfLink, httpLink]),
   );
 
   return { link, wsClient };

--- a/dashboard-ui/src/lib/auth.tsx
+++ b/dashboard-ui/src/lib/auth.tsx
@@ -31,10 +31,6 @@ export type Session = {
  * Get CSRF token
  */
 let csrfToken = '';
-let resolveTokenReady: (() => void) | null = null;
-let tokenReadyPromise = new Promise<void>((r) => {
-  resolveTokenReady = r;
-});
 let pendingTokenRefresh: Promise<void> | null = null;
 
 export function getCsrfToken(): string {
@@ -56,11 +52,7 @@ export async function getSession(): Promise<Session> {
   const resp = await fetch(url, { cache: 'no-store' });
 
   const tok = resp.headers.get('X-CSRF-Token');
-  if (tok) {
-    csrfToken = tok;
-    resolveTokenReady?.();
-    resolveTokenReady = null;
-  }
+  if (tok) csrfToken = tok;
 
   const sess = await resp.json();
 
@@ -74,25 +66,21 @@ export async function getSession(): Promise<Session> {
 }
 
 export function resetCsrfToken(): void {
-  if (csrfToken) {
-    csrfToken = '';
-    tokenReadyPromise = new Promise<void>((r) => {
-      resolveTokenReady = r;
-    });
-  }
-  if (!pendingTokenRefresh) {
-    pendingTokenRefresh = getSession()
-      .then(() => {})
-      .catch(() => {})
-      .finally(() => {
-        pendingTokenRefresh = null;
-      });
-  }
+  csrfToken = '';
 }
 
 export function waitForCsrfToken(): Promise<void> {
   if (csrfToken) return Promise.resolve();
-  return tokenReadyPromise;
+  if (!pendingTokenRefresh) {
+    pendingTokenRefresh = getSession()
+      .then(() => {
+        if (!csrfToken) throw new Error('CSRF token missing from session response');
+      })
+      .finally(() => {
+        pendingTokenRefresh = null;
+      });
+  }
+  return pendingTokenRefresh;
 }
 
 /**

--- a/dashboard-ui/src/lib/auth.tsx
+++ b/dashboard-ui/src/lib/auth.tsx
@@ -14,7 +14,6 @@
 
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
-import appConfig from '@/app-config';
 import { getBasename, joinPaths } from '@/lib/util';
 
 const bcName = 'auth/session';
@@ -27,6 +26,20 @@ export type Session = {
   message: string | null;
   timestamp: Date;
 };
+
+/**
+ * Get CSRF token
+ */
+let csrfToken = '';
+let resolveTokenReady: (() => void) | null = null;
+let tokenReadyPromise = new Promise<void>((r) => {
+  resolveTokenReady = r;
+});
+let pendingTokenRefresh: Promise<void> | null = null;
+
+export function getCsrfToken(): string {
+  return csrfToken;
+}
 
 type ContextType = {
   session: Session | undefined;
@@ -41,6 +54,14 @@ const Context = createContext({} as ContextType);
 export async function getSession(): Promise<Session> {
   const url = new URL(joinPaths(getBasename(), '/api/auth/session'), window.location.origin);
   const resp = await fetch(url, { cache: 'no-store' });
+
+  const tok = resp.headers.get('X-CSRF-Token');
+  if (tok) {
+    csrfToken = tok;
+    resolveTokenReady?.();
+    resolveTokenReady = null;
+  }
+
   const sess = await resp.json();
 
   // convert timestamp
@@ -50,6 +71,28 @@ export async function getSession(): Promise<Session> {
   bcOut.postMessage(sess);
 
   return sess;
+}
+
+export function resetCsrfToken(): void {
+  if (csrfToken) {
+    csrfToken = '';
+    tokenReadyPromise = new Promise<void>((r) => {
+      resolveTokenReady = r;
+    });
+  }
+  if (!pendingTokenRefresh) {
+    pendingTokenRefresh = getSession()
+      .then(() => {})
+      .catch(() => {})
+      .finally(() => {
+        pendingTokenRefresh = null;
+      });
+  }
+}
+
+export function waitForCsrfToken(): Promise<void> {
+  if (csrfToken) return Promise.resolve();
+  return tokenReadyPromise;
 }
 
 /**
@@ -66,33 +109,12 @@ export function useSession() {
 }
 
 /**
- * Session provider (Desktop)
+ * Session provider
  */
 
-export const SessionProviderDesktop = ({ children }: React.PropsWithChildren) => {
-  const context = useMemo(
-    () => ({
-      session: {
-        auth_mode: 'auto',
-        user: 'auto',
-        message: null,
-        timestamp: new Date(),
-      },
-    }),
-    [],
-  );
-
-  return <Context.Provider value={context}>{children}</Context.Provider>;
-};
-
-/**
- * Session provider (Cluster)
- */
-
-export const SessionProviderCluster = ({ children }: React.PropsWithChildren) => {
+export const SessionProvider = ({ children }: React.PropsWithChildren) => {
   const [session, setSession] = useState<Session | undefined>(undefined);
 
-  // subscribe to broadcast messages
   useEffect(() => {
     let lastTS = 0;
     const fn = (ev: any) => {
@@ -103,36 +125,16 @@ export const SessionProviderCluster = ({ children }: React.PropsWithChildren) =>
       }
     };
     bcIn.addEventListener('message', fn);
-
-    // fetch on first mount
-    (async () => {
-      await getSession();
-    })();
-
+    getSession();
     return () => bcIn.removeEventListener('message', fn);
   }, []);
 
-  // fetch on visibility change
   useEffect(() => {
-    const fn = async () => {
-      await getSession();
-    };
     document.addEventListener('visibilitychange', getSession);
-    return () => document.removeEventListener('visibilitychange', fn);
+    return () => document.removeEventListener('visibilitychange', getSession);
   }, []);
 
   const context = useMemo(() => ({ session }), [session]);
 
   return <Context.Provider value={context}>{children}</Context.Provider>;
-};
-
-/**
- * Session provider
- */
-
-export const SessionProvider = ({ children }: React.PropsWithChildren) => {
-  if (appConfig.environment === 'desktop') {
-    return <SessionProviderDesktop>{children}</SessionProviderDesktop>;
-  }
-  return <SessionProviderCluster>{children}</SessionProviderCluster>;
 };

--- a/dashboard-ui/src/main.tsx
+++ b/dashboard-ui/src/main.tsx
@@ -32,15 +32,15 @@ const router = createBrowserRouter(createRoutesFromElements(routes), { basename:
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ApolloProvider client={dashboardClient}>
-      <SessionProvider>
+    <SessionProvider>
+      <ApolloProvider client={dashboardClient}>
         <PreferencesProvider>
           <ThemeEffect />
           <UpdateNotificationProvider>
             <RouterProvider router={router} />
           </UpdateNotificationProvider>
         </PreferencesProvider>
-      </SessionProvider>
-    </ApolloProvider>
+      </ApolloProvider>
+    </SessionProvider>
   </StrictMode>,
 );

--- a/hack/tilt/kubetail-tokenauth.yaml
+++ b/hack/tilt/kubetail-tokenauth.yaml
@@ -18,7 +18,9 @@ data:
     ui:
       cluster-api-enabled: true
     session:
-      secret: REPLACEME
+      key-pairs:
+        - signing-key: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+          encryption-key: cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
       cookie:
         name: kubetail_dashboard_session
         path: /

--- a/hack/tilt/kubetail.yaml
+++ b/hack/tilt/kubetail.yaml
@@ -18,7 +18,9 @@ data:
     ui:
       cluster-api-enabled: true
     session:
-      secret: REPLACEME
+      key-pairs:
+        - signing-key: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+          encryption-key: cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
       cookie:
         name: kubetail_dashboard_session
         path: /

--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -32,6 +33,15 @@ import (
 
 	"github.com/kubetail-org/kubetail/modules/shared/graphql/directives"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
+)
+
+type ctxKey int
+
+const (
+	// SessionCSRFTokenCtxKey is the request-context key for the dashboard
+	// session's CSRF token, forwarded by the dashboard reverse proxy and
+	// validated by the WebSocket InitFunc.
+	SessionCSRFTokenCtxKey ctxKey = iota
 )
 
 // Represents Server
@@ -83,6 +93,15 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
 			EnableCompression: false,
+		},
+		// No expected token means a bot/programmatic client (no proxy header);
+		// the upgrade-time Origin gate is the only check in that path.
+		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
+			expected, _ := ctx.Value(SessionCSRFTokenCtxKey).(string)
+			if expected != "" && initPayload.GetString("csrfToken") != expected {
+				return ctx, nil, errors.New("invalid CSRF token")
+			}
+			return ctx, nil, nil
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})

--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -68,10 +68,6 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 		KeepAlivePingInterval: 10 * time.Second,
 	})
 
-	// Add transports from NewDefaultServer()
-	h.AddTransport(transport.GET{})
-	h.AddTransport(transport.POST{})
-
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
 	// Configure WebSocket. The cluster-api is intended for bot/programmatic
@@ -90,6 +86,8 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})
+
+	h.AddTransport(transport.POST{})
 
 	h.Use(extension.Introspection{})
 	h.Use(extension.AutomaticPersistedQuery{

--- a/modules/cluster-api/graph/server_test.go
+++ b/modules/cluster-api/graph/server_test.go
@@ -82,6 +82,89 @@ func TestServerWebSocketCheckOrigin(t *testing.T) {
 	}
 }
 
+// withSessionCSRFToken stands in for the cluster-api middleware that copies
+// X-Forwarded-CSRF-Token from the upgrade request into the request context.
+func withSessionCSRFToken(h http.Handler, token string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), SessionCSRFTokenCtxKey, token)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func TestServerWebSocketCSRFInit(t *testing.T) {
+	const expected = "expected-csrf-token"
+
+	tests := []struct {
+		name    string
+		ctxTok  string         // "" = bot path, no token in ctx
+		payload map[string]any // connection_init payload
+		wantAck bool
+	}{
+		{
+			name:    "bot path (no header) accepts empty payload",
+			payload: map[string]any{"type": "connection_init"},
+			wantAck: true,
+		},
+		{
+			name:    "bot path (no header) accepts any csrfToken",
+			payload: map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": "anything"}},
+			wantAck: true,
+		},
+		{
+			name:    "browser path with matching csrfToken is accepted",
+			ctxTok:  expected,
+			payload: map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": expected}},
+			wantAck: true,
+		},
+		{
+			name:    "browser path with wrong csrfToken is rejected",
+			ctxTok:  expected,
+			payload: map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": "bad"}},
+		},
+		{
+			name:    "browser path with missing csrfToken is rejected",
+			ctxTok:  expected,
+			payload: map[string]any{"type": "connection_init"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(nil, nil, []string{})
+			var handler http.Handler = s
+			if tt.ctxTok != "" {
+				handler = withSessionCSRFToken(s, tt.ctxTok)
+			}
+
+			client := testutils.NewWebTestClient(t, handler)
+			defer client.Teardown()
+
+			wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+			dialer := websocket.Dialer{Subprotocols: []string{"graphql-transport-ws"}}
+			conn, _, err := dialer.Dial(wsURL, nil)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			require.NoError(t, conn.WriteJSON(tt.payload))
+
+			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			var msg map[string]any
+			err = conn.ReadJSON(&msg)
+			if tt.wantAck {
+				require.NoError(t, err)
+				require.Equal(t, "connection_ack", msg["type"])
+				return
+			}
+			if err == nil {
+				require.NotEqual(t, "connection_ack", msg["type"])
+				conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+				_, _, err = conn.ReadMessage()
+			}
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestServerWebSocketCompressionDisabled(t *testing.T) {
 	graphqlServer := NewServer(nil, nil, []string{})
 

--- a/modules/cluster-api/internal/app/app.go
+++ b/modules/cluster-api/internal/app/app.go
@@ -127,7 +127,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 
 		// GraphQL endpoint
 		app.graphqlServer = graph.NewServer(app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)
-		dynamicRoutes.Any("/graphql", gin.WrapH(app.graphqlServer))
+		dynamicRoutes.Any("/graphql", forwardedCSRFTokenMiddleware, gin.WrapH(app.graphqlServer))
 
 		// Log download endpoint
 		dl := newDownloadHandlers(app.cm, app.grpcDispatcher, cfg.AllowedNamespaces)

--- a/modules/cluster-api/internal/app/middleware.go
+++ b/modules/cluster-api/internal/app/middleware.go
@@ -21,7 +21,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/kubetail-org/kubetail/modules/cluster-api/graph"
+	"github.com/kubetail-org/kubetail/modules/shared/ginhelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/grpchelpers"
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
@@ -56,6 +59,21 @@ func authenticationMiddleware(c *gin.Context) {
 	}
 
 	// Continue
+	c.Next()
+}
+
+// forwardedCSRFTokenMiddleware copies X-Forwarded-CSRF-Token (set by the
+// dashboard reverse proxy when forwarding browser upgrades) into the request
+// context so the GraphQL WebSocket InitFunc can validate connection_init.
+func forwardedCSRFTokenMiddleware(c *gin.Context) {
+	if !ginhelpers.IsWebSocketRequest(c) {
+		c.Next()
+		return
+	}
+	if tok := c.GetHeader(httphelpers.HeaderForwardedCSRFToken); tok != "" {
+		ctx := context.WithValue(c.Request.Context(), graph.SessionCSRFTokenCtxKey, tok)
+		c.Request = c.Request.WithContext(ctx)
+	}
 	c.Next()
 }
 

--- a/modules/cluster-api/internal/app/middleware_test.go
+++ b/modules/cluster-api/internal/app/middleware_test.go
@@ -20,9 +20,12 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/kubetail-org/kubetail/modules/shared/grpchelpers"
-	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubetail-org/kubetail/modules/cluster-api/graph"
+	"github.com/kubetail-org/kubetail/modules/shared/grpchelpers"
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
+	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
 func TestAuthenticationMiddleware(t *testing.T) {
@@ -112,6 +115,43 @@ func TestAuthenticationMiddleware(t *testing.T) {
 			router.ServeHTTP(w, r)
 
 			// Check response
+			assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+		})
+	}
+}
+
+func TestForwardedCSRFTokenMiddleware(t *testing.T) {
+	tests := []struct {
+		name      string
+		setHeader string
+		isUpgrade bool
+		wantValue any
+	}{
+		{"upgrade with header", "abc123", true, "abc123"},
+		{"upgrade without header", "", true, nil},
+		{"non-upgrade ignores header", "abc123", false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(forwardedCSRFTokenMiddleware)
+			router.GET("/", func(c *gin.Context) {
+				val := c.Request.Context().Value(graph.SessionCSRFTokenCtxKey)
+				assert.Equal(t, tt.wantValue, val)
+				c.String(http.StatusOK, "ok")
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.isUpgrade {
+				r.Header.Set("Connection", "Upgrade")
+				r.Header.Set("Upgrade", "websocket")
+			}
+			if tt.setHeader != "" {
+				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.setHeader)
+			}
+			router.ServeHTTP(w, r)
 			assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 		})
 	}

--- a/modules/dashboard/README.md
+++ b/modules/dashboard/README.md
@@ -39,7 +39,7 @@ The Kubetail Dashboard server can be configured using a configuration file writt
 | dashboard.logging.format                        | string   | Log format (json, pretty)                            | "json"       | stable       |
 | dashboard.logging.access-log.enabled            | bool     | Enable access log                                    | true         | stable       |
 | dashboard.logging.access-log.hide-health-checks | bool     | Hide requests to /healthz from access log            | false        | stable       |
-| dashboard.session.secret                        | string   | Session hash key                                     | ""           | stable       |
+| dashboard.session.key-pairs                     | []object | Session cookie signing/encryption key pairs (hex)    | []           | stable       |
 | dashboard.session.cookie.name                   | string   | Session cookie name                                  | "session"    | stable       |
 | dashboard.session.cookie.path                   | string   | Session cookie path                                  | "/"          | stable       |
 | dashboard.session.cookie.domain                 | string   | Session cookie domain                                | ""           | stable       |

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -77,10 +77,6 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 	// Init handler
 	h := handler.New(schema)
 
-	// Add transports from NewDefaultServer()
-	h.AddTransport(transport.GET{})
-	h.AddTransport(transport.POST{})
-
 	h.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 
 	// Configure WebSocket. The app-level Sec-Fetch-Site CSRF middleware does
@@ -96,6 +92,8 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})
+
+	h.AddTransport(transport.POST{})
 
 	h.Use(extension.Introspection{})
 	h.Use(extension.AutomaticPersistedQuery{

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -35,6 +36,15 @@ import (
 	clusterapi "github.com/kubetail-org/kubetail/modules/dashboard/internal/cluster-api"
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/preferences"
+)
+
+// ctxKey is a private type for keys defined in this package.
+type ctxKey int
+
+const (
+	// SessionCSRFTokenCtxKey is the request-context key for the session's
+	// expected CSRF token, validated by the WebSocket InitFunc.
+	SessionCSRFTokenCtxKey ctxKey = iota
 )
 
 // Represents Server
@@ -82,13 +92,21 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 	// Configure WebSocket. The app-level Sec-Fetch-Site CSRF middleware does
 	// not gate WebSocket upgrades (safe methods are skipped, since Chrome
 	// does not send Sec-Fetch-Site on upgrade requests), so CSWSH defense
-	// happens here via a same-origin Origin check.
+	// happens here in two layers: a same-origin Origin check at upgrade time,
+	// and a CSRF-token check in the connection_init payload.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
 			CheckOrigin:       httphelpers.IsSameOrigin,
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
 			EnableCompression: false,
+		},
+		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
+			expected, _ := ctx.Value(SessionCSRFTokenCtxKey).(string)
+			if expected == "" || initPayload.GetString("csrfToken") != expected {
+				return ctx, nil, errors.New("invalid CSRF token")
+			}
+			return ctx, nil, nil
 		},
 		KeepAlivePingInterval: 10 * time.Second,
 	})

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -29,6 +29,17 @@ import (
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 )
 
+const testCSRFToken = "expected-csrf-token"
+
+// withSessionCSRFToken stands in for the gin middleware that injects the
+// session's expected CSRF token into the request context.
+func withSessionCSRFToken(h http.Handler, token string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), SessionCSRFTokenCtxKey, token)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 func TestServerDrainWithContext_NoConnections(t *testing.T) {
 	cfg := config.DefaultConfig()
 	s := NewServer(cfg, nil)
@@ -80,6 +91,63 @@ func TestServerWebSocketCheckOrigin(t *testing.T) {
 			}
 			_, resp, _ := websocket.DefaultDialer.Dial(wsURL, header)
 			require.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestServerWebSocketCSRFInit(t *testing.T) {
+	cfg := config.DefaultConfig()
+	s := NewServer(cfg, nil)
+
+	client := testutils.NewWebTestClient(t, withSessionCSRFToken(s, testCSRFToken))
+	defer client.Teardown()
+
+	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+	dialer := websocket.Dialer{Subprotocols: []string{"graphql-transport-ws"}}
+
+	tests := []struct {
+		name    string
+		payload map[string]any
+		wantAck bool
+	}{
+		{
+			name:    "missing csrfToken is rejected",
+			payload: map[string]any{"type": "connection_init"},
+		},
+		{
+			name:    "wrong csrfToken is rejected",
+			payload: map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": "bad"}},
+		},
+		{
+			name:    "matching csrfToken is accepted",
+			payload: map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": testCSRFToken}},
+			wantAck: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{client.Server.URL}})
+			require.NoError(t, err)
+			defer conn.Close()
+
+			require.NoError(t, conn.WriteJSON(tt.payload))
+
+			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			var msg map[string]any
+			err = conn.ReadJSON(&msg)
+			if tt.wantAck {
+				require.NoError(t, err)
+				require.Equal(t, "connection_ack", msg["type"])
+				return
+			}
+			// Reject path: server may emit connection_error then close, or close directly — either way no ack.
+			if err == nil {
+				require.NotEqual(t, "connection_ack", msg["type"])
+				conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+				_, _, err = conn.ReadMessage()
+			}
+			require.Error(t, err)
 		})
 	}
 }
@@ -154,7 +222,7 @@ func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 
 	s := NewServer(cfg, nil)
 
-	client := testutils.NewWebTestClient(t, s)
+	client := testutils.NewWebTestClient(t, withSessionCSRFToken(s, testCSRFToken))
 	defer client.Teardown()
 
 	// Dial WebSocket with graphql-transport-ws subprotocol
@@ -165,7 +233,7 @@ func TestServerNotifyShutdown_ClosesConnections(t *testing.T) {
 	defer conn.Close()
 
 	// Complete the graphql-transport-ws handshake
-	err = conn.WriteJSON(map[string]any{"type": "connection_init"})
+	err = conn.WriteJSON(map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": testCSRFToken}})
 	require.NoError(t, err)
 
 	// Read connection_ack — confirms the WebSocket is fully established
@@ -194,7 +262,7 @@ func TestServerNotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 
 	s := NewServer(cfg, nil)
 
-	client := testutils.NewWebTestClient(t, s)
+	client := testutils.NewWebTestClient(t, withSessionCSRFToken(s, testCSRFToken))
 	defer client.Teardown()
 
 	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
@@ -209,7 +277,7 @@ func TestServerNotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		err = conn.WriteJSON(map[string]any{"type": "connection_init"})
+		err = conn.WriteJSON(map[string]any{"type": "connection_init", "payload": map[string]any{"csrfToken": testCSRFToken}})
 		require.NoError(t, err)
 
 		var msg map[string]any

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -203,6 +203,8 @@ func NewApp(cfg *config.Config) (*App, error) {
 			// Add K8S auth middleware
 			protectedRoutes.Use(k8sAuthenticationMiddleware(cfg.AuthMode))
 
+			protectedRoutes.Use(websocketCSRFContextMiddleware())
+
 			// GraphQL endpoint
 			app.graphqlServer = graph.NewServer(cfg, app.cm)
 			protectedRoutes.Any("/graphql", gin.WrapH(app.graphqlServer))

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -158,7 +158,11 @@ func NewApp(cfg *config.Config) (*App, error) {
 	dynamicRoutes := root.Group("/")
 	{
 		// Add session middleware
-		sessionStore := cookie.NewStore([]byte(cfg.Session.Secret))
+		keyPairs, err := resolveSessionKeyPairs(cfg)
+		if err != nil {
+			return nil, err
+		}
+		sessionStore := cookie.NewStore(keyPairs...)
 		sessionStore.Options(sessions.Options{
 			Path:     cfg.Session.Cookie.Path,
 			Domain:   cfg.Session.Cookie.Domain,

--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -49,7 +49,8 @@ type App struct {
 	queryHelpers    queryHelpers
 
 	// for testing
-	dynamicRoutes *gin.RouterGroup
+	dynamicRoutes   *gin.RouterGroup
+	protectedRoutes *gin.RouterGroup
 }
 
 // NotifyShutdown signals active connections to begin closing.
@@ -209,6 +210,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 			dl := newDownloadHandlers(app)
 			protectedRoutes.POST("/api/v1/download", dl.DownloadPOST)
 		}
+		app.protectedRoutes = protectedRoutes
 	}
 	app.dynamicRoutes = dynamicRoutes
 

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -19,18 +19,17 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
-	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 )
 
 func TestRequestID(t *testing.T) {
@@ -172,169 +171,35 @@ func TestHealthz(t *testing.T) {
 	assert.Equal(t, "{\"status\":\"ok\"}", w.Body.String())
 }
 
-func TestCSRFProtectionOnDynamicRoutes(t *testing.T) {
-	tests := []struct {
-		name            string
-		method          string
-		path            string
-		setSecFetchSite string
-		wantForbidden   bool
-	}{
-		// CSRF only applies to unsafe methods. Safe-method routes
-		// (GraphQL queries via GET, /api/auth/session) bypass the check;
-		// SOP and same-origin WS gating cover those paths.
-		{
-			"graphql GET cross-site is allowed",
-			"GET",
-			"/graphql",
-			"cross-site",
-			false,
-		},
-		{
-			"graphql GET allows same-origin",
-			"GET",
-			"/graphql",
-			"same-origin",
-			false,
-		},
-		{
-			"graphql GET non-browser is allowed",
-			"GET",
-			"/graphql",
-			"",
-			false,
-		},
-		{
-			"login blocks cross-site",
-			"POST",
-			"/api/auth/login",
-			"cross-site",
-			true,
-		},
-		{
-			"login allows same-origin",
-			"POST",
-			"/api/auth/login",
-			"same-origin",
-			false,
-		},
-		{
-			"logout blocks cross-site",
-			"POST",
-			"/api/auth/logout",
-			"cross-site",
-			true,
-		},
-		{
-			"session GET cross-site is allowed",
-			"GET",
-			"/api/auth/session",
-			"cross-site",
-			false,
-		},
-		{
-			"session allows same-origin",
-			"GET",
-			"/api/auth/session",
-			"same-origin",
-			false,
-		},
-		{
-			"download blocks cross-site",
-			"POST",
-			"/api/v1/download",
-			"cross-site",
-			true,
-		},
-		{
-			"download blocks non-browser",
-			"POST",
-			"/api/v1/download",
-			"",
-			true,
-		},
-		{
-			"download allows same-origin",
-			"POST",
-			"/api/v1/download",
-			"same-origin",
-			false,
-		},
-		{
-			"healthz ignores header (outside dynamic routes)",
-			"GET",
-			"/healthz",
-			"cross-site",
-			false,
-		},
+func handlerChainContains(chain gin.HandlersChain, fnName string) bool {
+	for _, h := range chain {
+		name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+		if strings.Contains(name, fnName) {
+			return true
+		}
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app := newTestApp(nil)
-
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest(tt.method, tt.path, nil)
-			if tt.setSecFetchSite != "" {
-				r.Header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
-			}
-			app.ServeHTTP(w, r)
-
-			if tt.wantForbidden {
-				assert.Equal(t, http.StatusForbidden, w.Result().StatusCode)
-			} else {
-				assert.NotEqual(t, http.StatusForbidden, w.Result().StatusCode)
-			}
-		})
-	}
+	return false
 }
 
-func TestWebSocketUpgradeBypassesCSRF(t *testing.T) {
-	// CSRF middleware skips safe methods, so a WebSocket upgrade (GET) is
-	// not subject to Sec-Fetch-Site — Chrome doesn't send it on upgrades.
-	// Authorization is handled by the WebSocket same-origin gate instead.
-	tests := []struct {
-		name            string
-		setSecFetchSite string
-	}{
-		{"missing Sec-Fetch-Site upgrades", ""},
-		{"cross-site Sec-Fetch-Site upgrades", "cross-site"},
-		{"same-origin Sec-Fetch-Site upgrades", "same-origin"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app := newTestApp(nil)
-
-			client := testutils.NewWebTestClient(t, app)
-			defer client.Teardown()
-
-			header := http.Header{}
-			if tt.setSecFetchSite != "" {
-				header.Set("Sec-Fetch-Site", tt.setSecFetchSite)
-			}
-			// Same-origin Origin to satisfy the WebSocket same-origin gate.
-			header.Set("Origin", client.Server.URL)
-
-			u := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
-			_, resp, _ := websocket.DefaultDialer.Dial(u, header)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
-		})
-	}
+func TestCSRFProtectionAppliedToDynamicRoutes(t *testing.T) {
+	app := newTestApp(nil)
+	assert.True(t,
+		handlerChainContains(app.dynamicRoutes.Handlers, "csrfProtectionMiddleware"),
+		"csrfProtectionMiddleware not found in dynamic-route handler chain")
 }
 
-func TestDownloadRequiresAuthInTokenMode(t *testing.T) {
-	cfg := newTestConfig()
-	cfg.AuthMode = config.AuthModeToken
-	app := newTestApp(cfg)
+func TestAuthenticationMiddlewareAppliedToDynamicRoutes(t *testing.T) {
+	app := newTestApp(nil)
+	assert.True(t,
+		handlerChainContains(app.dynamicRoutes.Handlers, "authenticationMiddleware"),
+		"authenticationMiddleware not found in dynamic-route handler chain")
+}
 
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/api/v1/download", nil)
-	r.Header.Set("Sec-Fetch-Site", "same-origin")
-	app.ServeHTTP(w, r)
-
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
+func TestK8sAuthenticationAppliedToProtectedRoutes(t *testing.T) {
+	app := newTestApp(nil)
+	assert.True(t,
+		handlerChainContains(app.protectedRoutes.Handlers, "k8sAuthenticationMiddleware"),
+		"k8sAuthenticationMiddleware not found in protected-route handler chain")
 }
 
 func TestClusterAPIProxyRouteWithBasePath(t *testing.T) {

--- a/modules/dashboard/pkg/app/auth.go
+++ b/modules/dashboard/pkg/app/auth.go
@@ -95,6 +95,16 @@ func (app *authHandlers) LogoutPOST(c *gin.Context) {
 func (app *authHandlers) SessionGET(c *gin.Context) {
 	authMode := app.config.AuthMode
 
+	session := sessions.Default(c)
+	token, isNew := getOrCreateCSRFToken(session)
+	if isNew {
+		if err := session.Save(); err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	c.Header("X-CSRF-Token", token)
+
 	response := gin.H{
 		"auth_mode": authMode,
 		"user":      nil,

--- a/modules/dashboard/pkg/app/auth_test.go
+++ b/modules/dashboard/pkg/app/auth_test.go
@@ -17,11 +17,14 @@ package app
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/utils/ptr"
@@ -49,6 +52,9 @@ func (suite *authTestSuite) SetupTest() {
 	// Init client
 	client := testutils.NewWebTestClient(suite.T(), app)
 
+	// Prime the CSRF token so that subsequent unsafe-method requests include it.
+	client.Get("/api/auth/session")
+
 	// Save
 	suite.app = app
 	suite.client = client
@@ -72,6 +78,19 @@ func (suite *authTestSuite) TestLoginPOSTFormErrors() {
 	// check result
 	suite.Equal(http.StatusUnprocessableEntity, resp.StatusCode)
 	suite.Contains(string(resp.Body), "Please enter your token")
+}
+
+// Behavioral check: an unsafe-method auth route is gated by the CSRF
+// middleware. Mirrors the protected-route behavioral coverage in download_test.go.
+func TestLoginPOSTRequiresCSRFToken(t *testing.T) {
+	app := newTestApp(nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 func (suite *authTestSuite) TestLoginPOSTSuccess() {
@@ -230,4 +249,25 @@ func (suite *authTestSuite) TestSessionGET() {
 			client.Teardown()
 		})
 	}
+}
+
+func TestSessionGETCSRFToken(t *testing.T) {
+	app := newTestApp(nil)
+
+	t.Run("GET /api/auth/session returns non-empty X-CSRF-Token header", func(t *testing.T) {
+		client := testutils.NewWebTestClient(t, app)
+		defer client.Teardown()
+		resp := client.Get("/api/auth/session")
+		assert.NotEmpty(t, resp.Header.Get("X-CSRF-Token"))
+	})
+
+	t.Run("repeated GET /api/auth/session returns the same token", func(t *testing.T) {
+		client := testutils.NewWebTestClient(t, app)
+		defer client.Teardown()
+		resp1 := client.Get("/api/auth/session")
+		resp2 := client.Get("/api/auth/session")
+		token1 := resp1.Header.Get("X-CSRF-Token")
+		require.NotEmpty(t, token1)
+		assert.Equal(t, token1, resp2.Header.Get("X-CSRF-Token"))
+	})
 }

--- a/modules/dashboard/pkg/app/cluster_api_proxy_test.go
+++ b/modules/dashboard/pkg/app/cluster_api_proxy_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/shared/testutils"
+)
+
+// POST without a CSRF token is blocked at the dynamic-route gate before
+// reaching the proxy.
+func TestClusterAPIProxyPOSTRequiresCSRFToken(t *testing.T) {
+	app := newTestApp(nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/cluster-api-proxy/some/path", nil)
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// POST in token mode without a session token is rejected by
+// k8sAuthenticationMiddleware on the protected-route group.
+func TestClusterAPIProxyPOSTRequiresAuthInTokenMode(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.AuthMode = config.AuthModeToken
+	app := newTestApp(cfg)
+	client := testutils.NewWebTestClient(t, app)
+	defer client.Teardown()
+
+	// Prime the CSRF token so the POST reaches the auth check.
+	client.Get("/api/auth/session")
+
+	req := client.NewRequest("POST", "/cluster-api-proxy/some/path", nil)
+	resp := client.Do(req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/modules/dashboard/pkg/app/download_test.go
+++ b/modules/dashboard/pkg/app/download_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
+	"github.com/kubetail-org/kubetail/modules/shared/testutils"
 )
 
 // fakeStreamer emits a pre-populated slice of LogRecords through the Records
@@ -189,4 +191,35 @@ func TestDownloadResponseHeaders(t *testing.T) {
 	cd := w.Header().Get("Content-Disposition")
 	assert.True(t, strings.HasPrefix(cd, `attachment; filename="logs-`), "Content-Disposition: %q", cd)
 	assert.True(t, strings.HasSuffix(cd, `.tsv"`), "Content-Disposition: %q", cd)
+}
+
+// Behavioral check: the download endpoint is mounted under protectedRoutes,
+// so requests without a CSRF token are blocked at the dynamic-route gate.
+func TestDownloadPOSTRequiresCSRFToken(t *testing.T) {
+	app := newTestApp(nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/download", nil)
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// Behavioral check: in token mode, a request without a session token is
+// rejected by k8sAuthenticationMiddleware on the protected-route group.
+func TestDownloadPOSTRequiresAuthInTokenMode(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.AuthMode = config.AuthModeToken
+	app := newTestApp(cfg)
+	client := testutils.NewWebTestClient(t, app)
+	defer client.Teardown()
+
+	// Prime the CSRF token so the POST reaches the auth check.
+	client.Get("/api/auth/session")
+
+	req := client.NewRequest("POST", "/api/v1/download", nil)
+	resp := client.Do(req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }

--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -32,6 +32,8 @@ const k8sTokenSessionKey = "k8sToken"
 
 const k8sTokenGinKey = "k8sToken"
 
+const csrfTokenSessionKey = "csrfToken"
+
 // newClusterAPIProxy
 func newClusterAPIProxy(cfg *config.Config, cm k8shelpers.ConnectionManager, pathPrefix string) (clusterapi.Proxy, error) {
 	// Initialize new ClusterAPI proxy depending on environment

--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -121,6 +121,11 @@ func resolveSessionKeyPairs(cfg *config.Config) ([][]byte, error) {
 		if !validAESKeySize(len(ek)) {
 			return nil, fmt.Errorf("session key-pair encryption-key must decode to 16, 24, or 32 bytes (got %d)", len(ek))
 		}
+		// gorilla/securecookie treats a non-nil block key as AES input, so an
+		// empty (but non-nil) slice would be rejected as an invalid AES key.
+		if len(ek) == 0 {
+			ek = nil
+		}
 		result = append(result, sk, ek)
 	}
 	return result, nil

--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -16,7 +16,13 @@ package app
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,4 +85,124 @@ func (qh *realQueryHelpers) HasAccess(ctx context.Context, token string) (*authv
 
 	// Execute
 	return clientset.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
+}
+
+// resolveSessionKeyPairs returns the flat [][]byte pairs expected by
+// cookie.NewStore: [signingKey0, encryptionKey0, signingKey1, encryptionKey1, ...].
+// Priority: explicit config key-pairs > persisted key file (desktop only) > random per startup.
+func resolveSessionKeyPairs(cfg *config.Config) ([][]byte, error) {
+	pairs := cfg.Session.KeyPairs
+	if len(pairs) == 0 {
+		if cfg.Environment == sharedcfg.EnvironmentDesktop {
+			var err error
+			pairs, err = loadOrCreateKeyPairs(cfg.SessionKeysPath())
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			kp, err := randomKeyPair()
+			if err != nil {
+				return nil, err
+			}
+			pairs = []config.KeyPair{kp}
+		}
+	}
+
+	result := make([][]byte, 0, len(pairs)*2)
+	for _, kp := range pairs {
+		sk, err := hex.DecodeString(kp.SigningKey)
+		if err != nil {
+			return nil, fmt.Errorf("session key-pair signing-key must be hex-encoded: %w", err)
+		}
+		ek, err := hex.DecodeString(kp.EncryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("session key-pair encryption-key must be hex-encoded: %w", err)
+		}
+		if !validAESKeySize(len(ek)) {
+			return nil, fmt.Errorf("session key-pair encryption-key must decode to 16, 24, or 32 bytes (got %d)", len(ek))
+		}
+		result = append(result, sk, ek)
+	}
+	return result, nil
+}
+
+// persistedKeyPair is the on-disk representation of a key pair. It extends
+// config.KeyPair with a creation timestamp so future rotation logic can
+// decide when to generate a new primary pair.
+type persistedKeyPair struct {
+	config.KeyPair
+	CreatedAt time.Time `json:"created-at"`
+}
+
+// validAESKeySize reports whether n is an acceptable AES key length (0 = disabled, or 16/24/32).
+func validAESKeySize(n int) bool {
+	return n == 0 || n == 16 || n == 24 || n == 32
+}
+
+// validPersistedKeyPairs returns true if all key pairs are hex-decodable and
+// their encryption keys (when present) are valid AES key sizes.
+func validPersistedKeyPairs(pairs []persistedKeyPair) bool {
+	for _, p := range pairs {
+		if _, err := hex.DecodeString(p.SigningKey); err != nil {
+			return false
+		}
+		ek, err := hex.DecodeString(p.EncryptionKey)
+		if err != nil {
+			return false
+		}
+		if !validAESKeySize(len(ek)) {
+			return false
+		}
+	}
+	return true
+}
+
+// loadOrCreateKeyPairs reads the JSON key-pair file at path, or generates and
+// persists a new single key pair if the file is missing or unreadable.
+func loadOrCreateKeyPairs(path string) ([]config.KeyPair, error) {
+	if data, err := os.ReadFile(path); err == nil {
+		var persisted []persistedKeyPair
+		if json.Unmarshal(data, &persisted) == nil && len(persisted) > 0 && validPersistedKeyPairs(persisted) {
+			pairs := make([]config.KeyPair, len(persisted))
+			for i, p := range persisted {
+				pairs[i] = p.KeyPair
+			}
+			return pairs, nil
+		}
+	}
+
+	kp, err := randomKeyPair()
+	if err != nil {
+		return nil, err
+	}
+	persisted := []persistedKeyPair{{KeyPair: kp, CreatedAt: time.Now().UTC()}}
+
+	data, err := json.Marshal(persisted)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return nil, err
+	}
+	return []config.KeyPair{kp}, nil
+}
+
+// randomKeyPair generates a new key pair with 32-byte random signing and
+// encryption keys, hex-encoded for safe JSON/YAML storage.
+func randomKeyPair() (config.KeyPair, error) {
+	sk := make([]byte, 32)
+	if _, err := rand.Read(sk); err != nil {
+		return config.KeyPair{}, err
+	}
+	ek := make([]byte, 32)
+	if _, err := rand.Read(ek); err != nil {
+		return config.KeyPair{}, err
+	}
+	return config.KeyPair{
+		SigningKey:    hex.EncodeToString(sk),
+		EncryptionKey: hex.EncodeToString(ek),
+	}, nil
 }

--- a/modules/dashboard/pkg/app/helpers_test.go
+++ b/modules/dashboard/pkg/app/helpers_test.go
@@ -1,0 +1,204 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+)
+
+func TestRandomKeyPair(t *testing.T) {
+	kp, err := randomKeyPair()
+	require.NoError(t, err)
+
+	sk, err := hex.DecodeString(kp.SigningKey)
+	require.NoError(t, err)
+	assert.Len(t, sk, 32)
+
+	ek, err := hex.DecodeString(kp.EncryptionKey)
+	require.NoError(t, err)
+	assert.Len(t, ek, 32)
+}
+
+func TestValidPersistedKeyPairs(t *testing.T) {
+	sk := hex.EncodeToString(make([]byte, 32))
+	ek32 := hex.EncodeToString(make([]byte, 32))
+	ek16 := hex.EncodeToString(make([]byte, 16))
+
+	tests := []struct {
+		name  string
+		pairs []persistedKeyPair
+		want  bool
+	}{
+		{
+			name:  "valid 32-byte keys",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: sk, EncryptionKey: ek32}}},
+			want:  true,
+		},
+		{
+			name:  "valid 16-byte encryption key",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: sk, EncryptionKey: ek16}}},
+			want:  true,
+		},
+		{
+			name:  "empty encryption key",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: sk, EncryptionKey: ""}}},
+			want:  true,
+		},
+		{
+			name:  "non-hex signing key",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: "not-hex!", EncryptionKey: ek32}}},
+			want:  false,
+		},
+		{
+			name:  "non-hex encryption key",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: sk, EncryptionKey: "not-hex!"}}},
+			want:  false,
+		},
+		{
+			name:  "bad encryption key length",
+			pairs: []persistedKeyPair{{KeyPair: config.KeyPair{SigningKey: sk, EncryptionKey: hex.EncodeToString(make([]byte, 10))}}},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, validPersistedKeyPairs(tt.pairs))
+		})
+	}
+}
+
+func TestLoadOrCreateKeyPairs(t *testing.T) {
+	t.Run("creates file when missing", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keys.json")
+
+		pairs, err := loadOrCreateKeyPairs(path)
+		require.NoError(t, err)
+		require.Len(t, pairs, 1)
+
+		_, err = os.Stat(path)
+		assert.NoError(t, err)
+	})
+
+	t.Run("loads existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keys.json")
+
+		kp, _ := randomKeyPair()
+		data, _ := json.Marshal([]persistedKeyPair{{KeyPair: kp, CreatedAt: time.Now().UTC()}})
+		require.NoError(t, os.WriteFile(path, data, 0600))
+
+		pairs, err := loadOrCreateKeyPairs(path)
+		require.NoError(t, err)
+		require.Len(t, pairs, 1)
+		assert.Equal(t, kp.SigningKey, pairs[0].SigningKey)
+	})
+
+	t.Run("rebuilds corrupt file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keys.json")
+
+		require.NoError(t, os.WriteFile(path, []byte("not valid json"), 0600))
+
+		pairs, err := loadOrCreateKeyPairs(path)
+		require.NoError(t, err)
+		require.Len(t, pairs, 1)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		var persisted []persistedKeyPair
+		require.NoError(t, json.Unmarshal(data, &persisted))
+	})
+
+	t.Run("rebuilds file with invalid key sizes", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keys.json")
+
+		bad := []persistedKeyPair{{KeyPair: config.KeyPair{
+			SigningKey:    hex.EncodeToString(make([]byte, 32)),
+			EncryptionKey: hex.EncodeToString(make([]byte, 10)),
+		}, CreatedAt: time.Now().UTC()}}
+		data, _ := json.Marshal(bad)
+		require.NoError(t, os.WriteFile(path, data, 0600))
+
+		pairs, err := loadOrCreateKeyPairs(path)
+		require.NoError(t, err)
+		require.Len(t, pairs, 1)
+
+		ek, err := hex.DecodeString(pairs[0].EncryptionKey)
+		require.NoError(t, err)
+		assert.Len(t, ek, 32)
+	})
+}
+
+func TestResolveSessionKeyPairs(t *testing.T) {
+	validSK := hex.EncodeToString(make([]byte, 32))
+	validEK := hex.EncodeToString(make([]byte, 32))
+
+	t.Run("returns decoded bytes for explicit config keys", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: validEK}}
+
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Len(t, result[0], 32)
+		assert.Len(t, result[1], 32)
+	})
+
+	t.Run("errors on non-hex signing key", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: "not-hex!", EncryptionKey: validEK}}
+
+		_, err := resolveSessionKeyPairs(cfg)
+		assert.ErrorContains(t, err, "signing-key")
+	})
+
+	t.Run("errors on non-hex encryption key", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: "not-hex!"}}
+
+		_, err := resolveSessionKeyPairs(cfg)
+		assert.ErrorContains(t, err, "encryption-key")
+	})
+
+	t.Run("errors on invalid encryption key length", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: hex.EncodeToString(make([]byte, 10))}}
+
+		_, err := resolveSessionKeyPairs(cfg)
+		assert.ErrorContains(t, err, "encryption-key")
+	})
+
+	t.Run("generates random pair for cluster env when no keys configured", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = nil
+
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+	})
+}

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -25,7 +25,10 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 
+	"github.com/kubetail-org/kubetail/modules/dashboard/graph"
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/shared/ginhelpers"
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
@@ -76,6 +79,29 @@ func csrfProtectionMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		c.Next()
+	}
+}
+
+// websocketCSRFContextMiddleware places the session's CSRF token into the
+// request context (for the dashboard's WebSocket InitFunc) and stamps it as
+// X-Forwarded-CSRF-Token (for the cluster-api proxy to forward upstream).
+// Always strips any client-supplied X-Forwarded-CSRF-Token to prevent
+// header smuggling.
+func websocketCSRFContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Header.Del(httphelpers.HeaderForwardedCSRFToken)
+
+		if !ginhelpers.IsWebSocketRequest(c) {
+			c.Next()
+			return
+		}
+		session := sessions.Default(c)
+		if tok, ok := session.Get(csrfTokenSessionKey).(string); ok && tok != "" {
+			ctx := context.WithValue(c.Request.Context(), graph.SessionCSRFTokenCtxKey, tok)
+			c.Request = c.Request.WithContext(ctx)
+			c.Request.Header.Set(httphelpers.HeaderForwardedCSRFToken, tok)
+		}
 		c.Next()
 	}
 }

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -16,6 +16,8 @@ package app
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"net/http"
 	"slices"
 	"strings"
@@ -37,6 +39,22 @@ var allowedSecFetchSite = []string{"same-origin"}
 // handles instead).
 var safeMethods = []string{http.MethodGet, http.MethodHead, http.MethodOptions}
 
+// getOrCreateCSRFToken returns the session's CSRF token, generating and
+// persisting a new one if none exists yet.
+func getOrCreateCSRFToken(session sessions.Session) (token string, isNew bool) {
+	if val, ok := session.Get(csrfTokenSessionKey).(string); ok && val != "" {
+		return val, false
+	}
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	token = hex.EncodeToString(b)
+	session.Set(csrfTokenSessionKey, token)
+	return token, true
+}
+
 func csrfProtectionMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if slices.Contains(safeMethods, c.Request.Method) {
@@ -44,7 +62,16 @@ func csrfProtectionMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		// Layer 1: Sec-Fetch-Site check
 		if !slices.Contains(allowedSecFetchSite, c.GetHeader("Sec-Fetch-Site")) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		// Layer 2: CSRF token check
+		session := sessions.Default(c)
+		token, _ := session.Get(csrfTokenSessionKey).(string)
+		if token == "" || c.GetHeader("X-CSRF-Token") != token {
 			c.AbortWithStatus(http.StatusForbidden)
 			return
 		}

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kubetail-org/kubetail/modules/dashboard/graph"
 	"github.com/kubetail-org/kubetail/modules/dashboard/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/shared/httphelpers"
 )
 
 func TestAuthenticationMiddleware(t *testing.T) {
@@ -301,6 +303,98 @@ func TestK8sTokenRequiredMiddleware(t *testing.T) {
 			resp := w.Result()
 			assert.Equal(t, "no-store", resp.Header["Cache-Control"][0])
 			assert.Equal(t, tt.wantStatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestWebSocketCSRFContextMiddleware(t *testing.T) {
+	const sessTok = "session-csrf-token"
+
+	tests := []struct {
+		name          string
+		hasSession    bool
+		isUpgrade     bool
+		clientHeader  string // value sent by client; "" = absent
+		wantCtxValue  any
+		wantOutHeader string
+	}{
+		{
+			name:          "WS upgrade with session: ctx and header set from session",
+			hasSession:    true,
+			isUpgrade:     true,
+			wantCtxValue:  sessTok,
+			wantOutHeader: sessTok,
+		},
+		{
+			name:         "non-WS request leaves ctx and header unset even with session",
+			hasSession:   true,
+			isUpgrade:    false,
+			wantCtxValue: nil,
+		},
+		{
+			name:         "WS upgrade without session leaves ctx and header unset",
+			isUpgrade:    true,
+			wantCtxValue: nil,
+		},
+		{
+			name:         "client-supplied X-Forwarded-CSRF-Token is stripped (no session)",
+			isUpgrade:    true,
+			clientHeader: "spoofed",
+			wantCtxValue: nil,
+		},
+		{
+			name:          "client-supplied X-Forwarded-CSRF-Token is overwritten (with session)",
+			hasSession:    true,
+			isUpgrade:     true,
+			clientHeader:  "spoofed",
+			wantCtxValue:  sessTok,
+			wantOutHeader: sessTok,
+		},
+		{
+			name:         "non-WS request strips client-supplied X-Forwarded-CSRF-Token",
+			isUpgrade:    false,
+			clientHeader: "spoofed",
+			wantCtxValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(sessions.Sessions("session", cookie.NewStore([]byte("xx"))))
+			router.Use(func(c *gin.Context) {
+				if tt.hasSession {
+					session := sessions.Default(c)
+					session.Set(csrfTokenSessionKey, sessTok)
+					session.Save()
+				}
+				c.Next()
+			})
+			router.Use(websocketCSRFContextMiddleware())
+
+			var (
+				gotCtxValue  any
+				gotOutHeader string
+			)
+			router.GET("/", func(c *gin.Context) {
+				gotCtxValue = c.Request.Context().Value(graph.SessionCSRFTokenCtxKey)
+				gotOutHeader = c.Request.Header.Get(httphelpers.HeaderForwardedCSRFToken)
+				c.String(http.StatusOK, "ok")
+			})
+
+			r := httptest.NewRequest("GET", "/", nil)
+			if tt.isUpgrade {
+				r.Header.Set("Connection", "Upgrade")
+				r.Header.Set("Upgrade", "websocket")
+			}
+			if tt.clientHeader != "" {
+				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.clientHeader)
+			}
+
+			router.ServeHTTP(httptest.NewRecorder(), r)
+
+			assert.Equal(t, tt.wantCtxValue, gotCtxValue)
+			assert.Equal(t, tt.wantOutHeader, gotOutHeader)
 		})
 	}
 }

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -120,41 +120,139 @@ func TestAuthenticationMiddlewareRejectsWhitespaceToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 }
 
-func TestCSRFProtectionMiddleware(t *testing.T) {
+const csrfPreseededToken = "testtokenvalue1234"
+
+// runCSRFCase executes one CSRF middleware test case and returns the response.
+func runCSRFCase(t *testing.T, method string, header http.Header, seedToken bool) *http.Response {
+	t.Helper()
+
+	store := cookie.NewStore([]byte("secret"))
+	store.Options(sessions.Options{Path: "/", Secure: false})
+
+	router := gin.New()
+	router.Use(sessions.Sessions("session", store))
+	if seedToken {
+		router.Use(func(c *gin.Context) {
+			session := sessions.Default(c)
+			session.Set(csrfTokenSessionKey, csrfPreseededToken)
+			session.Save()
+			c.Next()
+		})
+	}
+	router.Use(csrfProtectionMiddleware())
+	router.Any("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(method, "/", nil)
+	for k, v := range header {
+		r.Header[k] = v
+	}
+	router.ServeHTTP(w, r)
+	return w.Result()
+}
+
+func TestCSRFProtectionMiddlewareAllows(t *testing.T) {
 	tests := []struct {
-		name           string
-		method         string
-		setHeader      http.Header
-		wantStatusCode int
+		name      string
+		method    string
+		setHeader http.Header
+		seedToken bool
 	}{
 		// Safe methods bypass the check (no state change to protect).
-		{"GET without Sec-Fetch-Site is allowed", "GET", http.Header{}, http.StatusOK},
-		{"GET cross-site is allowed", "GET", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusOK},
-		{"HEAD without Sec-Fetch-Site is allowed", "HEAD", http.Header{}, http.StatusOK},
-		{"OPTIONS without Sec-Fetch-Site is allowed", "OPTIONS", http.Header{}, http.StatusOK},
-		// Unsafe methods enforce same-origin Sec-Fetch-Site.
-		{"POST without Sec-Fetch-Site is blocked", "POST", http.Header{}, http.StatusForbidden},
-		{"POST same-origin is allowed", "POST", http.Header{"Sec-Fetch-Site": []string{"same-origin"}}, http.StatusOK},
-		{"POST cross-site is blocked", "POST", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
-		{"DELETE cross-site is blocked", "DELETE", http.Header{"Sec-Fetch-Site": []string{"cross-site"}}, http.StatusForbidden},
+		{
+			name:      "GET without Sec-Fetch-Site",
+			method:    "GET",
+			setHeader: http.Header{},
+			seedToken: false,
+		},
+		{
+			name:      "GET cross-site",
+			method:    "GET",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
+			seedToken: false,
+		},
+		{
+			name:      "HEAD without Sec-Fetch-Site",
+			method:    "HEAD",
+			setHeader: http.Header{},
+			seedToken: false,
+		},
+		{
+			name:      "OPTIONS without Sec-Fetch-Site",
+			method:    "OPTIONS",
+			setHeader: http.Header{},
+			seedToken: false,
+		},
+		// Unsafe same-origin requests with a valid CSRF token are allowed.
+		{
+			name:      "POST same-origin with correct X-CSRF-Token",
+			method:    "POST",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-origin"}, "X-Csrf-Token": []string{csrfPreseededToken}},
+			seedToken: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router := gin.New()
-			router.Use(csrfProtectionMiddleware())
-			router.Any("/", func(c *gin.Context) {
-				c.String(http.StatusOK, "ok")
-			})
+			resp := runCSRFCase(t, tt.method, tt.setHeader, tt.seedToken)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
 
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest(tt.method, "/", nil)
-			for k, v := range tt.setHeader {
-				r.Header[k] = v
-			}
-			router.ServeHTTP(w, r)
+func TestCSRFProtectionMiddlewareForbids(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		setHeader http.Header
+		seedToken bool
+	}{
+		// Unsafe methods require same-origin Sec-Fetch-Site.
+		{
+			name:      "POST without Sec-Fetch-Site",
+			method:    "POST",
+			setHeader: http.Header{},
+			seedToken: false,
+		},
+		{
+			name:      "POST cross-site",
+			method:    "POST",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
+			seedToken: false,
+		},
+		{
+			name:      "DELETE cross-site",
+			method:    "DELETE",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"cross-site"}},
+			seedToken: false,
+		},
+		// Unsafe same-origin requests still require a valid CSRF token.
+		{
+			name:      "POST same-origin without session token",
+			method:    "POST",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
+			seedToken: false,
+		},
+		{
+			name:      "POST same-origin with no X-CSRF-Token header",
+			method:    "POST",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-origin"}},
+			seedToken: true,
+		},
+		{
+			name:      "POST same-origin with wrong X-CSRF-Token",
+			method:    "POST",
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-origin"}, "X-Csrf-Token": []string{"wrongtoken"}},
+			seedToken: true,
+		},
+	}
 
-			assert.Equal(t, tt.wantStatusCode, w.Result().StatusCode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := runCSRFCase(t, tt.method, tt.setHeader, tt.seedToken)
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 		})
 	}
 }

--- a/modules/dashboard/pkg/app/testutils_test.go
+++ b/modules/dashboard/pkg/app/testutils_test.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -36,7 +37,10 @@ func newTestConfig() *config.Config {
 	cfg.BasePath = "/"
 	cfg.Environment = sharedcfg.EnvironmentCluster
 	cfg.Logging.AccessLog.Enabled = false
-	cfg.Session.Secret = "TESTSESSIONSECRET"
+	cfg.Session.KeyPairs = []config.KeyPair{{
+		SigningKey:    hex.EncodeToString([]byte("TESTSESSIONSIGNINGKEY16byteslong")),
+		EncryptionKey: hex.EncodeToString([]byte("TESTSESSIONENCKEY16byteslong123!")),
+	}}
 	cfg.Session.Cookie.Name = "session"
 	return cfg
 }

--- a/modules/dashboard/pkg/app/websocket_test.go
+++ b/modules/dashboard/pkg/app/websocket_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubetail-org/kubetail/modules/shared/testutils"
+)
+
+func TestWebSocketCSRFToken(t *testing.T) {
+	app := newTestApp(nil)
+
+	tests := []struct {
+		name      string
+		token     func(captured string) any // returns csrfToken value to send (nil = omit)
+		wantAck   bool
+		wantClose bool
+	}{
+		{
+			name:      "missing csrfToken is rejected",
+			token:     func(string) any { return nil },
+			wantClose: true,
+		},
+		{
+			name:      "wrong csrfToken is rejected",
+			token:     func(string) any { return "bad" },
+			wantClose: true,
+		},
+		{
+			name:    "matching csrfToken is accepted",
+			token:   func(captured string) any { return captured },
+			wantAck: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := testutils.NewWebTestClient(t, app)
+			defer client.Teardown()
+
+			// Establish session and capture CSRF token
+			resp := client.Get("/api/auth/session")
+			captured := resp.Header.Get("X-CSRF-Token")
+			require.NotEmpty(t, captured)
+
+			wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+			dialer := websocket.Dialer{
+				Subprotocols: []string{"graphql-transport-ws"},
+				Jar:          client.Server.Client().Jar,
+			}
+			conn, _, err := dialer.Dial(wsURL, http.Header{"Origin": []string{client.Server.URL}})
+			require.NoError(t, err)
+			defer conn.Close()
+
+			initMsg := map[string]any{"type": "connection_init"}
+			if tok := tt.token(captured); tok != nil {
+				initMsg["payload"] = map[string]any{"csrfToken": tok}
+			}
+			require.NoError(t, conn.WriteJSON(initMsg))
+
+			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			var msg map[string]any
+			err = conn.ReadJSON(&msg)
+			if tt.wantAck {
+				require.NoError(t, err)
+				require.Equal(t, "connection_ack", msg["type"])
+				return
+			}
+			if err == nil {
+				require.NotEqual(t, "connection_ack", msg["type"])
+				conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+				_, _, err = conn.ReadMessage()
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -90,7 +90,7 @@ type Config struct {
 			SameSite http.SameSite `mapstructure:"same-site"`
 		}
 
-		KeyPairs []KeyPair `mapstructure:"key-pairs" validate:"required,min=1,dive"`
+		KeyPairs []KeyPair `mapstructure:"key-pairs" validate:"dive"`
 	}
 
 	// TLS options

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -30,6 +30,14 @@ import (
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 )
 
+// KeyPair holds a signing key and an optional encryption key for session cookies.
+// The first pair in Session.KeyPairs is used for new cookies; additional pairs
+// are accepted for reading only, enabling key rotation.
+type KeyPair struct {
+	SigningKey    string `mapstructure:"signing-key" json:"signing-key" validate:"required"`
+	EncryptionKey string `mapstructure:"encryption-key" json:"encryption-key"`
+}
+
 // AuthMode represents the authentication mode for the dashboard.
 type AuthMode string
 
@@ -71,9 +79,7 @@ type Config struct {
 
 	// session options
 	Session struct {
-		Secret string
-
-		// cookie options
+		// Cookie options
 		Cookie struct {
 			Name     string
 			Path     string
@@ -83,6 +89,8 @@ type Config struct {
 			HttpOnly bool          `mapstructure:"http-only"`
 			SameSite http.SameSite `mapstructure:"same-site"`
 		}
+
+		KeyPairs []KeyPair `mapstructure:"key-pairs" validate:"required,min=1,dive"`
 	}
 
 	// TLS options
@@ -106,6 +114,7 @@ func (cfg *Config) validate() error {
 // Filenames for files stored under LocalStorageDir. Kept unexported so
 // callers configure only the parent directory, not individual filenames.
 const preferencesFilename = "preferences.json"
+const sessionKeysFilename = "session-keys.json"
 
 // PreferencesPath returns the full path to the preferences file, or an
 // empty string when local storage is not configured.
@@ -114,6 +123,15 @@ func (cfg *Config) PreferencesPath() string {
 		return ""
 	}
 	return filepath.Join(cfg.LocalStorageDir, preferencesFilename)
+}
+
+// SessionKeysPath returns the full path to the persisted session keys file, or
+// an empty string when local storage is not configured.
+func (cfg *Config) SessionKeysPath() string {
+	if cfg.LocalStorageDir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.LocalStorageDir, sessionKeysFilename)
 }
 
 func DefaultConfig() *Config {
@@ -133,7 +151,6 @@ func DefaultConfig() *Config {
 	cfg.Logging.Format = "json"
 	cfg.Logging.AccessLog.Enabled = true
 	cfg.Logging.AccessLog.HideHealthChecks = false
-	cfg.Session.Secret = ""
 	cfg.Session.Cookie.Name = "kubetail_dashboard_session"
 	cfg.Session.Cookie.Path = "/"
 	cfg.Session.Cookie.Domain = ""

--- a/modules/go.work.sum
+++ b/modules/go.work.sum
@@ -147,6 +147,7 @@ cloud.google.com/go/websecurityscanner v1.6.4/go.mod h1:mUiyMQ+dGpPPRkHgknIZeCzS
 cloud.google.com/go/workflows v1.12.3/go.mod h1:fmOUeeqEwPzIU81foMjTRQIdwQHADi/vEr1cx9R1m5g=
 cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
@@ -235,6 +236,7 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
@@ -361,6 +363,7 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
@@ -394,6 +397,7 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -407,6 +411,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -626,6 +631,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -951,7 +957,6 @@ go.opentelemetry.io/otel/sdk v1.36.0/go.mod h1:+lC+mTgD+MUWfjJubi2vvXWcVxyr9rmls
 go.opentelemetry.io/otel/sdk v1.39.0/go.mod h1:vDojkC4/jsTJsE+kh+LXYQlbL8CgrEcwmt1ENZszdJE=
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
-go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.opentelemetry.io/otel/trace v1.32.0/go.mod h1:+i4rkvCraA+tG6AzwloGaCtkx53Fa+L+V8e9a7YvhT8=
 go.opentelemetry.io/otel/trace v1.33.0/go.mod h1:uIcdVUZMpTAmz0tI1z04GoVSezK37CbGV4fr1f2nBck=
@@ -1333,6 +1338,7 @@ google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 h1:1hfbdAfFbkmpg41000wDVqr7jUpK/Yo+LPnIxxGzmkg=
 google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3/go.mod h1:5RBcpGRxr25RbDzY5w+dmaqpSEvl8Gwl1x2CICf60ic=
 google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80/go.mod h1:cc8bqMqtv9gMOr0zHg2Vzff5ULhhL2IXP4sbcn32Dro=
 google.golang.org/genproto/googleapis/api v0.0.0-20231120223509-83a465c0220f/go.mod h1:Uy9bTZJqmfrw2rIBxgGLnamc78euZULUBrLZ9XTITKI=

--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 )
 
+// HeaderForwardedCSRFToken is the request header used to forward a
+// dashboard-session-bound CSRF token from the dashboard reverse proxy to
+// the cluster-api server, where it gates the GraphQL WebSocket InitFunc.
+const HeaderForwardedCSRFToken = "X-Forwarded-CSRF-Token"
+
 // IsSameOrigin reports whether r's Origin header is present and matches
 // the request's scheme and host (per the WebSocket spec's same-origin
 // rule). A missing Origin returns false.

--- a/modules/shared/testutils/testutils.go
+++ b/modules/shared/testutils/testutils.go
@@ -20,6 +20,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -44,6 +45,7 @@ type WebTestClient struct {
 	httpclient *http.Client
 	baseURL    string
 	t          *testing.T
+	csrfToken  string
 }
 
 // Execute GET request
@@ -71,6 +73,8 @@ func (c *WebTestClient) PostForm(url string, form url.Values) WebTestResponse {
 	return c.Do(req)
 }
 
+var csrfSafeMethods = []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+
 // Execute request
 func (c *WebTestClient) Do(req *http.Request) WebTestResponse {
 	// Default to same-origin so CSRF middleware treats this as a legitimate
@@ -79,10 +83,19 @@ func (c *WebTestClient) Do(req *http.Request) WebTestResponse {
 		req.Header.Set("Sec-Fetch-Site", "same-origin")
 	}
 
+	// Auto-inject the CSRF token on unsafe methods so callers don't manage it.
+	if !slices.Contains(csrfSafeMethods, req.Method) && c.csrfToken != "" && req.Header.Get("X-CSRF-Token") == "" {
+		req.Header.Set("X-CSRF-Token", c.csrfToken)
+	}
+
 	// execute request
 	resp, err := c.httpclient.Do(req)
 	if err != nil {
 		c.t.Fatal(err)
+	}
+
+	if tok := resp.Header.Get("X-CSRF-Token"); tok != "" {
+		c.csrfToken = tok
 	}
 
 	// read body


### PR DESCRIPTION
## Summary

Adds CSRF protection to the dashboard backend and cluster-api proxy. Unsafe-method HTTP requests are now gated by a synchronizer-token check paired with `Sec-Fetch-Site: same-origin`, and WebSocket upgrades validate the same session token in the `graphql-ws` `connection_init` payload (since browsers can't set custom headers on WebSocket handshakes). The legacy `session.secret` config is replaced with `session.key-pairs` to support zero-downtime key rotation.

## Key Changes

- Dashboard middleware issues a per-session CSRF token via `SessionGET` (`X-CSRF-Token` response header) and rejects unsafe-method requests whose `X-CSRF-Token` header doesn't match the value stored in the session, plus a `Sec-Fetch-Site: same-origin` check.
- Apollo client wires an `X-CSRF-Token` link that waits for the session fetch before the first GraphQL POST and retries once on 403 (handles server restart / key rotation). `SessionProvider` now wraps `ApolloProvider` so the token is available before any request fires.
- `/graphql` and `/cluster-api-proxy/graphql` WebSocket transports validate `connectionParams.csrfToken` in `graphql-ws` `InitFunc`. The dashboard stamps the session token onto `X-Forwarded-CSRF-Token` for the proxy hop (stripping any client-supplied value to prevent smuggling); cluster-api reads it back from the header.
- `session.secret` replaced by `session.key-pairs` (list of hash/block key pairs) for zero-downtime rotation. Desktop mode persists an auto-generated pair to disk. Empty config validates and auto-generates.
- GET transport removed from both GraphQL servers (POST-only).
- Bot/programmatic clients that don't carry session cookies are unaffected; the upgrade-time Origin gate remains in place as a defense-in-depth check.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused