### PR TITLE
✨ Trigger publish workflows only on stable releases

### DIFF
--- a/.github/workflows/publish-alpine.yml
+++ b/.github/workflows/publish-alpine.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-copr.yml
+++ b/.github/workflows/publish-copr.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-guru.yml
+++ b/.github/workflows/publish-guru.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-krew.yml
+++ b/.github/workflows/publish-krew.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-macports.yml
+++ b/.github/workflows/publish-macports.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-nix.yml
+++ b/.github/workflows/publish-nix.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-obs.yml
+++ b/.github/workflows/publish-obs.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -388,6 +388,7 @@ jobs:
         with:
           files: assets/*
           draft: true
+          prerelease: ${{ contains(needs.config.outputs.version, '-') }}
 
       - name: Cleanup GPG
         if: always()


### PR DESCRIPTION
Closes #1108 

## Summary

The publish-* workflows currently run for every published GitHub release, including pre-releases like cli/v1.1.1-rc1. This causes release candidates to fan out to every package registry alongside stable versions. This PR scopes the auto-trigger to stable releases only.

## Key Changes

- Switched all twelve publish-* workflows from the `published` to the `released` GitHub release activity type, which excludes pre-releases.
- Updated `release-cli.yml` to mark drafts whose version contains a `-` (e.g. `1.1.1-rc1`) as pre-releases, so the new filter has the right metadata to act on.
- Manual `workflow_dispatch` triggers are unchanged — pre-release publishing is still possible by hand if needed.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused