### PR TITLE
🎣 Stop trusting X-Forwarded-* headers in same-origin check

### DIFF
--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -28,14 +28,20 @@ import (
 const HeaderForwardedCSRFToken = "X-Forwarded-CSRF-Token"
 
 // IsSameOrigin reports whether r's Origin header is present and matches
-// the request's scheme and host (per the WebSocket spec's same-origin
-// rule). A missing Origin returns false.
+// the request's scheme and host. A missing Origin returns false.
+//
+// The comparison uses r.Host and r.TLS only. X-Forwarded-Host,
+// X-Forwarded-Proto, and the RFC 7239 Forwarded header are deliberately
+// ignored: they are attacker-controllable in direct-access deployments
+// and can be smuggled through proxies that append rather than overwrite
+// client-supplied values. Deployments behind a reverse proxy that rewrites
+// Host or terminates TLS without preserving scheme will need explicit
+// origin allowlisting (see the upcoming allowed-origins config).
 //
 // Host comparison is case-insensitive and normalizes the effective port,
 // so https://example.com matches a request Host of example.com:443 (and
 // likewise http://example.com matches example.com:80). This avoids
-// false rejections from ingress/reverse proxies that forward an explicit
-// default port in Host.
+// false rejections from clients/servers that emit an explicit default port.
 //
 // Intended for use on WebSocket upgrade requests, where browsers always
 // send Origin (so its absence indicates a non-browser client, which has
@@ -50,12 +56,15 @@ func IsSameOrigin(r *http.Request) bool {
 	if err != nil || u.Host == "" {
 		return false
 	}
-	scheme := requestScheme(r)
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
 	if !strings.EqualFold(u.Scheme, scheme) {
 		return false
 	}
 	originHost, originPort := splitHostPort(u.Host, u.Scheme)
-	reqHost, reqPort := splitHostPort(requestHost(r), scheme)
+	reqHost, reqPort := splitHostPort(r.Host, scheme)
 	return strings.EqualFold(originHost, reqHost) && originPort == reqPort
 }
 
@@ -82,71 +91,4 @@ func defaultPort(scheme string) string {
 		return "80"
 	}
 	return ""
-}
-
-// requestHost returns the effective host for r. X-Forwarded-Host is checked
-// first (most widely deployed), then the RFC 7239 Forwarded header's host
-// directive, then r.Host.
-func requestHost(r *http.Request) string {
-	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
-		return firstCommaValue(xfh)
-	}
-	if fwd := r.Header.Get("Forwarded"); fwd != "" {
-		if host := parseForwardedValue(firstCommaValue(fwd), "host"); host != "" {
-			return host
-		}
-	}
-	return r.Host
-}
-
-// parseForwardedValue extracts a directive from a single RFC 7239
-// forwarded-element (semicolon-separated key=value pairs).
-func parseForwardedValue(elem, key string) string {
-	for elem != "" {
-		var part string
-		if before, after, ok := strings.Cut(elem, ";"); ok {
-			part, elem = before, after
-		} else {
-			part, elem = elem, ""
-		}
-		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
-		if !ok || !strings.EqualFold(k, key) {
-			continue
-		}
-		v = strings.TrimSpace(v)
-		if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
-			v = v[1 : len(v)-1]
-		}
-		return v
-	}
-	return ""
-}
-
-// requestScheme returns the scheme the client used to reach r, accounting
-// for TLS terminated at this process (r.TLS) or upstream (X-Forwarded-Proto
-// or RFC 7239 Forwarded proto set by a trusted reverse proxy). Defaults to
-// "http". Browsers cannot override these headers on a WebSocket upgrade, so
-// trusting them here is safe for this gate.
-func requestScheme(r *http.Request) string {
-	if r.TLS != nil {
-		return "https"
-	}
-	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
-		return strings.ToLower(firstCommaValue(p))
-	}
-	if fwd := r.Header.Get("Forwarded"); fwd != "" {
-		if proto := parseForwardedValue(firstCommaValue(fwd), "proto"); proto != "" {
-			return strings.ToLower(proto)
-		}
-	}
-	return "http"
-}
-
-// firstCommaValue returns the first comma-separated element of s, trimmed.
-// Handles the common proxy convention of comma-joining repeated header values.
-func firstCommaValue(s string) string {
-	if i := strings.IndexByte(s, ','); i >= 0 {
-		return strings.TrimSpace(s[:i])
-	}
-	return strings.TrimSpace(s)
 }

