### PR TITLE
✨ Migrate e2e tests from k3d to kind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,11 +462,11 @@ jobs:
       matrix:
         include:
           - k8s-version: "1.21"
-            k3s-image: "rancher/k3s:v1.21.14-k3s1"
+            kind-image: "kindest/node:v1.21.14"
           - k8s-version: "1.25"
-            k3s-image: "rancher/k3s:v1.25.16-k3s4"
+            kind-image: "kindest/node:v1.25.16"
           - k8s-version: "latest"
-            k3s-image: ""
+            kind-image: ""
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-environment
@@ -475,13 +475,13 @@ jobs:
           setup-go: "true"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-      - name: Install k3d
-        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+      - name: Install kind
+        run: go install sigs.k8s.io/kind@latest
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run e2e tests
         env:
-          K3S_IMAGE: ${{ matrix.k3s-image }}
+          KIND_IMAGE: ${{ matrix.kind-image }}
         run: make test-e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,28 @@ cd crates/rgkl && cargo test
 
 Always use `pnpm` (not `npx`) to run frontend tests.
 
+### E2E tests
+
+E2E tests live in `e2e/` and require [kind](https://kind.sigs.k8s.io), Docker, kubectl, and uv.
+
+```sh
+# Full suite (builds images + CLI, then runs pytest):
+make test-e2e
+
+# Target a specific Kubernetes version:
+KIND_IMAGE=kindest/node:v1.21.14 make test-e2e
+KIND_IMAGE=kindest/node:v1.25.16 make test-e2e
+
+# Re-run pytest without rebuilding (cluster must already be up):
+cd e2e && uv run pytest -v
+
+# Bring up / tear down the cluster manually:
+./e2e/scripts/up.sh --backend=kubetail-api   # or --backend=kubernetes-api
+./e2e/scripts/down.sh
+```
+
+`down.sh` stops port-forwards, deletes the kind cluster, and removes `/tmp/kubetail-e2e.kubeconfig`. Run it to clean up after an interrupted test run.
+
 Never use `time.Sleep` (Go) or `setTimeout`/manual delays (TypeScript) in tests to wait for asynchronous state. Use channels, synchronization primitives, or condition-based polling instead.
 
 ## Import Order (JavaScript/TypeScript)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,28 @@ cd crates/rgkl && cargo test
 
 Always use `pnpm` (not `npx`) to run frontend tests.
 
+### E2E tests
+
+E2E tests live in `e2e/` and require [kind](https://kind.sigs.k8s.io), Docker, kubectl, and uv.
+
+```sh
+# Full suite (builds images + CLI, then runs pytest):
+make test-e2e
+
+# Target a specific Kubernetes version:
+KIND_IMAGE=kindest/node:v1.21.14 make test-e2e
+KIND_IMAGE=kindest/node:v1.25.16 make test-e2e
+
+# Re-run pytest without rebuilding (cluster must already be up):
+cd e2e && uv run pytest -v
+
+# Bring up / tear down the cluster manually:
+./e2e/scripts/up.sh --backend=kubetail-api   # or --backend=kubernetes-api
+./e2e/scripts/down.sh
+```
+
+`down.sh` stops port-forwards, deletes the kind cluster, and removes `/tmp/kubetail-e2e.kubeconfig`. Run it to clean up after an interrupted test run.
+
 Never use `time.Sleep` (Go) or `setTimeout`/manual delays (TypeScript) in tests to wait for asynchronous state. Use channels, synchronization primitives, or condition-based polling instead.
 
 ## Import Order (JavaScript/TypeScript)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -72,6 +72,28 @@ cd crates/rgkl && cargo test
 
 Always use `pnpm` (not `npx`) to run frontend tests.
 
+### E2E tests
+
+E2E tests live in `e2e/` and require [kind](https://kind.sigs.k8s.io), Docker, kubectl, and uv.
+
+```sh
+# Full suite (builds images + CLI, then runs pytest):
+make test-e2e
+
+# Target a specific Kubernetes version:
+KIND_IMAGE=kindest/node:v1.21.14 make test-e2e
+KIND_IMAGE=kindest/node:v1.25.16 make test-e2e
+
+# Re-run pytest without rebuilding (cluster must already be up):
+cd e2e && uv run pytest -v
+
+# Bring up / tear down the cluster manually:
+./e2e/scripts/up.sh --backend=kubetail-api   # or --backend=kubernetes-api
+./e2e/scripts/down.sh
+```
+
+`down.sh` stops port-forwards, deletes the kind cluster, and removes `/tmp/kubetail-e2e.kubeconfig`. Run it to clean up after an interrupted test run.
+
 Never use `time.Sleep` (Go) or `setTimeout`/manual delays (TypeScript) in tests to wait for asynchronous state. Use channels, synchronization primitives, or condition-based polling instead.
 
 ## Import Order (JavaScript/TypeScript)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ci-checks: lint-all test-all vet-all
 ## iterating on cluster-api / cluster-agent code while a kind cluster is up).
 test-e2e: build
 	@echo "Building e2e images..."
-	@cd e2e && docker buildx bake --allow=fs.read=.. --load --file docker-bake.hcl --progress=plain
+	@cd e2e && docker buildx bake --allow=fs.read=.. --load --file docker-bake.hcl --progress=quiet
 ifndef ONLY_BUILD
 	@cd e2e && uv run pytest -v
 endif

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,10 @@ ci-checks: lint-all test-all vet-all
 
 ## Build e2e images and CLI, then run the full e2e suite.
 ## Pass ONLY_BUILD=1 to skip pytest and just rebuild artifacts (useful when
-## iterating on cluster-api / cluster-agent code while a k3d cluster is up).
+## iterating on cluster-api / cluster-agent code while a kind cluster is up).
 test-e2e: build
 	@echo "Building e2e images..."
-	@cd e2e && docker buildx bake --allow=fs.read=.. --load --file docker-bake.hcl
+	@cd e2e && docker buildx bake --allow=fs.read=.. --load --file docker-bake.hcl --progress=plain
 ifndef ONLY_BUILD
 	@cd e2e && uv run pytest -v
 endif

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -11,7 +11,7 @@ in sequence:
 
 - [uv](https://docs.astral.sh/uv/)
 - [Docker](https://docs.docker.com/get-docker/)
-- [k3d](https://k3d.io)
+- [kind](https://kind.sigs.k8s.io)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 
 ## Configuration
@@ -34,7 +34,18 @@ make e2e
 ```
 
 This builds the CLI and Docker images, then runs all three environments in sequence,
-creating and tearing down the k3d cluster around each cluster suite.
+creating and tearing down the kind cluster around each cluster suite.
+
+## Test against a specific Kubernetes version
+
+Pass `KIND_IMAGE` to target a specific Kubernetes version:
+
+```sh
+KIND_IMAGE=kindest/node:v1.21.14 make test-e2e
+KIND_IMAGE=kindest/node:v1.25.16 make test-e2e
+```
+
+Omit `KIND_IMAGE` to use kind's default (latest supported) node image.
 
 ## Iterate on tests
 
@@ -43,6 +54,16 @@ Once images and the CLI are built, you can re-run pytest directly without rebuil
 ```sh
 cd e2e && uv run pytest -v
 ```
+
+## Clean up
+
+The test suite tears down the cluster automatically after each run. If a run is interrupted or you want to clean up manually:
+
+```sh
+./e2e/scripts/down.sh
+```
+
+This stops any active port-forwards, deletes the kind cluster, and removes the temporary kubeconfig at `/tmp/kubetail-e2e.kubeconfig`.
 
 ## Manual cluster management
 

--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # kind nodes do not fully support the nftables kube-proxy mode introduced
+  # as default in Kubernetes 1.31+. Force iptables so ClusterIP routing works
+  # correctly from the control-plane container (where kube-apiserver runs and
+  # needs to reach the cluster-api service via the aggregation layer).
+  kubeProxyMode: iptables

--- a/e2e/scripts/down.sh
+++ b/e2e/scripts/down.sh
@@ -17,9 +17,9 @@ if [ -f "$PID_FILE" ]; then
 fi
 
 # Delete cluster
-if k3d cluster list 2>/dev/null | grep -q "^$CLUSTER_NAME"; then
-  echo "Deleting k3d cluster: $CLUSTER_NAME"
-  KUBECONFIG="$KUBECONFIG" k3d cluster delete "$CLUSTER_NAME"
+if kind get clusters 2>/dev/null | grep -q "^$CLUSTER_NAME$"; then
+  echo "Deleting kind cluster: $CLUSTER_NAME"
+  kind delete cluster --name "$CLUSTER_NAME"
 else
   echo "Cluster $CLUSTER_NAME not found, nothing to delete."
 fi

--- a/e2e/scripts/up.sh
+++ b/e2e/scripts/up.sh
@@ -29,7 +29,7 @@ MANIFEST="$SCRIPT_DIR/../manifests/${BACKEND}.yaml.tmpl"
 PID_FILE="/tmp/kubetail-e2e-pf.pid"
 
 # Create cluster if it doesn't exist
-KIND_CREATE_ARGS=(--name "$CLUSTER_NAME")
+KIND_CREATE_ARGS=(--name "$CLUSTER_NAME" --config "$SCRIPT_DIR/../kind-config.yaml")
 if [ -n "${KIND_IMAGE:-}" ]; then
   KIND_CREATE_ARGS+=(--image "$KIND_IMAGE")
 fi
@@ -87,6 +87,9 @@ if [ "$BACKEND" = "kubetail-api" ]; then
     --namespace=kubetail-system --timeout=90s
   kubectl rollout status daemonset/kubetail-cluster-agent \
     --namespace=kubetail-system --timeout=90s
+  # Wait for the aggregation layer to be available — kube-apiserver registers
+  # the APIService asynchronously after the pod is Ready.
+  kubectl wait --for=condition=Available apiservice/v1.api.kubetail.com --timeout=60s
 fi
 
 # Kill any existing port-forwards

--- a/e2e/scripts/up.sh
+++ b/e2e/scripts/up.sh
@@ -29,33 +29,31 @@ MANIFEST="$SCRIPT_DIR/../manifests/${BACKEND}.yaml.tmpl"
 PID_FILE="/tmp/kubetail-e2e-pf.pid"
 
 # Create cluster if it doesn't exist
-K3D_CREATE_ARGS=()
-if [ -n "${K3S_IMAGE:-}" ]; then
-  K3D_CREATE_ARGS+=(--image "$K3S_IMAGE")
+KIND_CREATE_ARGS=(--name "$CLUSTER_NAME")
+if [ -n "${KIND_IMAGE:-}" ]; then
+  KIND_CREATE_ARGS+=(--image "$KIND_IMAGE")
 fi
 
-if ! k3d cluster list 2>/dev/null | grep -q "^$CLUSTER_NAME"; then
-  echo "Creating k3d cluster: $CLUSTER_NAME${K3S_IMAGE:+ (image: $K3S_IMAGE)}"
-  k3d cluster create "$CLUSTER_NAME" "${K3D_CREATE_ARGS[@]}"
+if ! kind get clusters 2>/dev/null | grep -q "^$CLUSTER_NAME$"; then
+  echo "Creating kind cluster: $CLUSTER_NAME${KIND_IMAGE:+ (image: $KIND_IMAGE)}"
+  kind create cluster "${KIND_CREATE_ARGS[@]}"
 else
   echo "Cluster $CLUSTER_NAME already exists, reusing."
 fi
 
-# Always write kubeconfig — k3d only writes it on create, not on reuse
-k3d kubeconfig get "$CLUSTER_NAME" > "$KUBECONFIG"
+# Write kubeconfig
+kind get kubeconfig --name "$CLUSTER_NAME" > "$KUBECONFIG"
 
 kubectl wait --for=condition=Ready nodes --all --timeout=60s
 
 # Load images into cluster
 echo "Loading images into cluster..."
 if [ "$BACKEND" = "kubernetes-api" ]; then
-  k3d image import "$KUBETAIL_DASHBOARD_IMAGE" --cluster "$CLUSTER_NAME"
+  kind load docker-image "$KUBETAIL_DASHBOARD_IMAGE" --name "$CLUSTER_NAME"
 else
-  k3d image import \
-    "$KUBETAIL_DASHBOARD_IMAGE" \
-    "$KUBETAIL_CLUSTER_API_IMAGE" \
-    "$KUBETAIL_CLUSTER_AGENT_IMAGE" \
-    --cluster "$CLUSTER_NAME"
+  kind load docker-image "$KUBETAIL_DASHBOARD_IMAGE" --name "$CLUSTER_NAME"
+  kind load docker-image "$KUBETAIL_CLUSTER_API_IMAGE" --name "$CLUSTER_NAME"
+  kind load docker-image "$KUBETAIL_CLUSTER_AGENT_IMAGE" --name "$CLUSTER_NAME"
 fi
 
 # Apply manifest (namespace is included)

--- a/e2e/test_csrf.py
+++ b/e2e/test_csrf.py
@@ -11,10 +11,10 @@ import websockets
 # of backend, so we only run against kubetail-api.
 pytestmark = [pytest.mark.kubetail_api]
 
-# k3d names the kubeconfig context "k3d-<cluster>". Used by the DesktopProxy
+# kind names the kubeconfig context "kind-<cluster>". Used by the DesktopProxy
 # in CLI mode, which requires /cluster-api-proxy/<kubeContext>/<relPath>;
 # in cluster mode the InClusterProxy ignores the path tail.
-_E2E_KUBE_CONTEXT = "k3d-kubetail-e2e"
+_E2E_KUBE_CONTEXT = "kind-kubetail-e2e"
 
 _PROXY_HTTP_PATH = f"/cluster-api-proxy/{_E2E_KUBE_CONTEXT}/healthz"
 _PROXY_WS_PATHS = {

--- a/e2e/test_namespace_rbac.py
+++ b/e2e/test_namespace_rbac.py
@@ -59,10 +59,10 @@ _CLUSTER_API_LOG_METADATA = (
     "{items{id}}}"
 )
 
-# k3d names the kubeconfig context "k3d-<cluster>". The CLI's DesktopProxy
+# kind names the kubeconfig context "kind-<cluster>". The CLI's DesktopProxy
 # requires /cluster-api-proxy/<kubeContext>/<relPath>; in cluster mode the
 # InClusterProxy ignores the path tail.
-_E2E_KUBE_CONTEXT = "k3d-kubetail-e2e"
+_E2E_KUBE_CONTEXT = "kind-kubetail-e2e"
 
 
 _NAMESPACE_CASES = pytest.mark.parametrize(

--- a/e2e/test_zero_trust.py
+++ b/e2e/test_zero_trust.py
@@ -55,32 +55,32 @@ _AGENT_TARGET_NAME = "kubetail-cluster-agent.kubetail-system.svc"
 _LIST_METHOD = "/cluster_agent.LogMetadataService/List"
 
 
-# k3s stores the front-proxy client cert+key under this path inside the
-# server container. k3d names the server container "k3d-<cluster>-server-0".
-_K3D_SERVER = "k3d-kubetail-e2e-server-0"
-_K3S_FRONT_PROXY_CRT = "/var/lib/rancher/k3s/server/tls/client-auth-proxy.crt"
-_K3S_FRONT_PROXY_KEY = "/var/lib/rancher/k3s/server/tls/client-auth-proxy.key"
+# kubeadm stores the front-proxy client cert+key under this path inside the
+# control-plane container. kind names it "<cluster>-control-plane".
+_KIND_CONTROL_PLANE = "kubetail-e2e-control-plane"
+_FRONT_PROXY_CRT = "/etc/kubernetes/pki/front-proxy-client.crt"
+_FRONT_PROXY_KEY = "/etc/kubernetes/pki/front-proxy-client.key"
 
 
 @pytest.fixture(scope="session")
 def front_proxy_client_cert(tmp_path_factory):
     """Extract the kube-apiserver's front-proxy client cert+key from the
-    k3d server container. This is the cert kube-apiserver presents when it
+    kind control-plane container. This is the cert kube-apiserver presents when it
     forwards aggregated requests to cluster-api — anything signed by it
     (and matching the requestheader-allowed-names CN) is trusted by
     aggregationAuthMiddleware to *carry* an identity in headers, but the
     headers themselves still have to be present."""
     def _docker_cat(path):
         return subprocess.run(
-            ["docker", "exec", _K3D_SERVER, "cat", path],
+            ["docker", "exec", _KIND_CONTROL_PLANE, "cat", path],
             check=True, capture_output=True,
         ).stdout
 
     try:
-        crt_bytes = _docker_cat(_K3S_FRONT_PROXY_CRT)
-        key_bytes = _docker_cat(_K3S_FRONT_PROXY_KEY)
+        crt_bytes = _docker_cat(_FRONT_PROXY_CRT)
+        key_bytes = _docker_cat(_FRONT_PROXY_KEY)
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        pytest.skip(f"front-proxy material unavailable (not a k3d cluster?): {e}")
+        pytest.skip(f"front-proxy material unavailable (not a kind cluster?): {e}")
 
     d = tmp_path_factory.mktemp("front-proxy-cert")
     crt = d / "fp.crt"
@@ -94,7 +94,7 @@ def front_proxy_client_cert(tmp_path_factory):
 def admin_client_cert(tmp_path_factory):
     """Extract the e2e admin's client cert+key from the kubeconfig.
 
-    The k3d admin cert is signed by the same CA the cluster-api loads
+    The kind admin cert is signed by the same CA the cluster-api loads
     into its ClientCAs pool (extension-apiserver-authentication's
     client-ca-file), so a request bearing it takes the middleware's
     direct-cert path."""


### PR DESCRIPTION
## Summary

Replaces k3d/k3s with [kind](https://kind.sigs.k8s.io) as the local
Kubernetes cluster tool for e2e tests. kind is the more widely-used
standard in the Kubernetes ecosystem and is already used in CI for many
upstream projects, making it easier for contributors to reproduce test
environments. The CI matrix continues to cover Kubernetes 1.21, 1.25,
and latest.

## Key Changes

- Replace k3d cluster create/delete/image-import commands with kind
  equivalents in `e2e/scripts/up.sh` and `e2e/scripts/down.sh`
- Update CI workflow to install kind via `go install` and rename the
  matrix variable from `k3s-image` to `kind-image`
- Update kube context references from `k3d-kubetail-e2e` to
  `kind-kubetail-e2e` in the three e2e test files
- Swap front-proxy cert paths in `test_zero_trust.py` from k3s paths
  (`/var/lib/rancher/k3s/...`) to kubeadm paths (`/etc/kubernetes/pki/...`)
  and update the container name from `k3d-kubetail-e2e-server-0` to
  `kubetail-e2e-control-plane`
- Add e2e test documentation section (kind prerequisites, version
  targeting, cleanup steps) to CLAUDE.md, AGENTS.md, GEMINI.md, and
  e2e/README.md

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused