### PR TITLE
🎣 Relax hex requirement for session key-pairs

### DIFF
--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -17,6 +17,7 @@ package app
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
+	zlog "github.com/rs/zerolog/log"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -109,17 +111,12 @@ func resolveSessionKeyPairs(cfg *config.Config) ([][]byte, error) {
 	}
 
 	result := make([][]byte, 0, len(pairs)*2)
-	for _, kp := range pairs {
-		sk, err := hex.DecodeString(kp.SigningKey)
-		if err != nil {
-			return nil, fmt.Errorf("session key-pair signing-key must be hex-encoded: %w", err)
-		}
-		ek, err := hex.DecodeString(kp.EncryptionKey)
-		if err != nil {
-			return nil, fmt.Errorf("session key-pair encryption-key must be hex-encoded: %w", err)
-		}
-		if !validAESKeySize(len(ek)) {
-			return nil, fmt.Errorf("session key-pair encryption-key must decode to 16, 24, or 32 bytes (got %d)", len(ek))
+	for i, kp := range pairs {
+		sk := decodeOrDeriveKey(kp.SigningKey, "signing-key", i, true)
+
+		var ek []byte
+		if kp.EncryptionKey != "" {
+			ek = decodeOrDeriveKey(kp.EncryptionKey, "encryption-key", i, false)
 		}
 		// gorilla/securecookie treats a non-nil block key as AES input, so an
 		// empty (but non-nil) slice would be rejected as an invalid AES key.
@@ -129,6 +126,25 @@ func resolveSessionKeyPairs(cfg *config.Config) ([][]byte, error) {
 		result = append(result, sk, ek)
 	}
 	return result, nil
+}
+
+// decodeOrDeriveKey returns hex-decoded bytes when input is valid hex of an
+// acceptable length; otherwise it derives a deterministic 32-byte key via
+// SHA-256 and logs a warning recommending the user switch to hex.
+// allowAnyLen controls whether non-AES lengths are accepted from hex input
+// (true for signing keys, false for encryption keys which must be 16/24/32).
+func decodeOrDeriveKey(input, label string, pairIndex int, allowAnyLen bool) []byte {
+	if decoded, err := hex.DecodeString(input); err == nil {
+		if allowAnyLen || validAESKeySize(len(decoded)) {
+			return decoded
+		}
+	}
+	sum := sha256.Sum256([]byte(input))
+	zlog.Warn().
+		Int("pairIndex", pairIndex).
+		Str("field", label).
+		Msgf("session key-pair %s is not valid hex; deriving 32-byte key via SHA-256. For best results, configure a hex-encoded key.", label)
+	return sum[:]
 }
 
 // persistedKeyPair is the on-disk representation of a key pair. It extends

--- a/modules/dashboard/pkg/app/helpers_test.go
+++ b/modules/dashboard/pkg/app/helpers_test.go
@@ -15,6 +15,7 @@
 package app
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -169,28 +170,65 @@ func TestResolveSessionKeyPairs(t *testing.T) {
 		assert.Len(t, result[1], 32)
 	})
 
-	t.Run("errors on non-hex signing key", func(t *testing.T) {
+	t.Run("derives signing key when not hex", func(t *testing.T) {
 		cfg := newTestConfig()
-		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: "not-hex!", EncryptionKey: validEK}}
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: "my passphrase", EncryptionKey: validEK}}
 
-		_, err := resolveSessionKeyPairs(cfg)
-		assert.ErrorContains(t, err, "signing-key")
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Len(t, result[0], 32)
+
+		expected := sha256.Sum256([]byte("my passphrase"))
+		assert.Equal(t, expected[:], result[0])
 	})
 
-	t.Run("errors on non-hex encryption key", func(t *testing.T) {
+	t.Run("derives encryption key when not hex", func(t *testing.T) {
 		cfg := newTestConfig()
-		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: "not-hex!"}}
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: "another passphrase"}}
 
-		_, err := resolveSessionKeyPairs(cfg)
-		assert.ErrorContains(t, err, "encryption-key")
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Len(t, result[1], 32)
+
+		expected := sha256.Sum256([]byte("another passphrase"))
+		assert.Equal(t, expected[:], result[1])
 	})
 
-	t.Run("errors on invalid encryption key length", func(t *testing.T) {
+	t.Run("derives encryption key when hex but wrong length", func(t *testing.T) {
 		cfg := newTestConfig()
-		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: hex.EncodeToString(make([]byte, 10))}}
+		shortHex := hex.EncodeToString(make([]byte, 10))
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: shortHex}}
 
-		_, err := resolveSessionKeyPairs(cfg)
-		assert.ErrorContains(t, err, "encryption-key")
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Len(t, result[1], 32)
+
+		expected := sha256.Sum256([]byte(shortHex))
+		assert.Equal(t, expected[:], result[1])
+	})
+
+	t.Run("derivation is deterministic", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: "passphrase-a", EncryptionKey: "passphrase-b"}}
+
+		r1, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		r2, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, r1, r2)
+	})
+
+	t.Run("empty encryption key stays nil", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Session.KeyPairs = []config.KeyPair{{SigningKey: validSK, EncryptionKey: ""}}
+
+		result, err := resolveSessionKeyPairs(cfg)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Nil(t, result[1])
 	})
 
 	t.Run("generates random pair for cluster env when no keys configured", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Configuring the dashboard with a non-hex `signing-key` or `encryption-key` was a fatal error at startup (e.g. `session key-pair signing-key must be hex-encoded`). This made it easy to misconfigure the dashboard in production and offered no graceful fallback. This PR relaxes that requirement: any string works, and we transparently derive a strong key when the input isn't valid hex.

## Key Changes

- `resolveSessionKeyPairs` now treats hex decoding as a fast path. When the input isn't valid hex (or is hex of an unsupported AES length for an encryption key), it falls back to deriving a deterministic 32-byte key via SHA-256 and logs a warning recommending hex.
- Empty `encryption-key` still means "no encryption" (unchanged).
- Desktop-mode persisted key file (`validPersistedKeyPairs`) remains strict, since we generate it ourselves.
- Tests updated to cover the new derivation paths (non-hex signing key, non-hex encryption key, hex-but-wrong-length encryption key, deterministic output, empty encryption key stays nil).

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused