### PR TITLE
🎣 Add arrow key navigation for selected log cells

### DIFF
--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -465,6 +465,8 @@ describe('useSelection', () => {
 
   const fakeVirtualizer = {
     getRecord: (key: number) => records[key],
+    getIndexOfKey: (key: number) => key,
+    getKeyAtIndex: (index: number) => (index >= 0 && index < records.length ? index : undefined),
   } as LogViewerVirtualizer;
 
   function renderUseSelection(storeOverrides?: (store: ReturnType<typeof createStore>) => void) {
@@ -1961,6 +1963,8 @@ describe('useSelectionKeyboard', () => {
 
   const fakeVirtualizer = {
     getRecord: (key: number) => records[key],
+    getIndexOfKey: (key: number) => key,
+    getKeyAtIndex: (index: number) => (index >= 0 && index < records.length ? index : undefined),
   } as LogViewerVirtualizer;
 
   function renderKeyboard(storeOverrides?: (store: ReturnType<typeof createStore>) => void) {
@@ -2074,5 +2078,73 @@ describe('useSelectionKeyboard', () => {
 
     // 10:30 UTC = 06:30 EDT (June is DST)
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('2024-06-15T06:30:00.000-04:00\tlog message 0');
+  });
+
+  it('moves selected cell right to the next selectable column', () => {
+    const { result, store } = renderKeyboard((s) => {
+      s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.ColorDot, ViewerColumn.Message]));
+    });
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Pod])]]));
+      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Pod });
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+    });
+
+    expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
+    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
+  });
+
+  it('moves selected cell left to the previous selectable column', () => {
+    const { result, store } = renderKeyboard((s) => {
+      s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.ColorDot, ViewerColumn.Message]));
+    });
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    });
+
+    expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Pod])]]));
+    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+  });
+
+  it('moves selected cell down to the same column on the next row', () => {
+    const { result, store } = renderKeyboard();
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowDown' });
+    });
+
+    expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
+    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 1, col: ViewerColumn.Message });
+  });
+
+  it('keeps selected cell unchanged when arrow key has no target cell', () => {
+    const { result, store } = renderKeyboard();
+
+    act(() => {
+      store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
+      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowUp' });
+    });
+
+    expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
+    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
   });
 });

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -33,6 +33,12 @@ import {
   visibleColsAtom,
 } from './state';
 
+type SelectableViewerColumn = Exclude<ViewerColumn, ViewerColumn.ColorDot>;
+
+function isSelectableViewerColumn(col: ViewerColumn): col is SelectableViewerColumn {
+  return col !== ViewerColumn.ColorDot;
+}
+
 /**
  * getPlainAttribute - Returns a plain text string for a given log record column.
  * This is the plain-text counterpart of getAttribute() in main.tsx (which returns JSX).
@@ -157,6 +163,50 @@ export function computeCellRange(
     result.set(r, colSet);
   }
   return result;
+}
+
+function getActiveSelectedCell(
+  selectedCells: Map<number, Set<ViewerColumn>>,
+  lastClickedCell: { rowKey: number; col: ViewerColumn } | null,
+  visibleCols: Set<ViewerColumn>,
+): { rowKey: number; col: ViewerColumn } | null {
+  if (lastClickedCell && selectedCells.get(lastClickedCell.rowKey)?.has(lastClickedCell.col)) {
+    return lastClickedCell;
+  }
+
+  const cols = [...visibleCols].filter(isSelectableViewerColumn);
+  const rowKey = [...selectedCells.keys()].sort((a, b) => a - b)[0];
+  if (rowKey === undefined) return null;
+
+  const selectedCols = selectedCells.get(rowKey);
+  const col = cols.find((c) => selectedCols?.has(c));
+  return col ? { rowKey, col } : null;
+}
+
+function getAdjacentSelectedCell(
+  activeCell: { rowKey: number; col: ViewerColumn },
+  key: string,
+  visibleCols: Set<ViewerColumn>,
+  virtualizer: LogViewerVirtualizer,
+): { rowKey: number; col: ViewerColumn } | null {
+  if (!isSelectableViewerColumn(activeCell.col)) return null;
+
+  const cols = [...visibleCols].filter(isSelectableViewerColumn);
+  const colIndex = cols.indexOf(activeCell.col);
+  if (colIndex === -1) return null;
+
+  if (key === 'ArrowLeft' || key === 'ArrowRight') {
+    const nextColIndex = colIndex + (key === 'ArrowRight' ? 1 : -1);
+    const col = cols[nextColIndex];
+    return col ? { rowKey: activeCell.rowKey, col } : null;
+  }
+
+  const rowIndex = virtualizer.getIndexOfKey(activeCell.rowKey);
+  if (rowIndex < 0) return null;
+
+  const nextRowIndex = rowIndex + (key === 'ArrowDown' ? 1 : -1);
+  const rowKey = virtualizer.getKeyAtIndex(nextRowIndex);
+  return rowKey === undefined ? null : { rowKey, col: activeCell.col };
 }
 
 /**
@@ -559,7 +609,17 @@ export function useSelectionKeyboard(
   state: ReturnType<typeof useSelectionState>,
   virtualizerRef: React.RefObject<LogViewerVirtualizer | null>,
 ) {
-  const { visibleCols, selectedKeysRef, selectedCellsRef, clearSelection } = state;
+  const {
+    visibleCols,
+    selectedKeysRef,
+    selectedCellsRef,
+    lastClickedCellRef,
+    setSelectedCells,
+    setLastClickedCell,
+    setIsTextSelectMode,
+    setIsCursorText,
+    clearSelection,
+  } = state;
   const [timezone] = useTimezone();
   const [timestampFormat] = useTimestampFormat();
 
@@ -599,11 +659,50 @@ export function useSelectionKeyboard(
           navigator.clipboard.writeText(text);
         }
       }
+
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+        const cells = selectedCellsRef.current;
+        if (cells.size === 0) return;
+
+        const v = virtualizerRef.current;
+        if (!v) return;
+
+        const activeCell = getActiveSelectedCell(cells, lastClickedCellRef.current, visibleCols);
+        if (!activeCell) return;
+
+        const nextCell = getAdjacentSelectedCell(activeCell, e.key, visibleCols, v);
+        if (!nextCell) return;
+
+        e.preventDefault();
+        window.getSelection()?.removeAllRanges();
+        const nextCells = new Map([[nextCell.rowKey, new Set([nextCell.col])]]);
+        selectedCellsRef.current = nextCells;
+        lastClickedCellRef.current = nextCell;
+        setSelectedCells(nextCells);
+        setLastClickedCell(nextCell);
+        setIsTextSelectMode(true);
+        setIsCursorText(false);
+      }
     };
 
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [visibleCols, timezone, timestampFormat, clearSelection, selectedKeysRef, selectedCellsRef, virtualizerRef]);
+  }, [
+    visibleCols,
+    timezone,
+    timestampFormat,
+    clearSelection,
+    selectedKeysRef,
+    selectedCellsRef,
+    lastClickedCellRef,
+    setSelectedCells,
+    setLastClickedCell,
+    setIsTextSelectMode,
+    setIsCursorText,
+    virtualizerRef,
+  ]);
 }
 
 export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {


### PR DESCRIPTION
Closes #1119


## Summary

Add keyboard navigation for selected log viewer cells so users can move between nearby cells with the arrow keys after selecting a cell. This makes the spreadsheet-like copy workflow easier to use without switching back to the mouse.

## Key Changes

- Add arrow key handling for selected log cells in the console selection logic.
- Move left and right across visible selectable columns, skipping the Color Dot column.
- Move up and down to the same column on adjacent log rows.
- Preserve the current selection when an arrow key has no valid target cell.
- Add tests covering horizontal, vertical, and boundary navigation.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