--- a/modules/shared/httphelpers/httphelpers_test.go
+++ b/modules/shared/httphelpers/httphelpers_test.go
@@ -54,15 +54,6 @@ func TestIsSameOrigin(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "https same-origin via X-Forwarded-Proto",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":            {"https://example.com"},
-				"X-Forwarded-Proto": {"https"},
-			},
-			want: true,
-		},
-		{
 			name: "https Origin on plain http request is rejected",
 			host: "example.com",
 			headers: http.Header{
@@ -77,15 +68,6 @@ func TestIsSameOrigin(t *testing.T) {
 				"Origin": {"http://example.com"},
 			},
 			tls:  true,
-			want: false,
-		},
-		{
-			name: "http Origin on https-by-proxy request is rejected",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":            {"http://example.com"},
-				"X-Forwarded-Proto": {"https"},
-			},
 			want: false,
 		},
 		{
@@ -121,15 +103,6 @@ func TestIsSameOrigin(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "X-Forwarded-Proto list takes first value",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":            {"https://example.com"},
-				"X-Forwarded-Proto": {"https, http"},
-			},
-			want: true,
-		},
-		{
 			name: "https default port in Host matches Origin without port",
 			host: "example.com:443",
 			headers: http.Header{
@@ -160,15 +133,6 @@ func TestIsSameOrigin(t *testing.T) {
 			host: "example.com",
 			headers: http.Header{
 				"Origin": {"http://example.com:80"},
-			},
-			want: true,
-		},
-		{
-			name: "default port via X-Forwarded-Proto matches",
-			host: "example.com:443",
-			headers: http.Header{
-				"Origin":            {"https://example.com"},
-				"X-Forwarded-Proto": {"https"},
 			},
 			want: true,
 		},
@@ -213,153 +177,42 @@ func TestIsSameOrigin(t *testing.T) {
 			},
 			want: true,
 		},
-		// X-Forwarded-Host: proxy sets the public host, internal r.Host differs
+		// Forwarded headers must NOT be honored: they're attacker-controllable
+		// in direct-access deployments and through non-sanitizing proxies.
 		{
-			name: "X-Forwarded-Host same-origin matches",
-			host: "internal:8080",
+			name: "forged X-Forwarded-Host with matching Origin is rejected",
+			host: "kubetail.local",
 			headers: http.Header{
-				"Origin":           {"http://example.com"},
-				"X-Forwarded-Host": {"example.com"},
-			},
-			want: true,
-		},
-		{
-			name: "X-Forwarded-Host different host is rejected",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":           {"http://evil.com"},
-				"X-Forwarded-Host": {"example.com"},
+				"Origin":            {"https://attacker.com"},
+				"X-Forwarded-Host":  {"attacker.com"},
+				"X-Forwarded-Proto": {"https"},
 			},
 			want: false,
 		},
 		{
-			name: "X-Forwarded-Host with port matches",
-			host: "internal:8080",
+			name: "forged Forwarded header with matching Origin is rejected",
+			host: "kubetail.local",
 			headers: http.Header{
-				"Origin":           {"http://example.com:9090"},
-				"X-Forwarded-Host": {"example.com:9090"},
-			},
-			want: true,
-		},
-		{
-			name: "X-Forwarded-Host list takes first value",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":           {"http://example.com"},
-				"X-Forwarded-Host": {"example.com, other.com"},
-			},
-			want: true,
-		},
-		{
-			name: "X-Forwarded-Host with X-Forwarded-Proto matches https",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":            {"https://example.com"},
-				"X-Forwarded-Proto": {"https"},
-				"X-Forwarded-Host":  {"example.com"},
-			},
-			want: true,
-		},
-		// Forwarded (RFC 7239)
-		{
-			name: "Forwarded host matches",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":    {"http://example.com"},
-				"Forwarded": {"host=example.com"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded host different is rejected",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":    {"http://evil.com"},
-				"Forwarded": {"host=example.com"},
+				"Origin":    {"https://attacker.com"},
+				"Forwarded": {"host=attacker.com;proto=https"},
 			},
 			want: false,
 		},
 		{
-			name: "Forwarded host with other directives",
-			host: "internal:8080",
+			name: "X-Forwarded-Proto cannot upgrade scheme on plaintext request",
+			host: "kubetail.local",
 			headers: http.Header{
-				"Origin":    {"http://example.com"},
-				"Forwarded": {"for=1.2.3.4;host=example.com;proto=http"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded proto matches https",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":    {"https://example.com"},
-				"Forwarded": {"proto=https"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded quoted proto matches https",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":    {"https://example.com"},
-				"Forwarded": {`proto="https"`},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded proto and host match https behind proxy",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":    {"https://example.com"},
-				"Forwarded": {"for=1.2.3.4;host=example.com;proto=https"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded proto takes first element",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":    {"https://example.com"},
-				"Forwarded": {"proto=https, proto=http"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded host takes first element",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":    {"http://example.com"},
-				"Forwarded": {"host=example.com, host=other.com"},
-			},
-			want: true,
-		},
-		{
-			name: "Forwarded quoted host matches",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":    {"http://example.com"},
-				"Forwarded": {`host="example.com"`},
-			},
-			want: true,
-		},
-		// X-Forwarded-Host takes precedence over Forwarded
-		{
-			name: "X-Forwarded-Host takes precedence over Forwarded",
-			host: "internal:8080",
-			headers: http.Header{
-				"Origin":           {"http://example.com"},
-				"X-Forwarded-Host": {"example.com"},
-				"Forwarded":        {"host=other.com"},
-			},
-			want: true,
-		},
-		{
-			name: "X-Forwarded-Proto takes precedence over Forwarded proto",
-			host: "example.com",
-			headers: http.Header{
-				"Origin":            {"https://example.com"},
+				"Origin":            {"https://kubetail.local"},
 				"X-Forwarded-Proto": {"https"},
-				"Forwarded":         {"proto=http"},
+			},
+			want: false,
+		},
+		{
+			name: "X-Forwarded-Host is ignored when Origin matches r.Host",
+			host: "kubetail.local",
+			headers: http.Header{
+				"Origin":           {"http://kubetail.local"},
+				"X-Forwarded-Host": {"attacker.com"},
 			},
 			want: true,
 		},


### PR DESCRIPTION
## Summary

`IsSameOrigin` previously honored `X-Forwarded-Host`, `X-Forwarded-Proto`, and the RFC 7239 `Forwarded` header when comparing `Origin` against the request host. Those values are attacker-controllable in direct-access deployments and can be smuggled through reverse proxies that append rather than overwrite client-supplied values. This PR drops that trust and compares `Origin` against `r.Host` and `r.TLS` only, closing a header-smuggling vector flagged in CSRF review.

The HTTP path is already well-defended by `Sec-Fetch-Site` plus the session-bound CSRF token, so this hardening is most meaningful for the WebSocket upgrade gate (`graph/server.go`, cluster-api `proxy.go`), where browsers always send `Origin`.

**Note:** Deployments behind a reverse proxy that rewrites `Host` or terminates TLS without preserving scheme will see WebSocket connections rejected after this change. A follow-up PR will add an `allowed-origins` config option as the supported escape hatch for those setups.

## Key Changes

- `IsSameOrigin` (`modules/shared/httphelpers/httphelpers.go`) now derives scheme from `r.TLS` only and compares `Origin` against `r.Host` directly.
- Removed unused helpers `requestHost`, `requestScheme`, `parseForwardedValue`, and `firstCommaValue`.
- Updated tests to assert that forged `X-Forwarded-Host`, `Forwarded`, and `X-Forwarded-Proto` headers are ignored; removed cases that depended on those headers being trusted.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused