### PR TITLE
🎣 Fix CSRF rejection of legitimate same-origin POSTs

### DIFF
--- a/dashboard-ui/src/pages/auth/login.test.tsx
+++ b/dashboard-ui/src/pages/auth/login.test.tsx
@@ -14,12 +14,15 @@
 
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 import { useSession } from '@/lib/auth';
 import LoginPage from '@/pages/auth/login';
 import { renderElement } from '@/test-utils';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 describe('Login Page', () => {
   it('renders loading page while waiting for session', () => {
@@ -37,6 +40,23 @@ describe('Login Page', () => {
   it('renders login form when user is logged out', () => {
     const { getByText } = renderElement(<LoginPage />);
     expect(getByText('Sign into Kubernetes')).toBeInTheDocument();
+  });
+
+  it('sends X-CSRF-Token header on login POST', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    const { getByText, getByPlaceholderText } = renderElement(<LoginPage />);
+
+    fireEvent.change(getByPlaceholderText(/Enter your kubernetes token/i), {
+      target: { value: 'my-k8s-token' },
+    });
+    fireEvent.click(getByText('Sign in'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-CSRF-Token']).toBe('test-csrf-token');
   });
 
   it('navigates to callbackUrl when user is logged in', () => {

--- a/dashboard-ui/src/pages/auth/login.tsx
+++ b/dashboard-ui/src/pages/auth/login.tsx
@@ -25,7 +25,7 @@ import { Spinner } from '@kubetail/ui/elements/spinner';
 
 import ModalLayout from '@/components/layouts/ModalLayout';
 import LoadingPage from '@/components/utils/LoadingPage';
-import { getSession, useSession } from '@/lib/auth';
+import { getCsrfToken, getSession, useSession, waitForCsrfToken } from '@/lib/auth';
 
 const loginForm = z.object({
   token: z.string().min(1, 'Please enter a token'),
@@ -58,10 +58,12 @@ export default function LoginPage() {
 
     setServerLoading(true);
     const url = new URL('/api/auth/login', window.location.origin);
+    await waitForCsrfToken();
     const resp = await fetch(url, {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
       },
       body: JSON.stringify(values),
     });

--- a/dashboard-ui/src/pages/auth/logout.test.tsx
+++ b/dashboard-ui/src/pages/auth/logout.test.tsx
@@ -14,7 +14,7 @@
 
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 import { useSession } from '@/lib/auth';
@@ -38,6 +38,18 @@ describe('Logout Page', () => {
 
     // assertions
     expect(getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('sends X-CSRF-Token header on logout POST', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    renderElement(<LogoutPage />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-CSRF-Token']).toBe('test-csrf-token');
   });
 
   it('navigates to callbackUrl when user is logged out', () => {

--- a/dashboard-ui/src/pages/auth/logout.tsx
+++ b/dashboard-ui/src/pages/auth/logout.tsx
@@ -16,7 +16,7 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import LoadingPage from '@/components/utils/LoadingPage';
-import { getSession, useSession } from '@/lib/auth';
+import { getCsrfToken, getSession, useSession, waitForCsrfToken } from '@/lib/auth';
 
 export default function Logout() {
   const navigate = useNavigate();
@@ -31,8 +31,12 @@ export default function Logout() {
   useEffect(() => {
     (async () => {
       const url = new URL('/api/auth/logout', window.location.origin);
+      await waitForCsrfToken();
       const resp = await fetch(url, {
         method: 'post',
+        headers: {
+          'X-CSRF-Token': getCsrfToken(),
+        },
       });
 
       // update session

--- a/dashboard-ui/src/pages/console/download.tsx
+++ b/dashboard-ui/src/pages/console/download.tsx
@@ -32,6 +32,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@kubetail/ui/elements/t
 
 import appConfig from '@/app-config';
 import { parseTimestamp } from '@/components/widgets/DateRangeDropdown';
+import { getCsrfToken, waitForCsrfToken } from '@/lib/auth';
 import { LogRecordsQueryMode, LogSourceFilter } from '@/lib/graphql/dashboard/__generated__/graphql';
 import { useTimezone } from '@/lib/timezone';
 import { ClusterAPIProxyPathInput, clusterAPIProxyPath, getBasename, joinPaths } from '@/lib/util';
@@ -218,6 +219,11 @@ export function submitLogDownload(action: string, filters: DownloadFilters, args
   append('includeMetadata', String(args.includeMetadata));
   (args.columns ?? []).forEach((c) => append('columns', c));
 
+  // HTML form submission can't set headers, so deliver the CSRF token via a
+  // hidden form field. The server middleware accepts this fallback for
+  // form-encoded POSTs.
+  append('csrfToken', getCsrfToken());
+
   document.body.appendChild(form);
   try {
     form.submit();
@@ -253,7 +259,7 @@ export const DownloadDialog = (props: DownloadDialogProps) => {
   const [outputFormat, setOutputFormat] = useState<OutputFormat>('tsv');
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     if (!logServerClient) return;
     const args = buildDownloadArgs(
       { rangeMode, firstN, lastN, since, until, messageFormat, contentMode, outputFormat },
@@ -269,6 +275,7 @@ export const DownloadDialog = (props: DownloadDialogProps) => {
       shouldUseClusterAPI: !!shouldUseClusterAPI,
       kubeContext: kubeContext ?? '',
     });
+    await waitForCsrfToken();
     submitLogDownload(action, downloadSource, args);
 
     onOpenChange(false);

--- a/dashboard-ui/vitest.setup.ts
+++ b/dashboard-ui/vitest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'; // adds .toBeInTheDocument() to global `expe
 import { cleanup } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
-import { getSession, useSession } from '@/lib/auth';
+import { getCsrfToken, getSession, useSession, waitForCsrfToken } from '@/lib/auth';
 import { useIsClusterAPIEnabled } from '@/lib/hooks';
 
 vi.mock('@/lib/auth', async (importOriginal) => {
@@ -12,6 +12,8 @@ vi.mock('@/lib/auth', async (importOriginal) => {
     ...mod,
     getSession: vi.fn(),
     useSession: vi.fn(),
+    getCsrfToken: vi.fn(),
+    waitForCsrfToken: vi.fn(),
   };
 });
 
@@ -79,6 +81,9 @@ beforeEach(() => {
   });
 
   (useIsClusterAPIEnabled as Mock).mockReturnValue(true);
+
+  (getCsrfToken as Mock).mockReturnValue('test-csrf-token');
+  (waitForCsrfToken as Mock).mockResolvedValue(undefined);
 });
 
 afterEach(() => {

--- a/modules/dashboard/pkg/app/download_test.go
+++ b/modules/dashboard/pkg/app/download_test.go
@@ -17,6 +17,7 @@ package app
 import (
 	"context"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -191,6 +192,82 @@ func TestDownloadResponseHeaders(t *testing.T) {
 	cd := w.Header().Get("Content-Disposition")
 	assert.True(t, strings.HasPrefix(cd, `attachment; filename="logs-`), "Content-Disposition: %q", cd)
 	assert.True(t, strings.HasSuffix(cd, `.tsv"`), "Content-Disposition: %q", cd)
+}
+
+// Behavioral check: the download endpoint accepts the CSRF token via a
+// `csrfToken` form field when no X-CSRF-Token header is present (HTML form
+// submission via a hidden iframe can't set headers).
+//
+// Uses token auth mode so the request passes the CSRF gate and is rejected
+// later by k8sAuthenticationMiddleware (401) — we assert specifically that
+// the CSRF gate did not return 403.
+func TestDownloadPOSTAcceptsCSRFTokenInFormField(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.AuthMode = config.AuthModeToken
+	app := newTestApp(cfg)
+
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	// Prime the CSRF token + session cookie.
+	primeReq, _ := http.NewRequest("GET", srv.URL+"/api/auth/session", nil)
+	primeResp, err := client.Do(primeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	primeResp.Body.Close()
+	csrfTok := primeResp.Header.Get("X-CSRF-Token")
+	assert.NotEmpty(t, csrfTok)
+
+	// POST with csrfToken in the form, no X-CSRF-Token header.
+	form := baseDownloadForm()
+	form.Set("csrfToken", csrfTok)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/v1/download", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// CSRF gate must allow the request through. Token-mode auth then
+	// rejects it with 401 because there's no bearer/session k8s token.
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"expected request to pass CSRF gate (form-field token) and be rejected later by auth")
+}
+
+// Same setup as the form-field test, but without the csrfToken field —
+// expect a 403 from the CSRF gate (the form fallback doesn't trip without
+// the field).
+func TestDownloadPOSTRejectsMissingCSRFTokenFormField(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.AuthMode = config.AuthModeToken
+	app := newTestApp(cfg)
+
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	// Prime so the session has a token; we just don't send it.
+	primeReq, _ := http.NewRequest("GET", srv.URL+"/api/auth/session", nil)
+	primeResp, _ := client.Do(primeReq)
+	primeResp.Body.Close()
+
+	form := baseDownloadForm()
+	req, _ := http.NewRequest("POST", srv.URL+"/api/v1/download", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 // Behavioral check: the download endpoint is mounted under protectedRoutes,

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -15,10 +15,13 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -71,10 +74,27 @@ func csrfProtectionMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// Layer 2: CSRF token check
+		// Layer 2: CSRF token check. Header is the primary path; HTML form
+		// submissions (which can't set headers) fall back to a `csrfToken`
+		// urlencoded field. We parse the body manually and restore it
+		// because gin's c.PostForm drains r.Body, which breaks downstream
+		// consumers like the cluster-api reverse proxy that forward it.
 		session := sessions.Default(c)
 		token, _ := session.Get(csrfTokenSessionKey).(string)
-		if token == "" || c.GetHeader("X-CSRF-Token") != token {
+		got := c.GetHeader("X-CSRF-Token")
+		if got == "" && c.ContentType() == "application/x-www-form-urlencoded" && c.Request.Body != nil {
+			bodyBytes, err := io.ReadAll(c.Request.Body)
+			c.Request.Body.Close()
+			if err != nil {
+				c.AbortWithStatus(http.StatusBadRequest)
+				return
+			}
+			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			if vals, err := url.ParseQuery(string(bodyBytes)); err == nil {
+				got = vals.Get("csrfToken")
+			}
+		}
+		if token == "" || got != token {
 			c.AbortWithStatus(http.StatusForbidden)
 			return
 		}

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -15,8 +15,12 @@
 package app
 
 import (
+	"bytes"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-contrib/sessions"
@@ -127,6 +131,13 @@ const csrfPreseededToken = "testtokenvalue1234"
 // runCSRFCase executes one CSRF middleware test case and returns the response.
 func runCSRFCase(t *testing.T, method string, header http.Header, seedToken bool) *http.Response {
 	t.Helper()
+	return runCSRFCaseWithBody(t, method, header, seedToken, "", nil)
+}
+
+// runCSRFCaseWithBody is like runCSRFCase but allows a content-type and body
+// (for form-encoded / multipart cases).
+func runCSRFCaseWithBody(t *testing.T, method string, header http.Header, seedToken bool, contentType string, body io.Reader) *http.Response {
+	t.Helper()
 
 	store := cookie.NewStore([]byte("secret"))
 	store.Options(sessions.Options{Path: "/", Secure: false})
@@ -147,7 +158,10 @@ func runCSRFCase(t *testing.T, method string, header http.Header, seedToken bool
 	})
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(method, "/", nil)
+	r := httptest.NewRequest(method, "/", body)
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
 	for k, v := range header {
 		r.Header[k] = v
 	}
@@ -202,6 +216,105 @@ func TestCSRFProtectionMiddlewareAllows(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		})
 	}
+}
+
+func TestCSRFProtectionMiddlewareFormFieldFallback(t *testing.T) {
+	const sameOrigin = "same-origin"
+
+	t.Run("form-encoded POST with valid csrfToken field allowed", func(t *testing.T) {
+		body := strings.NewReader("csrfToken=" + csrfPreseededToken + "&foo=bar")
+		resp := runCSRFCaseWithBody(t, "POST",
+			http.Header{"Sec-Fetch-Site": []string{sameOrigin}},
+			true,
+			"application/x-www-form-urlencoded",
+			body,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("form-encoded POST with mismatched csrfToken field forbidden", func(t *testing.T) {
+		body := strings.NewReader("csrfToken=wrongtoken&foo=bar")
+		resp := runCSRFCaseWithBody(t, "POST",
+			http.Header{"Sec-Fetch-Site": []string{sameOrigin}},
+			true,
+			"application/x-www-form-urlencoded",
+			body,
+		)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("multipart POST with valid csrfToken field forbidden (fallback only covers urlencoded)", func(t *testing.T) {
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		_ = mw.WriteField("csrfToken", csrfPreseededToken)
+		_ = mw.WriteField("foo", "bar")
+		_ = mw.Close()
+
+		resp := runCSRFCaseWithBody(t, "POST",
+			http.Header{"Sec-Fetch-Site": []string{sameOrigin}},
+			true,
+			mw.FormDataContentType(),
+			&buf,
+		)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("body is restored after form-field check so downstream handlers can read it", func(t *testing.T) {
+		store := cookie.NewStore([]byte("secret"))
+		store.Options(sessions.Options{Path: "/", Secure: false})
+
+		router := gin.New()
+		router.Use(sessions.Sessions("session", store))
+		router.Use(func(c *gin.Context) {
+			session := sessions.Default(c)
+			session.Set(csrfTokenSessionKey, csrfPreseededToken)
+			session.Save()
+			c.Next()
+		})
+		router.Use(csrfProtectionMiddleware())
+
+		var seenBody string
+		router.POST("/", func(c *gin.Context) {
+			b, _ := io.ReadAll(c.Request.Body)
+			seenBody = string(b)
+			c.String(http.StatusOK, "ok")
+		})
+
+		body := "csrfToken=" + csrfPreseededToken + "&foo=bar&baz=qux"
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("Sec-Fetch-Site", sameOrigin)
+		router.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.Equal(t, body, seenBody)
+	})
+
+	t.Run("JSON POST with csrfToken in body forbidden", func(t *testing.T) {
+		body := strings.NewReader(`{"csrfToken":"` + csrfPreseededToken + `"}`)
+		resp := runCSRFCaseWithBody(t, "POST",
+			http.Header{"Sec-Fetch-Site": []string{sameOrigin}},
+			true,
+			"application/json",
+			body,
+		)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("header takes precedence over form field", func(t *testing.T) {
+		body := strings.NewReader("csrfToken=wrongtoken")
+		resp := runCSRFCaseWithBody(t, "POST",
+			http.Header{
+				"Sec-Fetch-Site": []string{sameOrigin},
+				"X-Csrf-Token":   []string{csrfPreseededToken},
+			},
+			true,
+			"application/x-www-form-urlencoded",
+			body,
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
 }
 
 func TestCSRFProtectionMiddlewareForbids(t *testing.T) {


### PR DESCRIPTION
## Summary

The CSRF middleware added in #1106 required `X-CSRF-Token` on every unsafe-method request, which rejected three legitimate same-origin POSTs from the SPA: login, logout, and the log download form. The download case was particularly tricky — it submits a hidden HTML form via an iframe (to enable streaming), and HTML form submission cannot set request headers at all.

## Key Changes

- Send `X-CSRF-Token` from the login and logout `fetch` calls, gated by `waitForCsrfToken()` so the token cache is populated first.
- Extend `csrfProtectionMiddleware` to accept the token from a `csrfToken` urlencoded field as a fallback when no header is present. The fallback is gated on `Content-Type: application/x-www-form-urlencoded` so JSON callers can't smuggle the token through body parsing.
- The middleware reads the body once and restores it, because `gin.Context.PostForm` calls `ParseForm` and drains `r.Body` — that would break downstream consumers like the cluster-api reverse proxy that forward the body upstream (manifests as 502 on `/cluster-api-proxy/api/v1/download`).
- The download form appends a hidden `csrfToken` input alongside the existing fields.
- New tests cover the form-field fallback (allowed, mismatched, header precedence, JSON rejection, multipart rejection, body restoration) and the proxy-friendly download path.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused