### PR TITLE
🎣 Prevent client-supplied X-Forwarded-Authorization from shadowing service-account-token

### DIFF
--- a/modules/dashboard/internal/cluster-api/proxy.go
+++ b/modules/dashboard/internal/cluster-api/proxy.go
@@ -146,7 +146,8 @@ func (p *DesktopProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	r.Header.Add("X-Forwarded-Authorization", fmt.Sprintf("Bearer %s", token))
+	r.Header.Del("X-Forwarded-Authorization")
+	r.Header.Set("X-Forwarded-Authorization", fmt.Sprintf("Bearer %s", token))
 
 	// Strip the browser-supplied Origin so the cluster-api can treat its
 	// presence as a CSWSH signal. Cross-origin browser upgrades are already

--- a/modules/dashboard/internal/cluster-api/proxy_test.go
+++ b/modules/dashboard/internal/cluster-api/proxy_test.go
@@ -328,6 +328,46 @@ func TestDesktopProxy_StripsOriginHeader(t *testing.T) {
 	assert.Empty(t, capturedOrigin, "Origin header must be stripped before forwarding")
 }
 
+func TestDesktopProxy_OverwritesClientSuppliedXForwardedAuthorization(t *testing.T) {
+	var capturedValues []string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedValues = r.Header.Values("X-Forwarded-Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	clientset := fake.NewSimpleClientset()
+	clientset.Fake.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenRequest{
+			Status: authv1.TokenRequestStatus{
+				Token:               "fake-sat",
+				ExpirationTimestamp: metav1.NewTime(time.Now().Add(time.Hour)),
+			},
+		}, nil
+	})
+
+	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
+	sat, err := k8shelpers.NewServiceAccountToken(context.Background(), clientset, "ns", "sa", shutdownCh)
+	require.NoError(t, err)
+
+	proxy, err := NewDesktopProxy(nil, "/prefix")
+	require.NoError(t, err)
+	proxy.phCache["ctx"] = handler
+	proxy.satCache["ctx/ns"] = sat
+
+	req := httptest.NewRequest(http.MethodGet, "/prefix/ctx/ns/svc/relpath", nil)
+	req.Header.Set("Origin", "https://example.com")
+	// Client-supplied attempt to inject an upstream token. The proxy must
+	// clobber this value with its own service-account-token bearer header
+	// rather than appending alongside it.
+	req.Header.Set("X-Forwarded-Authorization", "Bearer attacker-token")
+
+	proxy.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, capturedValues, 1, "exactly one X-Forwarded-Authorization value must be forwarded")
+	assert.Equal(t, "Bearer fake-sat", capturedValues[0])
+}
+
 func TestDesktopProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

The DesktopProxy injects a server-minted service-account-token into the `X-Forwarded-Authorization` header before forwarding to the cluster-api. It used `Header.Add`, which appends after any client-supplied value. The cluster-api's `authenticationMiddleware` reads the header via `c.GetHeader` (a `Header.Get` that returns only the first value), so a malicious client could pre-populate `X-Forwarded-Authorization` and have their bearer token shadow the SAT. This change clobbers any existing value at the trust boundary so the SAT always wins.

## Key Changes

- `modules/dashboard/internal/cluster-api/proxy.go`: replace `Header.Add` with `Header.Del` + `Header.Set` for `X-Forwarded-Authorization` in the DesktopProxy hot path.
- `modules/dashboard/internal/cluster-api/proxy_test.go`: add `TestDesktopProxy_OverwritesClientSuppliedXForwardedAuthorization`, which sends a request carrying `Bearer attacker-token` and asserts the upstream sees exactly one value, equal to the SAT-derived bearer.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused