### PR TITLE
✨ Drop Fedora 41 and 42 from package-healthcheck matrix

### DIFF
--- a/.github/workflows/package-healthcheck.yml
+++ b/.github/workflows/package-healthcheck.yml
@@ -337,7 +337,6 @@ jobs:
         os:
           - centos-stream-9
           - centos-stream-10
-          - fedora-41
           - fedora-42
           - fedora-43
           - fedora-rawhide
@@ -359,8 +358,6 @@ jobs:
             image: dokken/centos-stream-9:latest
           - os: centos-stream-10
             image: dokken/centos-stream-10:latest
-          - os: fedora-41
-            image: fedora:41
           - os: fedora-42
             image: fedora:42
           - os: fedora-43
@@ -410,8 +407,6 @@ jobs:
       matrix:
         os:
           - fedora-43
-          - fedora-42
-          - fedora-41
           - fedora-rawhide
           - centos-stream-10
           - centos-stream-9
@@ -429,16 +424,6 @@ jobs:
           - os: fedora-43
             image: fedora:43
             distro: Fedora_43
-            setup: |
-              dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/kubetail/${DISTRO}/home:kubetail.repo
-          - os: fedora-42
-            image: fedora:42
-            distro: Fedora_42
-            setup: |
-              dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/kubetail/${DISTRO}/home:kubetail.repo
-          - os: fedora-41
-            image: fedora:41
-            distro: Fedora_41
             setup: |
               dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/kubetail/${DISTRO}/home:kubetail.repo
           - os: fedora-rawhide


### PR DESCRIPTION
## Summary

Removes Fedora 41 and Fedora 42 from the package-healthcheck workflow matrix to keep the test surface aligned with currently supported Fedora releases.

## Key Changes

- Drop `fedora-41` from the `rpm-install` job matrix
- Drop `fedora-41` and `fedora-42` from the `rpm-upgrade` job matrix

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused