### PR TITLE
✨ Add CSRF token support to GraphiQL page

### DIFF
--- a/modules/dashboard/static/graphiql.html
+++ b/modules/dashboard/static/graphiql.html
@@ -41,10 +41,17 @@
       // get graphql endpoint
       const graphqlEndpoint = (new URL(basePath + 'graphql', window.location.origin)).toString();
 
+      // fetch CSRF token from session endpoint
+      const sessionEndpoint = (new URL(basePath + 'api/auth/session', window.location.origin)).toString();
+      const sessionResp = await fetch(sessionEndpoint, { credentials: 'same-origin' });
+      const csrfToken = sessionResp.headers.get('X-CSRF-Token') || '';
+
       // init fetcher
       const fetcher = GraphiQL.createFetcher({
         url: graphqlEndpoint,
         subscriptionUrl: graphqlEndpoint.replace(/^(http)/, 'ws'),
+        headers: { 'X-CSRF-Token': csrfToken },
+        wsConnectionParams: { csrfToken },
       });
 
       ReactDOM.render(


### PR DESCRIPTION
## Summary

The dashboard backend enforces CSRF protection on `/graphql` (HTTP `X-CSRF-Token` header and a `csrfToken` field in the WebSocket `connection_init` payload), but the bundled GraphiQL page wasn't sending either, so it could no longer talk to the API. This restores GraphiQL by having it acquire and forward the session's CSRF token.

## Key Changes

- On load, GraphiQL now fetches `/api/auth/session` to obtain the session's CSRF token from the `X-CSRF-Token` response header.
- The token is passed to `GraphiQL.createFetcher` via `headers` (HTTP queries/mutations) and `wsConnectionParams` (WebSocket subscriptions).

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused