### PR TITLE
🎣 Strip X-Forwarded-CSRF-Token at dynamicRoutes level

### DIFF
--- a/modules/dashboard/pkg/app/app.go
+++ b/modules/dashboard/pkg/app/app.go
@@ -182,6 +182,10 @@ func NewApp(cfg *config.Config) (*App, error) {
 			ContentTypeNosniff:    true,
 		}))
 
+		// Strip any client-supplied X-Forwarded-CSRF-Token on entry to
+		// prevent header smuggling into upstream proxies.
+		dynamicRoutes.Use(stripForwardedCSRFTokenMiddleware())
+
 		// Add CSRF protection middleware
 		dynamicRoutes.Use(csrfProtectionMiddleware())
 

--- a/modules/dashboard/pkg/app/app_test.go
+++ b/modules/dashboard/pkg/app/app_test.go
@@ -188,6 +188,13 @@ func TestCSRFProtectionAppliedToDynamicRoutes(t *testing.T) {
 		"csrfProtectionMiddleware not found in dynamic-route handler chain")
 }
 
+func TestStripForwardedCSRFTokenAppliedToDynamicRoutes(t *testing.T) {
+	app := newTestApp(nil)
+	assert.True(t,
+		handlerChainContains(app.dynamicRoutes.Handlers, "stripForwardedCSRFTokenMiddleware"),
+		"stripForwardedCSRFTokenMiddleware not found in dynamic-route handler chain")
+}
+
 func TestAuthenticationMiddlewareAppliedToDynamicRoutes(t *testing.T) {
 	app := newTestApp(nil)
 	assert.True(t,

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -104,15 +104,24 @@ func csrfProtectionMiddleware() gin.HandlerFunc {
 	}
 }
 
+// stripForwardedCSRFTokenMiddleware removes any client-supplied
+// X-Forwarded-CSRF-Token header on entry to prevent header smuggling into
+// upstream proxies. Applied at the dynamicRoutes level so every downstream
+// route is covered, not just those that consume the header.
+func stripForwardedCSRFTokenMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Header.Del(httphelpers.HeaderForwardedCSRFToken)
+		c.Next()
+	}
+}
+
 // websocketCSRFContextMiddleware places the session's CSRF token into the
 // request context (for the dashboard's WebSocket InitFunc) and stamps it as
 // X-Forwarded-CSRF-Token (for the cluster-api proxy to forward upstream).
-// Always strips any client-supplied X-Forwarded-CSRF-Token to prevent
-// header smuggling.
+// Relies on stripForwardedCSRFTokenMiddleware running earlier in the chain
+// to clear any client-supplied value.
 func websocketCSRFContextMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Request.Header.Del(httphelpers.HeaderForwardedCSRFToken)
-
 		if !ginhelpers.IsWebSocketRequest(c) {
 			c.Next()
 			return

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -516,6 +516,7 @@ func TestWebSocketCSRFContextMiddleware(t *testing.T) {
 				}
 				c.Next()
 			})
+			router.Use(stripForwardedCSRFTokenMiddleware())
 			router.Use(websocketCSRFContextMiddleware())
 
 			var (


### PR DESCRIPTION
## Summary

The inbound `X-Forwarded-CSRF-Token` strip — a header-smuggling defense for the cluster-api proxy — was bundled inside `websocketCSRFContextMiddleware`, which is only mounted on `protectedRoutes`. Any future route added under `dynamicRoutes` (or the existing `/api/auth/*` routes) would not be defended. This PR splits the strip into its own middleware and mounts it at the `dynamicRoutes` level so the protection is future-proof.

## Key Changes

- Extract the inbound `X-Forwarded-CSRF-Token` strip into a new `stripForwardedCSRFTokenMiddleware`.
- Mount it on `dynamicRoutes` alongside `csrfProtectionMiddleware` so it covers every downstream route, not just `protectedRoutes`.
- `websocketCSRFContextMiddleware` now only handles WebSocket context/header injection and relies on the strip running earlier in the chain.
- Add `TestStripForwardedCSRFTokenAppliedToDynamicRoutes` and update the existing middleware test to chain in the new middleware.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused