### PR TITLE
✨ Add allowed-origins config for proxied deployments

### DIFF
--- a/config/default/dashboard.yaml
+++ b/config/default/dashboard.yaml
@@ -30,6 +30,28 @@ kubeconfig: ""
 #
 addr: :80
 
+## allowed-origins ##
+#
+# Additional origins (in addition to same-origin) accepted on WebSocket
+# upgrade requests. Each entry must be a fully-qualified origin —
+# scheme://host[:port] with no path. Comparison is case-insensitive on
+# host and normalizes default ports (so https://example.com matches
+# https://example.com:443).
+#
+# Use this when running the dashboard behind a reverse proxy that
+# rewrites Host or terminates TLS without preserving scheme — direct
+# same-origin matching against r.Host/r.TLS would otherwise reject
+# legitimate browser requests. List the public-facing origin(s) the
+# dashboard is served at.
+#
+# Examples:
+#   - https://kubetail.example.com
+#   - https://kubetail.example.com:8443
+#
+# Default value: []
+#
+allowed-origins: []
+
 ## auth-mode ##
 #
 # The authentication mode for the dashboard.

--- a/modules/dashboard/graph/server.go
+++ b/modules/dashboard/graph/server.go
@@ -97,7 +97,9 @@ func NewServer(cfg *config.Config, cm k8shelpers.ConnectionManager) *Server {
 	// and a CSRF-token check in the connection_init payload.
 	h.AddTransport(&transport.Websocket{
 		Upgrader: websocket.Upgrader{
-			CheckOrigin:       httphelpers.IsSameOrigin,
+			CheckOrigin: func(r *http.Request) bool {
+				return httphelpers.IsAllowedOrigin(r, cfg.AllowedOrigins)
+			},
 			ReadBufferSize:    1024,
 			WriteBufferSize:   1024,
 			EnableCompression: false,

--- a/modules/dashboard/graph/server_test.go
+++ b/modules/dashboard/graph/server_test.go
@@ -95,6 +95,42 @@ func TestServerWebSocketCheckOrigin(t *testing.T) {
 	}
 }
 
+func TestServerWebSocketCheckOrigin_AllowedOrigins(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.AllowedOrigins = []string{"https://allowed.example.com"}
+	s := NewServer(cfg, nil)
+
+	client := testutils.NewWebTestClient(t, s)
+	defer client.Teardown()
+
+	wsURL := "ws" + strings.TrimPrefix(client.Server.URL, "http") + "/graphql"
+
+	tests := []struct {
+		name       string
+		setOrigin  string
+		wantStatus int
+	}{
+		{
+			"allowlisted Origin is accepted across host rewrite",
+			"https://allowed.example.com",
+			http.StatusSwitchingProtocols,
+		},
+		{
+			"non-allowlisted cross-origin is still rejected",
+			"https://attacker.example.com",
+			http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{"Origin": []string{tt.setOrigin}}
+			_, resp, _ := websocket.DefaultDialer.Dial(wsURL, header)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
 func TestServerWebSocketCSRFInit(t *testing.T) {
 	cfg := config.DefaultConfig()
 	s := NewServer(cfg, nil)

--- a/modules/dashboard/internal/cluster-api/proxy.go
+++ b/modules/dashboard/internal/cluster-api/proxy.go
@@ -81,13 +81,14 @@ type Proxy interface {
 
 // Represents DesktopProxy
 type DesktopProxy struct {
-	cm         k8shelpers.ConnectionManager
-	pathPrefix string
-	phCache    map[string]http.Handler
-	satCache   map[string]*k8shelpers.ServiceAccountToken
-	mu         sync.Mutex
-	shutdownCh chan struct{}
-	wg         sync.WaitGroup
+	cm             k8shelpers.ConnectionManager
+	pathPrefix     string
+	allowedOrigins []string
+	phCache        map[string]http.Handler
+	satCache       map[string]*k8shelpers.ServiceAccountToken
+	mu             sync.Mutex
+	shutdownCh     chan struct{}
+	wg             sync.WaitGroup
 }
 
 // ServeHTTP
@@ -99,7 +100,7 @@ func (p *DesktopProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// CSWSH defense for WebSocket upgrades. Chrome does not send
 	// Sec-Fetch-Site on upgrade requests, so the app-level CSRF middleware
 	// can't gate them; check Origin directly here instead.
-	if r.Header.Get("Upgrade") != "" && !httphelpers.IsSameOrigin(r) {
+	if r.Header.Get("Upgrade") != "" && !httphelpers.IsAllowedOrigin(r, p.allowedOrigins) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
@@ -269,22 +270,25 @@ func (p *DesktopProxy) getOrCreateServiceAccountToken(ctx context.Context, kubeC
 	return sat, nil
 }
 
-// Create new DesktopProxy
-func NewDesktopProxy(cm k8shelpers.ConnectionManager, pathPrefix string) (*DesktopProxy, error) {
+// Create new DesktopProxy. allowedOrigins is forwarded to the WebSocket
+// upgrade origin check (see httphelpers.IsAllowedOrigin).
+func NewDesktopProxy(cm k8shelpers.ConnectionManager, pathPrefix string, allowedOrigins []string) (*DesktopProxy, error) {
 	return &DesktopProxy{
-		cm:         cm,
-		pathPrefix: pathPrefix,
-		phCache:    make(map[string]http.Handler),
-		satCache:   make(map[string]*k8shelpers.ServiceAccountToken),
-		shutdownCh: make(chan struct{}),
+		cm:             cm,
+		pathPrefix:     pathPrefix,
+		allowedOrigins: allowedOrigins,
+		phCache:        make(map[string]http.Handler),
+		satCache:       make(map[string]*k8shelpers.ServiceAccountToken),
+		shutdownCh:     make(chan struct{}),
 	}, nil
 }
 
 // Represents InClusterProxy
 type InClusterProxy struct {
 	*httputil.ReverseProxy
-	shutdownCh chan struct{}
-	wg         sync.WaitGroup
+	allowedOrigins []string
+	shutdownCh     chan struct{}
+	wg             sync.WaitGroup
 }
 
 // ServeHTTP wraps the reverse proxy to track active requests for graceful
@@ -296,7 +300,7 @@ func (p *InClusterProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// CSWSH defense for WebSocket upgrades. Chrome does not send
 	// Sec-Fetch-Site on upgrade requests, so the app-level CSRF middleware
 	// can't gate them; check Origin directly here instead.
-	if r.Header.Get("Upgrade") != "" && !httphelpers.IsSameOrigin(r) {
+	if r.Header.Get("Upgrade") != "" && !httphelpers.IsAllowedOrigin(r, p.allowedOrigins) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
@@ -340,7 +344,7 @@ func (p *InClusterProxy) DrainWithContext(ctx context.Context) error {
 }
 
 // Create new InClusterProxy with injectable transport (used in tests)
-func newInClusterProxy(clusterAPIEndpoint string, pathPrefix string, transport http.RoundTripper) (*InClusterProxy, error) {
+func newInClusterProxy(clusterAPIEndpoint string, pathPrefix string, allowedOrigins []string, transport http.RoundTripper) (*InClusterProxy, error) {
 	// Parse endpoint url
 	endpointUrl, err := url.Parse(clusterAPIEndpoint)
 	if err != nil {
@@ -388,16 +392,18 @@ func newInClusterProxy(clusterAPIEndpoint string, pathPrefix string, transport h
 	}
 
 	return &InClusterProxy{
-		ReverseProxy: reverseProxy,
-		shutdownCh:   make(chan struct{}),
+		ReverseProxy:   reverseProxy,
+		allowedOrigins: allowedOrigins,
+		shutdownCh:     make(chan struct{}),
 	}, nil
 }
 
-// Create new InClusterProxy
-func NewInClusterProxy(clusterAPIEndpoint string, pathPrefix string) (*InClusterProxy, error) {
+// Create new InClusterProxy. allowedOrigins is forwarded to the WebSocket
+// upgrade origin check (see httphelpers.IsAllowedOrigin).
+func NewInClusterProxy(clusterAPIEndpoint string, pathPrefix string, allowedOrigins []string) (*InClusterProxy, error) {
 	rt, err := k8shelpers.NewInClusterSATRoundTripper(http.DefaultTransport)
 	if err != nil {
 		return nil, err
 	}
-	return newInClusterProxy(clusterAPIEndpoint, pathPrefix, rt)
+	return newInClusterProxy(clusterAPIEndpoint, pathPrefix, allowedOrigins, rt)
 }

--- a/modules/dashboard/internal/cluster-api/proxy_test.go
+++ b/modules/dashboard/internal/cluster-api/proxy_test.go
@@ -43,7 +43,7 @@ func TestInClusterProxy_StripsOriginHeader(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
@@ -74,7 +74,7 @@ func TestInClusterProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
 			}))
 			defer backend.Close()
 
-			proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+			proxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
@@ -91,6 +91,31 @@ func TestInClusterProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
 			assert.False(t, captured, "backend must not be reached on cross-origin upgrade")
 		})
 	}
+}
+
+func TestInClusterProxy_AllowedOriginsAcceptsCrossHostUpgrade(t *testing.T) {
+	var captured bool
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxy, err := newInClusterProxy(backend.URL, "/prefix", []string{"https://allowed.example.com"}, http.DefaultTransport)
+	require.NoError(t, err)
+
+	// Request Host is example.com (httptest default) but Origin matches the
+	// allowlist — emulates a Host-rewriting reverse proxy in front.
+	req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Origin", "https://allowed.example.com")
+
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusForbidden, rec.Code)
+	assert.True(t, captured, "allowlisted upgrade must reach the backend")
 }
 
 func TestInClusterProxy_XForwardedAuthorization(t *testing.T) {
@@ -120,7 +145,7 @@ func TestInClusterProxy_XForwardedAuthorization(t *testing.T) {
 			}))
 			defer backend.Close()
 
-			proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+			proxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "/prefix/somepath", nil)
@@ -139,7 +164,7 @@ func TestInClusterProxy_XForwardedAuthorization(t *testing.T) {
 // --- InClusterProxy drain/shutdown tests ---
 
 func TestInClusterProxy_DrainWithContext_NoConnections(t *testing.T) {
-	proxy, err := newInClusterProxy("http://localhost", "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy("http://localhost", "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -149,7 +174,7 @@ func TestInClusterProxy_DrainWithContext_NoConnections(t *testing.T) {
 }
 
 func TestInClusterProxy_DrainWithContext_CancelledContext(t *testing.T) {
-	proxy, err := newInClusterProxy("http://localhost", "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy("http://localhost", "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	// Simulate an open connection that never finishes
@@ -164,7 +189,7 @@ func TestInClusterProxy_DrainWithContext_CancelledContext(t *testing.T) {
 }
 
 func TestInClusterProxy_DrainWithContext_DeadlineExceeded(t *testing.T) {
-	proxy, err := newInClusterProxy("http://localhost", "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy("http://localhost", "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	// Simulate an open connection that never finishes
@@ -221,7 +246,7 @@ func waitConnected(t *testing.T, connected <-chan struct{}) {
 func TestInClusterProxy_NotifyShutdown_ClosesConnections(t *testing.T) {
 	backend, connected := newWSBackend(t)
 
-	proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	proxyServer := httptest.NewServer(proxy)
@@ -252,7 +277,7 @@ func TestInClusterProxy_NotifyShutdown_ClosesConnections(t *testing.T) {
 func TestInClusterProxy_NotifyShutdown_ClosesMultipleConnections(t *testing.T) {
 	backend, connected := newWSBackend(t)
 
-	proxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+	proxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	proxyServer := httptest.NewServer(proxy)
@@ -313,7 +338,7 @@ func TestDesktopProxy_StripsOriginHeader(t *testing.T) {
 	sat, err := k8shelpers.NewServiceAccountToken(context.Background(), clientset, "ns", "sa", shutdownCh)
 	require.NoError(t, err)
 
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 	proxy.phCache["ctx"] = handler
 	proxy.satCache["ctx/ns"] = sat
@@ -350,7 +375,7 @@ func TestDesktopProxy_OverwritesClientSuppliedXForwardedAuthorization(t *testing
 	sat, err := k8shelpers.NewServiceAccountToken(context.Background(), clientset, "ns", "sa", shutdownCh)
 	require.NoError(t, err)
 
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 	proxy.phCache["ctx"] = handler
 	proxy.satCache["ctx/ns"] = sat
@@ -385,7 +410,7 @@ func TestDesktopProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			proxy, err := NewDesktopProxy(nil, "/prefix")
+			proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 			require.NoError(t, err)
 			proxy.phCache["ctx"] = handler
 
@@ -405,8 +430,47 @@ func TestDesktopProxy_RejectsCrossOriginUpgradeRequest(t *testing.T) {
 	}
 }
 
+func TestDesktopProxy_AllowedOriginsAcceptsCrossHostUpgrade(t *testing.T) {
+	var captured bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	clientset := fake.NewSimpleClientset()
+	clientset.Fake.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenRequest{
+			Status: authv1.TokenRequestStatus{
+				Token:               "fake-sat",
+				ExpirationTimestamp: metav1.NewTime(time.Now().Add(time.Hour)),
+			},
+		}, nil
+	})
+
+	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
+	sat, err := k8shelpers.NewServiceAccountToken(context.Background(), clientset, "ns", "sa", shutdownCh)
+	require.NoError(t, err)
+
+	proxy, err := NewDesktopProxy(nil, "/prefix", []string{"https://allowed.example.com"})
+	require.NoError(t, err)
+	proxy.phCache["ctx"] = handler
+	proxy.satCache["ctx/ns"] = sat
+
+	req := httptest.NewRequest(http.MethodGet, "/prefix/ctx/ns/svc/relpath", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Origin", "https://allowed.example.com")
+
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusForbidden, rec.Code)
+	assert.True(t, captured, "allowlisted upgrade must reach the backend handler")
+}
+
 func TestDesktopProxy_DrainWithContext_NoConnections(t *testing.T) {
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -416,7 +480,7 @@ func TestDesktopProxy_DrainWithContext_NoConnections(t *testing.T) {
 }
 
 func TestDesktopProxy_DrainWithContext_CancelledContext(t *testing.T) {
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 
 	// Simulate an open connection that never finishes
@@ -431,7 +495,7 @@ func TestDesktopProxy_DrainWithContext_CancelledContext(t *testing.T) {
 }
 
 func TestDesktopProxy_DrainWithContext_DeadlineExceeded(t *testing.T) {
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 
 	// Simulate an open connection that never finishes
@@ -451,13 +515,13 @@ func TestDesktopProxy_NotifyShutdown_ClosesConnections(t *testing.T) {
 	// Use InClusterProxy as backend transport to avoid needing a real k8s ConnectionManager.
 	// The DesktopProxy delegates to a k8s proxy handler, so we build a custom DesktopProxy
 	// that routes directly to our test backend instead.
-	proxy, err := NewDesktopProxy(nil, "/prefix")
+	proxy, err := NewDesktopProxy(nil, "/prefix", nil)
 	require.NoError(t, err)
 
 	// Replace the handler: wrap in a server that upgrades through the backend
 	// We test the shutdown plumbing by going through InClusterProxy's hijack path
 	// since DesktopProxy uses the same hijackTrackingResponseWriter mechanism.
-	inProxy, err := newInClusterProxy(backend.URL, "/prefix", http.DefaultTransport)
+	inProxy, err := newInClusterProxy(backend.URL, "/prefix", nil, http.DefaultTransport)
 	require.NoError(t, err)
 
 	// Wire the DesktopProxy's shutdownCh into the InClusterProxy

--- a/modules/dashboard/pkg/app/helpers.go
+++ b/modules/dashboard/pkg/app/helpers.go
@@ -47,9 +47,9 @@ func newClusterAPIProxy(cfg *config.Config, cm k8shelpers.ConnectionManager, pat
 	// Initialize new ClusterAPI proxy depending on environment
 	switch cfg.Environment {
 	case sharedcfg.EnvironmentDesktop:
-		return clusterapi.NewDesktopProxy(cm, pathPrefix)
+		return clusterapi.NewDesktopProxy(cm, pathPrefix, cfg.AllowedOrigins)
 	case sharedcfg.EnvironmentCluster:
-		return clusterapi.NewInClusterProxy(cfg.ClusterAPIEndpoint, pathPrefix)
+		return clusterapi.NewInClusterProxy(cfg.ClusterAPIEndpoint, pathPrefix, cfg.AllowedOrigins)
 	default:
 		return nil, fmt.Errorf("env not supported: %s", cfg.Environment)
 	}

--- a/modules/dashboard/pkg/config/config.go
+++ b/modules/dashboard/pkg/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	KubeconfigPath    string   `mapstructure:"kubeconfig"`
 
 	Addr               string   `mapstructure:"addr" validate:"omitempty,hostname_port"`
+	AllowedOrigins     []string `mapstructure:"allowed-origins" validate:"dive,url"`
 	AuthMode           AuthMode `mapstructure:"auth-mode"`
 	BasePath           string   `mapstructure:"base-path"`
 	CLIVersion         string
@@ -141,6 +142,7 @@ func DefaultConfig() *Config {
 	cfg.KubeconfigPath = ""
 
 	cfg.Addr = ":8080"
+	cfg.AllowedOrigins = []string{}
 	cfg.AuthMode = AuthModeAuto
 	cfg.BasePath = "/"
 	cfg.ClusterAPIEndpoint = ""

--- a/modules/dashboard/pkg/config/config_test.go
+++ b/modules/dashboard/pkg/config/config_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadYAML(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(bytes.NewBufferString(body)))
+	// NewConfig with empty path skips file-read but still applies viper bindings.
+	// Using an in-memory viper avoids touching the filesystem.
+	cfg := DefaultConfig()
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, err
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func TestDefaultConfigAllowedOrigins(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, []string{}, cfg.AllowedOrigins)
+}
+
+func TestAllowedOriginsAcceptsValidEntries(t *testing.T) {
+	cfg, err := loadYAML(t, `
+allowed-origins:
+  - https://kubetail.example.com
+  - https://kubetail.example.com:8443
+`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"https://kubetail.example.com",
+		"https://kubetail.example.com:8443",
+	}, cfg.AllowedOrigins)
+}
+
+func TestAllowedOriginsRejectsMalformedEntry(t *testing.T) {
+	_, err := loadYAML(t, `
+allowed-origins:
+  - not-a-url
+`)
+	assert.Error(t, err)
+}

--- a/modules/shared/httphelpers/httphelpers.go
+++ b/modules/shared/httphelpers/httphelpers.go
@@ -68,6 +68,50 @@ func IsSameOrigin(r *http.Request) bool {
 	return strings.EqualFold(originHost, reqHost) && originPort == reqPort
 }
 
+// IsAllowedOrigin reports whether r passes IsSameOrigin OR its Origin
+// matches one of allowedOrigins. Each allowedOrigins entry is a fully-
+// qualified origin (scheme://host[:port]); comparison normalizes case
+// and default ports the same way as IsSameOrigin.
+//
+// Use this for deployments where a reverse proxy rewrites Host or
+// terminates TLS without preserving the scheme — situations in which
+// IsSameOrigin alone would reject legitimate requests because r.Host
+// and r.TLS no longer reflect what the browser sent. Operators
+// enumerate the public-facing origin(s) the dashboard is served at.
+//
+// An empty allowedOrigins slice is equivalent to IsSameOrigin.
+func IsAllowedOrigin(r *http.Request, allowedOrigins []string) bool {
+	if IsSameOrigin(r) {
+		return true
+	}
+	if len(allowedOrigins) == 0 {
+		return false
+	}
+	raw := r.Header.Get("Origin")
+	if raw == "" {
+		return false
+	}
+	got, err := url.Parse(raw)
+	if err != nil || got.Host == "" {
+		return false
+	}
+	gotHost, gotPort := splitHostPort(got.Host, got.Scheme)
+	for _, allowed := range allowedOrigins {
+		u, err := url.Parse(allowed)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		if !strings.EqualFold(u.Scheme, got.Scheme) {
+			continue
+		}
+		aHost, aPort := splitHostPort(u.Host, u.Scheme)
+		if strings.EqualFold(aHost, gotHost) && aPort == gotPort {
+			return true
+		}
+	}
+	return false
+}
+
 // splitHostPort returns the host and effective port for a host[:port]
 // string, falling back to scheme's default port when no port is present.
 // IPv6 brackets are stripped so bracketed and unbracketed literals compare

--- a/modules/shared/httphelpers/httphelpers_test.go
+++ b/modules/shared/httphelpers/httphelpers_test.go
@@ -231,3 +231,152 @@ func TestIsSameOrigin(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAllowedOrigin(t *testing.T) {
+	tests := []struct {
+		name           string
+		host           string
+		headers        http.Header
+		tls            bool
+		allowedOrigins []string
+		want           bool
+	}{
+		{
+			name: "empty allowlist + same-origin request is allowed",
+			host: "example.com",
+			headers: http.Header{
+				"Origin": {"http://example.com"},
+			},
+			allowedOrigins: nil,
+			want:           true,
+		},
+		{
+			name: "empty allowlist + cross-origin request is rejected",
+			host: "example.com",
+			headers: http.Header{
+				"Origin": {"https://attacker.com"},
+			},
+			allowedOrigins: nil,
+			want:           false,
+		},
+		{
+			name: "allowlist match across hostname rewrite",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://kubetail.example.com"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           true,
+		},
+		{
+			name: "allowlist scheme-mismatch is rejected",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"http://kubetail.example.com"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           false,
+		},
+		{
+			name: "allowlist host-mismatch is rejected",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://attacker.example.com"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           false,
+		},
+		{
+			name: "allowlist port-mismatch is rejected",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://kubetail.example.com:9090"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com:8443"},
+			want:           false,
+		},
+		{
+			name: "allowlist host compare is case-insensitive",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://KubeTail.Example.COM"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           true,
+		},
+		{
+			name: "allowlist default-port: entry without port matches Origin with default port",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://kubetail.example.com:443"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           true,
+		},
+		{
+			name: "allowlist default-port: entry with default port matches Origin without port",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://kubetail.example.com"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com:443"},
+			want:           true,
+		},
+		{
+			name: "allowlist IPv6 brackets normalize",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"http://[::1]:8080"},
+			},
+			allowedOrigins: []string{"http://[::1]:8080"},
+			want:           true,
+		},
+		{
+			name: "malformed allowlist entry is skipped, later entry still matches",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"https://kubetail.example.com"},
+			},
+			allowedOrigins: []string{"::not a url", "https://kubetail.example.com"},
+			want:           true,
+		},
+		{
+			name:           "missing Origin with non-empty allowlist is rejected",
+			host:           "kubetail.svc.cluster.local",
+			headers:        http.Header{},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           false,
+		},
+		{
+			name: "malformed Origin with non-empty allowlist is rejected",
+			host: "kubetail.svc.cluster.local",
+			headers: http.Header{
+				"Origin": {"://not a url"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           false,
+		},
+		{
+			name: "same-origin still wins when allowlist is non-empty and unrelated",
+			host: "example.com",
+			headers: http.Header{
+				"Origin": {"http://example.com"},
+			},
+			allowedOrigins: []string{"https://kubetail.example.com"},
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{
+				Host:   tt.host,
+				Header: tt.headers,
+			}
+			if tt.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			assert.Equal(t, tt.want, IsAllowedOrigin(r, tt.allowedOrigins))
+		})
+	}
+}


### PR DESCRIPTION
Ref #1117

## Summary

Adds an `allowed-origins` top-level config option to the dashboard as the supported escape hatch for deployments behind a reverse proxy that rewrites `Host` or terminates TLS without preserving scheme. After #1117 tightened the WebSocket same-origin gate to only trust `r.Host` and `r.TLS`, those proxied deployments would reject legitimate browser upgrades; operators can now enumerate the public-facing origin(s) the dashboard is served at and have them accepted in addition to same-origin. Default is empty (closed), so direct-access deployments are unchanged.

## Key Changes

- New `httphelpers.IsAllowedOrigin(r, allowedOrigins)` helper that delegates to `IsSameOrigin` and falls back to scheme+host+port comparison against the operator-supplied list, reusing existing case/default-port/IPv6 normalization.
- New `allowed-origins` field on the dashboard `Config` (`validate:"dive,url"`, default `[]`), documented in `config/default/dashboard.yaml`.
- Dashboard graph server's WebSocket `CheckOrigin` and the cluster-api proxies (`DesktopProxy`, `InClusterProxy`) all switch from `IsSameOrigin` to `IsAllowedOrigin`, with the slice plumbed through their constructors.
- Tests covering the helper, config validation, and the WebSocket/proxy wiring.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused