### PR TITLE
✨ Migrate e2e cluster tool from k3d to kind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,11 +462,11 @@ jobs:
       matrix:
         include:
           - k8s-version: "1.21"
-            k3s-image: "rancher/k3s:v1.21.14-k3s1"
+            kind-node-image: "kindest/node:v1.21.14"
           - k8s-version: "1.25"
-            k3s-image: "rancher/k3s:v1.25.16-k3s4"
+            kind-node-image: "kindest/node:v1.25.16"
           - k8s-version: "latest"
-            k3s-image: ""
+            kind-node-image: ""
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-environment
@@ -475,13 +475,15 @@ jobs:
           setup-go: "true"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-      - name: Install k3d
-        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run e2e tests
         env:
-          K3S_IMAGE: ${{ matrix.k3s-image }}
+          KIND_NODE_IMAGE: ${{ matrix.kind-node-image }}
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ ci-checks: lint-all test-all vet-all
 
 ## Build e2e images and CLI, then run the full e2e suite.
 ## Pass ONLY_BUILD=1 to skip pytest and just rebuild artifacts (useful when
-## iterating on cluster-api / cluster-agent code while a k3d cluster is up).
-## The k3d cluster persists across runs; run e2e/scripts/down.sh to tear it down.
+## iterating on cluster-api / cluster-agent code while a kind cluster is up).
+## The kind cluster persists across runs; run e2e/scripts/down.sh to tear it down.
 test-e2e:
 	@bash e2e/scripts/build.sh
 ifndef ONLY_BUILD

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -11,7 +11,7 @@ in sequence:
 
 - [uv](https://docs.astral.sh/uv/)
 - [Docker](https://docs.docker.com/get-docker/)
-- [k3d](https://k3d.io)
+- [kind](https://kind.sigs.k8s.io/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 
 ## Configuration
@@ -33,7 +33,7 @@ From the repo root:
 make e2e
 ```
 
-This builds the CLI and Docker images, brings up the k3d cluster (reusing
+This builds the CLI and Docker images, brings up the kind cluster (reusing
 it if already running), and runs all three environments in sequence. The
 cluster persists after the run — tear it down with `e2e/scripts/down.sh`
 when you're done.

--- a/e2e/scripts/down.sh
+++ b/e2e/scripts/down.sh
@@ -17,9 +17,9 @@ if [ -f "$PID_FILE" ]; then
 fi
 
 # Delete cluster
-if k3d cluster list 2>/dev/null | grep -q "^$CLUSTER_NAME"; then
-  echo "Deleting k3d cluster: $CLUSTER_NAME"
-  KUBECONFIG="$KUBECONFIG" k3d cluster delete "$CLUSTER_NAME"
+if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  echo "Deleting kind cluster: $CLUSTER_NAME"
+  KUBECONFIG="$KUBECONFIG" kind delete cluster --name "$CLUSTER_NAME"
 else
   echo "Cluster $CLUSTER_NAME not found, nothing to delete."
 fi

--- a/e2e/scripts/up.sh
+++ b/e2e/scripts/up.sh
@@ -26,29 +26,27 @@ BASE_MANIFEST="$MANIFESTS_DIR/base.yaml.tmpl"
 PID_FILE="/tmp/kubetail-e2e-pf.pid"
 
 # Create cluster if it doesn't exist
-K3D_CREATE_ARGS=()
-if [ -n "${K3S_IMAGE:-}" ]; then
-  K3D_CREATE_ARGS+=(--image "$K3S_IMAGE")
+KIND_CREATE_ARGS=()
+if [ -n "${KIND_NODE_IMAGE:-}" ]; then
+  KIND_CREATE_ARGS+=(--image "$KIND_NODE_IMAGE")
 fi
 
-if ! k3d cluster list 2>/dev/null | grep -q "^$CLUSTER_NAME"; then
-  echo "Creating k3d cluster: $CLUSTER_NAME${K3S_IMAGE:+ (image: $K3S_IMAGE)}"
-  k3d cluster create "$CLUSTER_NAME" "${K3D_CREATE_ARGS[@]}"
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  echo "Creating kind cluster: $CLUSTER_NAME${KIND_NODE_IMAGE:+ (image: $KIND_NODE_IMAGE)}"
+  kind create cluster --name "$CLUSTER_NAME" --kubeconfig "$KUBECONFIG" "${KIND_CREATE_ARGS[@]}"
 else
   echo "Cluster $CLUSTER_NAME already exists, reusing."
+  kind export kubeconfig --name "$CLUSTER_NAME" --kubeconfig "$KUBECONFIG"
 fi
-
-# Always write kubeconfig — k3d only writes it on create, not on reuse
-k3d kubeconfig get "$CLUSTER_NAME" > "$KUBECONFIG"
 
 kubectl wait --for=condition=Ready nodes --all --timeout=60s
 
 echo "Loading images into cluster..."
-k3d image import \
+kind load docker-image \
   "$KUBETAIL_DASHBOARD_IMAGE" \
   "$KUBETAIL_CLUSTER_API_IMAGE" \
   "$KUBETAIL_CLUSTER_AGENT_IMAGE" \
-  --cluster "$CLUSTER_NAME"
+  --name "$CLUSTER_NAME"
 
 # Apply base manifest (namespace + Dashboard + cluster-api + cluster-agent + APIService).
 envsubst < "$BASE_MANIFEST" | kubectl apply -f -

--- a/e2e/test_allowed_namespaces.py
+++ b/e2e/test_allowed_namespaces.py
@@ -158,6 +158,55 @@ def _wait_for_healthz(url, *, verify=False, timeout=30):
     raise RuntimeError(f"healthz never became ready at {url}: {last_err}")
 
 
+def _wait_for_apiservice_available(name="v1.api.kubetail.com", timeout=60):
+    """Wait until the kube-apiserver's APIService aggregation handler can
+    actually dial the cluster-api Service. After a rollout-restart, the
+    Service Endpoints flip to the new pod and kube-proxy iptables update;
+    on some CNIs (notably kind's default) this can lag the deployment's
+    Ready signal by a few seconds, so the proxy path returns
+    `connection refused` even though `kubectl rollout status` returned."""
+    deadline = time.monotonic() + timeout
+    last_status = None
+    while time.monotonic() < deadline:
+        out = kubectl(
+            "get", "apiservice", name,
+            "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+        ).stdout.strip()
+        last_status = out
+        if out == "True":
+            return
+        time.sleep(0.3)
+    raise RuntimeError(
+        f"APIService {name} never became Available (last status={last_status!r})"
+    )
+
+
+def _wait_for_proxy_path(dashboard_url, timeout=60):
+    """Poll the dashboard's /cluster-api-proxy until it actually round-trips
+    to the cluster-api. After a cluster-api rollout, the kube-apiserver's
+    aggregation dialer can still hold a connection to the terminated pod's
+    IP — kube-proxy iptables and the apiserver's own connection cache both
+    take a few seconds to converge. Symptom: `connection refused` on the
+    Service ClusterIP even though APIService.Available is True."""
+    deadline = time.monotonic() + timeout
+    last_err = None
+    while time.monotonic() < deadline:
+        try:
+            body = post_graphql(
+                dashboard_url,
+                "/cluster-api-proxy/graphql",
+                "query Q{__typename}",
+                {},
+            )
+            if isinstance(body, dict) and body.get("data", {}).get("__typename"):
+                return
+            last_err = repr(body)
+        except (AssertionError, requests.RequestException) as e:
+            last_err = repr(e)
+        time.sleep(0.3)
+    raise RuntimeError(f"cluster-api proxy never warmed up: {last_err}")
+
+
 def _reconfigure(allowed, *, dashboard_url, cluster_api_url):
     """Apply `allowed-namespaces=allowed` to the live deployments and
     re-establish port-forwards on the original local ports. Used for
@@ -189,6 +238,8 @@ def _reconfigure(allowed, *, dashboard_url, cluster_api_url):
 
     _wait_for_healthz(dashboard_url)
     _wait_for_healthz(cluster_api_url, verify=False)
+    _wait_for_apiservice_available()
+    _wait_for_proxy_path(dashboard_url)
     return procs
 
 

--- a/e2e/test_csrf.py
+++ b/e2e/test_csrf.py
@@ -7,10 +7,10 @@ import pytest
 import requests
 import websockets
 
-# k3d names the kubeconfig context "k3d-<cluster>". Used by the DesktopProxy
+# kind names the kubeconfig context "kind-<cluster>". Used by the DesktopProxy
 # in CLI mode, which requires /cluster-api-proxy/<kubeContext>/<relPath>;
 # in cluster mode the InClusterProxy ignores the path tail.
-_E2E_KUBE_CONTEXT = "k3d-kubetail-e2e"
+_E2E_KUBE_CONTEXT = "kind-kubetail-e2e"
 
 _PROXY_HTTP_PATH = f"/cluster-api-proxy/{_E2E_KUBE_CONTEXT}/healthz"
 _PROXY_WS_PATHS = {

--- a/e2e/test_namespace_rbac.py
+++ b/e2e/test_namespace_rbac.py
@@ -54,10 +54,10 @@ _CLUSTER_API_LOG_METADATA = (
     "{items{id}}}"
 )
 
-# k3d names the kubeconfig context "k3d-<cluster>". The CLI's DesktopProxy
+# kind names the kubeconfig context "kind-<cluster>". The CLI's DesktopProxy
 # requires /cluster-api-proxy/<kubeContext>/<relPath>; in cluster mode the
 # InClusterProxy ignores the path tail.
-_E2E_KUBE_CONTEXT = "k3d-kubetail-e2e"
+_E2E_KUBE_CONTEXT = "kind-kubetail-e2e"
 
 
 _NAMESPACE_CASES = pytest.mark.parametrize(

--- a/e2e/test_zero_trust.py
+++ b/e2e/test_zero_trust.py
@@ -54,32 +54,33 @@ _AGENT_TARGET_NAME = "kubetail-cluster-agent.kubetail-system.svc"
 _LIST_METHOD = "/cluster_agent.LogMetadataService/List"
 
 
-# k3s stores the front-proxy client cert+key under this path inside the
-# server container. k3d names the server container "k3d-<cluster>-server-0".
-_K3D_SERVER = "k3d-kubetail-e2e-server-0"
-_K3S_FRONT_PROXY_CRT = "/var/lib/rancher/k3s/server/tls/client-auth-proxy.crt"
-_K3S_FRONT_PROXY_KEY = "/var/lib/rancher/k3s/server/tls/client-auth-proxy.key"
+# kind/kubeadm stores the front-proxy client cert+key under this path inside
+# the control-plane container. kind names the control-plane container
+# "<cluster>-control-plane".
+_KIND_SERVER = "kubetail-e2e-control-plane"
+_FRONT_PROXY_CRT = "/etc/kubernetes/pki/front-proxy-client.crt"
+_FRONT_PROXY_KEY = "/etc/kubernetes/pki/front-proxy-client.key"
 
 
 @pytest.fixture(scope="session")
 def front_proxy_client_cert(tmp_path_factory):
     """Extract the kube-apiserver's front-proxy client cert+key from the
-    k3d server container. This is the cert kube-apiserver presents when it
-    forwards aggregated requests to cluster-api — anything signed by it
-    (and matching the requestheader-allowed-names CN) is trusted by
+    kind control-plane container. This is the cert kube-apiserver presents
+    when it forwards aggregated requests to cluster-api — anything signed
+    by it (and matching the requestheader-allowed-names CN) is trusted by
     aggregationAuthMiddleware to *carry* an identity in headers, but the
     headers themselves still have to be present."""
     def _docker_cat(path):
         return subprocess.run(
-            ["docker", "exec", _K3D_SERVER, "cat", path],
+            ["docker", "exec", _KIND_SERVER, "cat", path],
             check=True, capture_output=True,
         ).stdout
 
     try:
-        crt_bytes = _docker_cat(_K3S_FRONT_PROXY_CRT)
-        key_bytes = _docker_cat(_K3S_FRONT_PROXY_KEY)
+        crt_bytes = _docker_cat(_FRONT_PROXY_CRT)
+        key_bytes = _docker_cat(_FRONT_PROXY_KEY)
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        pytest.skip(f"front-proxy material unavailable (not a k3d cluster?): {e}")
+        pytest.skip(f"front-proxy material unavailable (not a kind cluster?): {e}")
 
     d = tmp_path_factory.mktemp("front-proxy-cert")
     crt = d / "fp.crt"
@@ -93,7 +94,7 @@ def front_proxy_client_cert(tmp_path_factory):
 def admin_client_cert(tmp_path_factory):
     """Extract the e2e admin's client cert+key from the kubeconfig.
 
-    The k3d admin cert is signed by the same CA the cluster-api loads
+    The kind admin cert is signed by the same CA the cluster-api loads
     into its ClientCAs pool (extension-apiserver-authentication's
     client-ca-file), so a request bearing it takes the middleware's
     direct-cert path."""


### PR DESCRIPTION
## Summary

Replaces the k3d/k3s-based local cluster used by the e2e suite with kind
(Kubernetes IN Docker). kind uses standard kubeadm and is better aligned with
real cluster behavior — in particular, front-proxy cert paths and kube context
naming conventions differ from k3d's k3s-based layout, which required several
fixes in the zero-trust and CSRF tests.

Two extra wait helpers (`_wait_for_apiservice_available`,
`_wait_for_proxy_path`) are added to `test_allowed_namespaces.py` to handle
kind's slightly slower iptables propagation after a rollout restart.

## Key Changes

- Replace k3d cluster lifecycle commands in `e2e/scripts/up.sh` and
  `down.sh` with `kind create/delete/export` equivalents
- Update CI matrix to use `kindest/node` images and install kind via
  `helm/kind-action` instead of the k3d install script
- Update kubeconfig context references from `k3d-kubetail-e2e` to
  `kind-kubetail-e2e` across all test files
- Update front-proxy cert paths and container name in `test_zero_trust.py`
  to match kind's kubeadm layout (`/etc/kubernetes/pki/`)
- Add proxy-readiness polling helpers to absorb kind's iptables convergence
  lag after cluster-api rollout restarts

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused