### PR TITLE
🎣 Harden CSRF token handling

### DIFF
--- a/modules/cluster-api/graph/server.go
+++ b/modules/cluster-api/graph/server.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"strings"
@@ -98,7 +99,8 @@ func NewServer(cm k8shelpers.ConnectionManager, grpcDispatcher *grpcdispatcher.D
 		// the upgrade-time Origin gate is the only check in that path.
 		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
 			expected, _ := ctx.Value(SessionCSRFTokenCtxKey).(string)
-			if expected != "" && initPayload.GetString("csrfToken") != expected {
+			got := initPayload.GetString("csrfToken")
+			if expected != "" && subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
 				return ctx, nil, errors.New("invalid CSRF token")
 			}
 			return ctx, nil, nil

--- a/modules/cluster-api/internal/app/middleware_test.go
+++ b/modules/cluster-api/internal/app/middleware_test.go
@@ -122,14 +122,16 @@ func TestAuthenticationMiddleware(t *testing.T) {
 
 func TestForwardedCSRFTokenMiddleware(t *testing.T) {
 	tests := []struct {
-		name      string
-		setHeader string
-		isUpgrade bool
-		wantValue any
+		name        string
+		headerSet   bool
+		headerValue string
+		isUpgrade   bool
+		wantValue   any
 	}{
-		{"upgrade with header", "abc123", true, "abc123"},
-		{"upgrade without header", "", true, nil},
-		{"non-upgrade ignores header", "abc123", false, nil},
+		{"upgrade with header", true, "abc123", true, "abc123"},
+		{"upgrade without header", false, "", true, nil},
+		{"upgrade with empty header is not propagated", true, "", true, nil},
+		{"non-upgrade ignores header", true, "abc123", false, nil},
 	}
 
 	for _, tt := range tests {
@@ -148,8 +150,8 @@ func TestForwardedCSRFTokenMiddleware(t *testing.T) {
 				r.Header.Set("Connection", "Upgrade")
 				r.Header.Set("Upgrade", "websocket")
 			}
-			if tt.setHeader != "" {
-				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.setHeader)
+			if tt.headerSet {
+				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.headerValue)
 			}
 			router.ServeHTTP(w, r)
 			assert.Equal(t, http.StatusOK, w.Result().StatusCode)

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -16,6 +16,7 @@ package graph
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"sync"
@@ -103,7 +104,8 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 		},
 		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, *transport.InitPayload, error) {
 			expected, _ := ctx.Value(SessionCSRFTokenCtxKey).(string)
-			if expected == "" || initPayload.GetString("csrfToken") != expected {
+			got := initPayload.GetString("csrfToken")
+			if expected == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
 				return ctx, nil, errors.New("invalid CSRF token")
 			}
 			return ctx, nil, nil

--- a/modules/dashboard/pkg/app/auth.go
+++ b/modules/dashboard/pkg/app/auth.go
@@ -72,6 +72,9 @@ func (app *authHandlers) LoginPOST(c *gin.Context) {
 	session := sessions.Default(c)
 	session.Set(k8sTokenSessionKey, form.Token)
 
+	// Rotate CSRF token on auth state change to prevent fixation.
+	session.Delete(csrfTokenSessionKey)
+
 	// Save
 	err = session.Save()
 	if err != nil {
@@ -85,6 +88,7 @@ func (app *authHandlers) LoginPOST(c *gin.Context) {
 // Logout endpoint
 func (app *authHandlers) LogoutPOST(c *gin.Context) {
 	session := sessions.Default(c)
+	// Clear() also drops csrfTokenSessionKey, rotating the CSRF token.
 	session.Clear()
 	session.Save()
 

--- a/modules/dashboard/pkg/app/auth_test.go
+++ b/modules/dashboard/pkg/app/auth_test.go
@@ -137,6 +137,47 @@ func (suite *authTestSuite) TestLoginPOSTFailure() {
 	suite.Equal(http.StatusUnprocessableEntity, resp.StatusCode)
 }
 
+func (suite *authTestSuite) TestAuthRotatesCSRFToken() {
+	m := suite.app.queryHelpers.(*mockQueryHelpers)
+	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
+		Status: authv1.TokenReviewStatus{Authenticated: true},
+	}, nil)
+
+	loginForm := url.Values{}
+	loginForm.Add("token", "xxx")
+
+	tests := []struct {
+		name   string
+		setup  func()
+		action func()
+	}{
+		{
+			name:   "login",
+			setup:  func() {},
+			action: func() { suite.client.PostForm("/api/auth/login", loginForm) },
+		},
+		{
+			name:   "logout",
+			setup:  func() { suite.client.PostForm("/api/auth/login", loginForm) },
+			action: func() { suite.client.PostForm("/api/auth/logout", nil) },
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			tc.setup()
+			before := suite.client.Get("/api/auth/session").Header.Get("X-CSRF-Token")
+			suite.NotEmpty(before)
+
+			tc.action()
+
+			after := suite.client.Get("/api/auth/session").Header.Get("X-CSRF-Token")
+			suite.NotEmpty(after)
+			suite.NotEqual(before, after)
+		})
+	}
+}
+
 func (suite *authTestSuite) TestLogoutPOSTSuccess() {
 	m := suite.app.queryHelpers.(*mockQueryHelpers)
 	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
@@ -155,6 +196,9 @@ func (suite *authTestSuite) TestLogoutPOSTSuccess() {
 	// Verify that session cookie was added
 	cookie1 := getCookie(resp1.Cookies, "session")
 	suite.NotNil(cookie1)
+
+	// Login rotates the CSRF token; refresh before the next unsafe request.
+	suite.client.Get("/api/auth/session")
 
 	// Log out
 	resp2 := suite.client.PostForm("/api/auth/logout", nil)

--- a/modules/dashboard/pkg/app/auth_test.go
+++ b/modules/dashboard/pkg/app/auth_test.go
@@ -64,6 +64,16 @@ func (suite *authTestSuite) TearDownTest() {
 	suite.client.Teardown()
 }
 
+// mockHasAccess registers a HasAccess expectation for token "xxx" returning
+// the given authentication result. Returns the mock for further assertions.
+func (suite *authTestSuite) mockHasAccess(authenticated bool) *mockQueryHelpers {
+	m := suite.app.queryHelpers.(*mockQueryHelpers)
+	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
+		Status: authv1.TokenReviewStatus{Authenticated: authenticated},
+	}, nil)
+	return m
+}
+
 func (suite *authTestSuite) TestLoginPOSTFormErrors() {
 	// Init empty form
 	form := url.Values{}
@@ -94,57 +104,31 @@ func TestLoginPOSTRequiresCSRFToken(t *testing.T) {
 }
 
 func (suite *authTestSuite) TestLoginPOSTSuccess() {
-	// Configure mock
-	m := suite.app.queryHelpers.(*mockQueryHelpers)
-	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
-		Status: authv1.TokenReviewStatus{
-			Authenticated: true,
-		},
-	}, nil)
+	m := suite.mockHasAccess(true)
 
-	// Init form
-	form := url.Values{}
-	form.Add("token", "xxx")
-
-	// Execute
+	form := url.Values{"token": {"xxx"}}
 	resp := suite.client.PostForm("/api/auth/login", form)
 
-	// Assertions
 	m.AssertNumberOfCalls(suite.T(), "HasAccess", 1)
 	m.AssertCalled(suite.T(), "HasAccess", mock.Anything, "xxx")
 	suite.Equal(http.StatusNoContent, resp.StatusCode)
 }
 
 func (suite *authTestSuite) TestLoginPOSTFailure() {
-	// Configure mock
-	m := suite.app.queryHelpers.(*mockQueryHelpers)
-	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
-		Status: authv1.TokenReviewStatus{
-			Authenticated: false,
-		},
-	}, nil)
+	m := suite.mockHasAccess(false)
 
-	// Init form
-	form := url.Values{}
-	form.Add("token", "xxx")
-
-	// Execute
+	form := url.Values{"token": {"xxx"}}
 	resp := suite.client.PostForm("/api/auth/login", form)
 
-	// Assertions
 	m.AssertNumberOfCalls(suite.T(), "HasAccess", 1)
 	m.AssertCalled(suite.T(), "HasAccess", mock.Anything, "xxx")
 	suite.Equal(http.StatusUnprocessableEntity, resp.StatusCode)
 }
 
 func (suite *authTestSuite) TestAuthRotatesCSRFToken() {
-	m := suite.app.queryHelpers.(*mockQueryHelpers)
-	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
-		Status: authv1.TokenReviewStatus{Authenticated: true},
-	}, nil)
+	suite.mockHasAccess(true)
 
-	loginForm := url.Values{}
-	loginForm.Add("token", "xxx")
+	loginForm := url.Values{"token": {"xxx"}}
 
 	tests := []struct {
 		name   string
@@ -179,16 +163,9 @@ func (suite *authTestSuite) TestAuthRotatesCSRFToken() {
 }
 
 func (suite *authTestSuite) TestLogoutPOSTSuccess() {
-	m := suite.app.queryHelpers.(*mockQueryHelpers)
-	m.On("HasAccess", mock.Anything, "xxx").Return(&authv1.TokenReview{
-		Status: authv1.TokenReviewStatus{
-			Authenticated: true,
-		},
-	}, nil)
+	suite.mockHasAccess(true)
 
-	// Init form
-	form := url.Values{}
-	form.Add("token", "xxx")
+	form := url.Values{"token": {"xxx"}}
 
 	// Log in
 	resp1 := suite.client.PostForm("/api/auth/login", form)

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"io"
 	"net/http"
@@ -94,7 +95,7 @@ func csrfProtectionMiddleware() gin.HandlerFunc {
 				got = vals.Get("csrfToken")
 			}
 		}
-		if token == "" || got != token {
+		if token == "" || subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
 			c.AbortWithStatus(http.StatusForbidden)
 			return
 		}

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -423,13 +423,16 @@ func TestK8sTokenRequiredMiddleware(t *testing.T) {
 func TestWebSocketCSRFContextMiddleware(t *testing.T) {
 	const sessTok = "session-csrf-token"
 
+	emptyTok := ""
 	tests := []struct {
-		name          string
-		hasSession    bool
-		isUpgrade     bool
-		clientHeader  string // value sent by client; "" = absent
-		wantCtxValue  any
-		wantOutHeader string
+		name            string
+		hasSession      bool
+		sessionTokVal   *string // override stored value; nil = use sessTok
+		isUpgrade       bool
+		clientHeaderSet bool
+		clientHeaderVal string
+		wantCtxValue    any
+		wantOutHeader   string
 	}{
 		{
 			name:          "WS upgrade with session: ctx and header set from session",
@@ -450,24 +453,50 @@ func TestWebSocketCSRFContextMiddleware(t *testing.T) {
 			wantCtxValue: nil,
 		},
 		{
-			name:         "client-supplied X-Forwarded-CSRF-Token is stripped (no session)",
-			isUpgrade:    true,
-			clientHeader: "spoofed",
-			wantCtxValue: nil,
+			name:            "client-supplied X-Forwarded-CSRF-Token is stripped (no session)",
+			isUpgrade:       true,
+			clientHeaderSet: true,
+			clientHeaderVal: "spoofed",
+			wantCtxValue:    nil,
 		},
 		{
-			name:          "client-supplied X-Forwarded-CSRF-Token is overwritten (with session)",
+			name:            "client-supplied X-Forwarded-CSRF-Token is overwritten (with session)",
+			hasSession:      true,
+			isUpgrade:       true,
+			clientHeaderSet: true,
+			clientHeaderVal: "spoofed",
+			wantCtxValue:    sessTok,
+			wantOutHeader:   sessTok,
+		},
+		{
+			name:            "non-WS request strips client-supplied X-Forwarded-CSRF-Token",
+			isUpgrade:       false,
+			clientHeaderSet: true,
+			clientHeaderVal: "spoofed",
+			wantCtxValue:    nil,
+		},
+		{
+			name:          "WS upgrade with empty session token leaves ctx and header unset",
 			hasSession:    true,
+			sessionTokVal: &emptyTok,
 			isUpgrade:     true,
-			clientHeader:  "spoofed",
-			wantCtxValue:  sessTok,
-			wantOutHeader: sessTok,
+			wantCtxValue:  nil,
 		},
 		{
-			name:         "non-WS request strips client-supplied X-Forwarded-CSRF-Token",
-			isUpgrade:    false,
-			clientHeader: "spoofed",
-			wantCtxValue: nil,
+			name:            "WS upgrade with empty session token strips empty client-supplied header",
+			hasSession:      true,
+			sessionTokVal:   &emptyTok,
+			isUpgrade:       true,
+			clientHeaderSet: true,
+			clientHeaderVal: "",
+			wantCtxValue:    nil,
+		},
+		{
+			name:            "WS upgrade with empty client-supplied header (no session) leaves ctx unset",
+			isUpgrade:       true,
+			clientHeaderSet: true,
+			clientHeaderVal: "",
+			wantCtxValue:    nil,
 		},
 	}
 
@@ -477,8 +506,12 @@ func TestWebSocketCSRFContextMiddleware(t *testing.T) {
 			router.Use(sessions.Sessions("session", cookie.NewStore([]byte("xx"))))
 			router.Use(func(c *gin.Context) {
 				if tt.hasSession {
+					tok := sessTok
+					if tt.sessionTokVal != nil {
+						tok = *tt.sessionTokVal
+					}
 					session := sessions.Default(c)
-					session.Set(csrfTokenSessionKey, sessTok)
+					session.Set(csrfTokenSessionKey, tok)
 					session.Save()
 				}
 				c.Next()
@@ -500,8 +533,8 @@ func TestWebSocketCSRFContextMiddleware(t *testing.T) {
 				r.Header.Set("Connection", "Upgrade")
 				r.Header.Set("Upgrade", "websocket")
 			}
-			if tt.clientHeader != "" {
-				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.clientHeader)
+			if tt.clientHeaderSet {
+				r.Header.Set(httphelpers.HeaderForwardedCSRFToken, tt.clientHeaderVal)
 			}
 
 			router.ServeHTTP(httptest.NewRecorder(), r)


### PR DESCRIPTION
## Summary

Hardens the dashboard's CSRF protection along three axes:

- Rotate the CSRF token on every authentication state change (login/logout) so a token observed before login cannot be reused after, closing a session-fixation window.
- Use `crypto/subtle.ConstantTimeCompare` for token equality so verification is not vulnerable to timing differences.
- Add coverage for the empty `X-Forwarded-CSRF-Token` case across the dashboard and cluster-api WebSocket paths to lock in current behavior.

Also extracts a small `mockHasAccess` helper to reduce duplication in the auth test suite.

## Key Changes

- `modules/dashboard/pkg/app/auth.go`: `LoginPOST` now deletes `csrfTokenSessionKey` from the session before saving so the next `/api/auth/session` mints a fresh token. `LogoutPOST` already drops it via `session.Clear()` — added a comment to preserve that intent.
- `modules/dashboard/pkg/app/middleware.go` and `modules/cluster-api/graph/server.go`: switch CSRF token comparisons to `subtle.ConstantTimeCompare`.
- `modules/dashboard/pkg/app/middleware_test.go`, `modules/cluster-api/internal/app/middleware_test.go`: cover the empty forwarded-token case.
- `modules/dashboard/pkg/app/auth_test.go`: add `TestAuthRotatesCSRFToken` (table-driven, login + logout); refresh the test client's CSRF token between login and logout in `TestLogoutPOSTSuccess`; extract `mockHasAccess` helper.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused