### PR TITLE
🐋 Add Kubetail API backend to `kubetail logs`

### DIFF
--- a/e2e/_kubeconfig.py
+++ b/e2e/_kubeconfig.py
@@ -1,0 +1,83 @@
+"""Helpers to extract apiserver URL + TLS material from the e2e kubeconfig.
+
+Used by the WebSocket auth tests, which need to dial the kube-apiserver
+directly (with and without client credentials) instead of going through the
+dashboard or `kubetail` CLI.
+"""
+
+import base64
+import json
+import ssl
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from _namespace_rbac import kubectl
+
+
+@dataclass
+class ApiserverAccess:
+    """Materialized apiserver coordinates for a Python TLS client.
+
+    `cert_path` / `key_path` are paths to PEM files written to a private
+    temp dir; callers can pass them to `ssl.SSLContext.load_cert_chain`.
+    """
+    server: str
+    ca_path: str
+    cert_path: str
+    key_path: str
+    _tmpdir: tempfile.TemporaryDirectory
+
+    def cleanup(self):
+        self._tmpdir.cleanup()
+
+
+def materialize_apiserver_access() -> ApiserverAccess:
+    """Read the e2e kubeconfig and write its TLS material to a temp dir.
+
+    `kubectl config view --raw --minify --flatten -o json` resolves any
+    file references and base64-encodes them; we decode and write to disk
+    so Python's ssl module can consume them.
+    """
+    cfg = json.loads(
+        kubectl("config", "view", "--raw", "--minify", "--flatten", "-o", "json").stdout
+    )
+    cluster = cfg["clusters"][0]["cluster"]
+    user = cfg["users"][0]["user"]
+
+    server = cluster["server"]
+
+    tmpdir = tempfile.TemporaryDirectory(prefix="kubetail-e2e-tls-")
+    base = Path(tmpdir.name)
+
+    ca_path = base / "ca.crt"
+    ca_path.write_bytes(base64.b64decode(cluster["certificate-authority-data"]))
+
+    cert_path = base / "client.crt"
+    cert_path.write_bytes(base64.b64decode(user["client-certificate-data"]))
+
+    key_path = base / "client.key"
+    key_path.write_bytes(base64.b64decode(user["client-key-data"]))
+
+    return ApiserverAccess(
+        server=server,
+        ca_path=str(ca_path),
+        cert_path=str(cert_path),
+        key_path=str(key_path),
+        _tmpdir=tmpdir,
+    )
+
+
+def ssl_ctx(access: ApiserverAccess, *, with_client_cert: bool) -> ssl.SSLContext:
+    """Build an SSLContext that trusts the kind apiserver CA.
+
+    With `with_client_cert=True`, also presents the kubeconfig's admin
+    client cert/key — that's how we get an authenticated request through
+    the apiserver. Without it, the apiserver sees no client cert and
+    treats the caller as `system:anonymous`, which has no RBAC for
+    api.kubetail.com and is rejected.
+    """
+    ctx = ssl.create_default_context(cafile=access.ca_path)
+    if with_client_cert:
+        ctx.load_cert_chain(access.cert_path, access.key_path)
+    return ctx

--- a/e2e/_log_producer.py
+++ b/e2e/_log_producer.py
@@ -1,0 +1,37 @@
+"""Shared constants and helpers for the e2e log-producer fixture.
+
+Used by test_logs_backends.py, test_cluster_api_websocket_auth.py, and the
+`log_producer` fixture in conftest.py.
+"""
+
+import string
+from dataclasses import dataclass
+from pathlib import Path
+
+LP_NS = "e2e-log-producer"
+LP_NAME = "log-producer"
+LP_LINE_PREFIX = "kubetail-e2e-line"
+POD_IMAGE = "busybox:1.36"
+
+_MANIFEST_PATH = Path(__file__).parent / "manifests" / "log_producer.yaml.tmpl"
+
+
+@dataclass(frozen=True)
+class LogProducer:
+    namespace: str
+    name: str
+    line_prefix: str
+
+    @property
+    def source(self) -> str:
+        """The kubetail logs source path: '<ns>:deployment/<name>'."""
+        return f"{self.namespace}:deployment/{self.name}"
+
+
+def rendered_manifest() -> str:
+    return string.Template(_MANIFEST_PATH.read_text()).substitute(
+        LP_NS=LP_NS,
+        LP_NAME=LP_NAME,
+        LP_LINE_PREFIX=LP_LINE_PREFIX,
+        POD_IMAGE=POD_IMAGE,
+    )

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -135,6 +135,36 @@ def assert_healthz(url):
 
 
 @pytest.fixture(scope="session")
+def log_producer(_cluster_ready):
+    """Apply the log-producer manifest and yield its identity.
+
+    A single-replica busybox deployment that emits a stable line every
+    200ms; tests use it as a deterministic log source for both backends.
+    Session-scoped so the manifest-apply + rollout cost is paid once.
+    """
+    from _log_producer import (
+        LP_NAME,
+        LP_NS,
+        LP_LINE_PREFIX,
+        LogProducer,
+        rendered_manifest,
+    )
+    from _namespace_rbac import kubectl
+
+    kubectl("apply", "-f", "-", input=rendered_manifest())
+    try:
+        kubectl(
+            "rollout", "status",
+            "deployment", LP_NAME,
+            "-n", LP_NS,
+            "--timeout=60s",
+        )
+        yield LogProducer(namespace=LP_NS, name=LP_NAME, line_prefix=LP_LINE_PREFIX)
+    finally:
+        kubectl("delete", "namespace", LP_NS, "--wait=false", check=False)
+
+
+@pytest.fixture(scope="session")
 def restricted_sa_tokens(_cluster_ready):
     """Apply the namespace-scoped RBAC manifest and yield SA bearer tokens.
 

--- a/e2e/manifests/log_producer.yaml.tmpl
+++ b/e2e/manifests/log_producer.yaml.tmpl
@@ -1,0 +1,27 @@
+# Test fixture for test_logs_backends.py and test_cluster_api_websocket_auth.py.
+#
+# A single-replica deployment in a dedicated namespace whose container emits a
+# stable, predictable line every 200ms ("$LP_LINE_PREFIX-N"). Tests grep for
+# that prefix so output assertions don't depend on log volume from other pods.
+apiVersion: v1
+kind: Namespace
+metadata: {name: $LP_NS}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $LP_NAME
+  namespace: $LP_NS
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: $LP_NAME}}
+  template:
+    metadata: {labels: {app: $LP_NAME}}
+    spec:
+      containers:
+        - name: emitter
+          image: $POD_IMAGE
+          command:
+            - sh
+            - -c
+            - 'i=0; while true; do echo "$LP_LINE_PREFIX-$$i"; i=$$((i+1)); sleep 0.2; done'

--- a/e2e/test_cli.py
+++ b/e2e/test_cli.py
@@ -1,6 +1,24 @@
-import subprocess
+"""Tests that exec the `kubetail` binary on the host."""
 
+import os
+import re
+import subprocess
+import time
+
+import pytest
+
+from _log_producer import LP_LINE_PREFIX
 from conftest import assert_healthz
+
+KUBECONFIG = "/tmp/kubetail-e2e.kubeconfig"
+
+_LINE_RE = re.compile(rf"\b{re.escape(LP_LINE_PREFIX)}-\d+\b")
+
+
+def _env():
+    env = os.environ.copy()
+    env["KUBECONFIG"] = KUBECONFIG
+    return env
 
 
 def test_version(cli):
@@ -11,3 +29,87 @@ def test_version(cli):
 
 def test_serve_healthz(serve_url):
     assert_healthz(serve_url)
+
+
+# ---------------------------------------------------------------------------
+# `kubetail logs` against both backends
+#
+# Covers the four backend x mode combinations:
+#   - kubernetes-api backend, --tail (one-shot via pods/log)
+#   - kubetail-api backend,   --tail (GraphQL POST through aggregation)
+#   - kubernetes-api backend, --follow
+#   - kubetail-api backend,   --follow (graphql-transport-ws over the apiserver)
+#
+# The kubetail-api follow case is the regression-guard for the apiserver's
+# 60s deadline on non-watch requests — the previous SSE-over-POST path got
+# RST_STREAM INTERNAL_ERROR after ~60s through aggregation. WebSocket
+# upgrades get hijacked by the apiserver and bypass that filter; this test
+# only asserts the stream produces data, not that it survives 60s, since
+# waiting that long in CI is wasteful. See test_cluster_api_websocket_auth.py
+# for the auth-gate proof that pins down the upgrade behavior.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["kubernetes", "kubetail"])
+def backend(request):
+    return request.param
+
+
+def test_logs_tail(cli, log_producer, backend):
+    result = subprocess.run(
+        [
+            cli, "logs", log_producer.source,
+            "--backend", backend,
+            "--tail", "5",
+            "--raw",
+        ],
+        capture_output=True,
+        text=True,
+        env=_env(),
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"kubetail logs failed (backend={backend}): "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    matches = _LINE_RE.findall(result.stdout)
+    assert len(matches) >= 1, (
+        f"expected at least one '{LP_LINE_PREFIX}-N' line "
+        f"(backend={backend}), got: {result.stdout!r}"
+    )
+
+
+def test_logs_follow(cli, log_producer, backend):
+    proc = subprocess.Popen(
+        [
+            cli, "logs", log_producer.source,
+            "--backend", backend,
+            "--follow",
+            "--raw",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_env(),
+    )
+    try:
+        seen = []
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and len(seen) < 3:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            if _LINE_RE.search(line):
+                seen.append(line.rstrip("\n"))
+    finally:
+        proc.terminate()
+        try:
+            stderr = proc.communicate(timeout=5)[1]
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stderr = proc.communicate()[1]
+
+    assert len(seen) >= 3, (
+        f"expected >=3 follow lines (backend={backend}), got {len(seen)}: "
+        f"{seen!r} stderr={stderr!r}"
+    )

--- a/e2e/test_cluster_api_websocket_auth.py
+++ b/e2e/test_cluster_api_websocket_auth.py
@@ -1,0 +1,146 @@
+"""WebSocket auth gating for the cluster-api graphql endpoint.
+
+Two layers of defense exist on top of the cluster-api `/graphql` WS upgrade:
+
+  1. **kube-apiserver aggregation gate** — when a client dials the apiserver
+     at `/apis/api.kubetail.com/v1/graphql`, kube-apiserver authenticates
+     the request before forwarding to the cluster-api Service. Anonymous
+     callers fail RBAC (or authn outright) and never reach cluster-api.
+     This is the layer the kubetail CLI relies on for follow streams: an
+     attacker who can't satisfy kube-apiserver auth can't open a
+     subscription, period.
+
+  2. **cluster-api front-proxy gate** — direct hits to the cluster-api
+     Service (bypassing the apiserver) are rejected by
+     newAggregationAuthMiddleware unless the request carries a valid
+     front-proxy client cert. This protects against in-cluster lateral
+     callers that can route to the cluster-api Service IP without going
+     through the apiserver.
+
+These tests dial WebSocket upgrades directly (no `kubetail logs` in the
+loop) so the assertions are about the upgrade response, not about CLI UX.
+"""
+
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from _kubeconfig import materialize_apiserver_access, ssl_ctx
+
+_WS_SUBPROTOCOL = "graphql-transport-ws"
+_GRAPHQL_PATH = "/apis/api.kubetail.com/v1/graphql"
+
+
+def _to_ws(url: str) -> str:
+    return url.replace("http://", "ws://").replace("https://", "wss://")
+
+
+@pytest.fixture(scope="module")
+def apiserver():
+    access = materialize_apiserver_access()
+    yield access
+    access.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: kube-apiserver aggregation gate
+# ---------------------------------------------------------------------------
+
+
+def test_apiserver_rejects_anonymous_ws_upgrade(apiserver):
+    """A client with no kubeconfig credentials cannot upgrade through the
+    aggregation layer. kube-apiserver answers 401/403 on the upgrade
+    response (anonymous auth either disabled outright or mapped to
+    system:anonymous, which has no RBAC for api.kubetail.com).
+    """
+    ws_url = _to_ws(apiserver.server) + _GRAPHQL_PATH
+    ctx = ssl_ctx(apiserver, with_client_cert=False)
+
+    async def go():
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(
+                ws_url,
+                subprotocols=[_WS_SUBPROTOCOL],
+                ssl=ctx,
+                open_timeout=5,
+            ):
+                pass
+        return excinfo.value.response.status_code
+
+    status = asyncio.run(go())
+    assert status in (401, 403), (
+        f"expected 401/403 from apiserver auth gate, got {status}"
+    )
+
+
+def test_apiserver_authenticated_ws_upgrade_succeeds(apiserver):
+    """With a valid kubeconfig client cert (cluster-admin in kind), the
+    upgrade is forwarded to cluster-api which completes the
+    graphql-transport-ws handshake by replying `connection_ack`.
+
+    Proves end-to-end that an authenticated WebSocket actually reaches
+    cluster-api through aggregation — i.e. that the auth gate is the only
+    thing blocking the anonymous case above, not some unrelated
+    misconfiguration.
+    """
+    ws_url = _to_ws(apiserver.server) + _GRAPHQL_PATH
+    ctx = ssl_ctx(apiserver, with_client_cert=True)
+
+    async def go():
+        async with websockets.connect(
+            ws_url,
+            subprotocols=[_WS_SUBPROTOCOL],
+            ssl=ctx,
+            open_timeout=10,
+        ) as ws:
+            await ws.send(json.dumps({"type": "connection_init", "payload": {}}))
+            return json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+
+    msg = asyncio.run(go())
+    assert msg.get("type") == "connection_ack", msg
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: cluster-api front-proxy gate (direct, bypassing the apiserver)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_api_rejects_direct_ws_upgrade_without_front_proxy_cert(
+    cluster_api_url,
+):
+    """A WS upgrade hitting the cluster-api Service directly (port-forwarded
+    in e2e; in-cluster service IP in production) without a front-proxy
+    client cert is rejected by newAggregationAuthMiddleware with HTTP 401.
+
+    This is the regression guard for the "cluster-api accepts requests
+    only via the kube-apiserver chain" invariant — without it, anyone
+    on-cluster who can reach the Service IP could open a follow stream.
+    """
+    ws_url = _to_ws(cluster_api_url) + _GRAPHQL_PATH
+
+    # cluster-api uses a self-signed cert in e2e; suppress verification
+    # since we're testing authn, not TLS trust. (The real test in
+    # production is the apiserver layer above; this layer's job is the
+    # 401 once a TLS handshake completes.)
+    import ssl as _ssl
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+
+    async def go():
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(
+                ws_url,
+                subprotocols=[_WS_SUBPROTOCOL],
+                ssl=ctx,
+                open_timeout=5,
+            ):
+                pass
+        return excinfo.value.response.status_code
+
+    status = asyncio.run(go())
+    assert status == 401, (
+        f"expected 401 from cluster-api front-proxy gate, got {status}"
+    )

--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -30,15 +30,63 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/rest"
 
 	sharedcfg "github.com/kubetail-org/kubetail/modules/shared/config"
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 	"github.com/kubetail-org/kubetail/modules/shared/logs"
 
 	"github.com/kubetail-org/kubetail/modules/cli/internal/cli"
+	"github.com/kubetail-org/kubetail/modules/cli/internal/clusterapi"
 	"github.com/kubetail-org/kubetail/modules/cli/internal/tablewriter"
 	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 )
+
+// backendChoice represents which logs backend the CLI should use.
+type backendChoice int
+
+const (
+	backendKubernetes backendChoice = iota
+	backendKubetail
+)
+
+// BackendFlag is the name of the --backend CLI flag.
+const BackendFlag = "backend"
+
+const grepKubernetesBackendWarning = `Warning: --grep on the Kubernetes API backend downloads all matching records to the client and filters locally, which can be slow and high-volume.
+For node-local server-side filtering, install the Kubetail API:
+
+    kubetail cluster install
+`
+
+// selectBackend resolves the user's --backend choice into a concrete
+// backendChoice. With "auto", the probe decides; probe errors fall back to
+// the Kubernetes backend so the CLI still works on degraded clusters. With
+// "kubetail", probe errors and unavailability are surfaced loudly so the
+// user knows their explicit request can't be honored.
+func selectBackend(ctx context.Context, flag string, probe func(context.Context) (bool, error)) (backendChoice, error) {
+	switch flag {
+	case "kubernetes":
+		return backendKubernetes, nil
+	case "kubetail":
+		ok, err := probe(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("--backend=kubetail: probe failed: %w", err)
+		}
+		if !ok {
+			return 0, fmt.Errorf("--backend=kubetail requested but APIService %q is not Available on this cluster", clusterapi.APIServiceName)
+		}
+		return backendKubetail, nil
+	case "auto", "":
+		ok, err := probe(ctx)
+		if err != nil || !ok {
+			return backendKubernetes, nil
+		}
+		return backendKubetail, nil
+	default:
+		return 0, fmt.Errorf("--backend: invalid value %q (expected auto, kubernetes, or kubetail)", flag)
+	}
+}
 
 var headFlag config.OptionalInt64
 var tailFlag config.OptionalInt64
@@ -82,6 +130,8 @@ type logsCmdConfig struct {
 	withCursors   bool
 
 	raw bool
+
+	backend string
 }
 
 const logsHelpTmpl = `
@@ -161,19 +211,19 @@ Examples:
 		# Return all records between two exact timestamps
 		{{.CommandDisplayName}} nginx --since 2006-01-02T15:04:05Z07:00 --until 2007-01-02T15:04:05Z07:00 --all
 
-	- Grep filter (requires --force)
+	- Grep filter
 
 		# Return last 10 records from the 'nginx' pod that match "GET /about"
-		{{.CommandDisplayName}} nginx --grep "GET /about" --force
+		{{.CommandDisplayName}} nginx --grep "GET /about"
 
 		# Return first 10 records
-		{{.CommandDisplayName}} nginx --grep "GET /about" --head --force
+		{{.CommandDisplayName}} nginx --grep "GET /about" --head
 
 		# Return last 10 records that match "GET /about" or "GET /contact"
-		{{.CommandDisplayName}} nginx --grep "GET /(about|contact)" --force
+		{{.CommandDisplayName}} nginx --grep "GET /(about|contact)"
 
 		# Stream new records that match "GET /about"
-		{{.CommandDisplayName}} nginx --grep "GET /about" --follow --force
+		{{.CommandDisplayName}} nginx --grep "GET /about" --follow
 
 	- Source filters
 
@@ -207,8 +257,9 @@ Notes:
 
 	- Default behavior is "tail" unless 'since' is specified
 
-	- Using 'grep' requires 'force' because the command may unexpectedly download
-	  more log records than expected
+	- 'grep' is most efficient with the Kubetail API backend, which filters
+	  on each node. Without it the CLI must download all matching records
+	  client-side. Install the Kubetail API with: 'kubetail cluster install'
 
 `
 
@@ -292,6 +343,8 @@ func loadLogsCmdConfig(cmd *cobra.Command) (*logsCmdConfig, error) {
 	removeColumns, _ := flags.GetStringSlice("remove-columns")
 	columns = applyColumnAddRemove(columns, addColumns, removeColumns)
 
+	backend, _ := flags.GetString(BackendFlag)
+
 	raw, _ := flags.GetBool("raw")
 	if raw {
 		hideHeader = true
@@ -311,11 +364,6 @@ func loadLogsCmdConfig(cmd *cobra.Command) (*logsCmdConfig, error) {
 		streamMode = logsStreamModeHead
 	} else {
 		streamMode = logsStreamModeTail
-	}
-
-	// Default tail num to 0 if follow is true
-	if follow && !tail {
-		tailVal = 0
 	}
 
 	// Parse `since`
@@ -406,6 +454,8 @@ func loadLogsCmdConfig(cmd *cobra.Command) (*logsCmdConfig, error) {
 		withCursors:   withCursors,
 
 		raw: raw,
+
+		backend: backend,
 	}
 
 	return cmdCfg, nil
@@ -450,6 +500,38 @@ func normalizeColumns(columns []string) []string {
 	}
 
 	return out
+}
+
+// buildClusterAPIStreamConfig translates resolved CLI flags into the
+// StreamConfig expected by the Kubetail-API-backed Stream.
+func buildClusterAPIStreamConfig(cmdCfg *logsCmdConfig, sources []string) clusterapi.StreamConfig {
+	cfg := clusterapi.StreamConfig{
+		KubeContext: cmdCfg.kubecontext,
+		Sources:     sources,
+		Grep:        cmdCfg.grep,
+		Follow:      cmdCfg.follow,
+	}
+	if !cmdCfg.sinceTime.IsZero() {
+		cfg.Since = cmdCfg.sinceTime.Format(time.RFC3339Nano)
+	}
+	if !cmdCfg.untilTime.IsZero() {
+		cfg.Until = cmdCfg.untilTime.Format(time.RFC3339Nano)
+	}
+	switch {
+	case cmdCfg.head:
+		cfg.Mode = "HEAD"
+		cfg.Limit = int(cmdCfg.headVal)
+	case cmdCfg.all:
+		// Express "all" as HEAD pagination with no limit cap; the server
+		// will apply its own batch size and we'll iterate via NextCursor.
+		cfg.Mode = "HEAD"
+	case cmdCfg.tailVal == 0:
+		// `--tail=0` means no backlog; empty Mode skips bootstrap fetch.
+	default:
+		cfg.Mode = "TAIL"
+		cfg.Limit = int(cmdCfg.tailVal)
+	}
+	return cfg
 }
 
 func printLogs(rootCtx context.Context, cmd *cobra.Command, cmdCfg *logsCmdConfig, stream logs.Stream) {
@@ -540,12 +622,6 @@ var logsCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
-		grep, _ := flags.GetString("grep")
-		force, _ := flags.GetBool("force")
-
-		if grep != "" && !force {
-			return fmt.Errorf("--force is required when using --grep")
-		}
 
 		var cli config.CLI
 		cli.Config, _ = flags.GetString("config")
@@ -573,13 +649,37 @@ var logsCmd = &cobra.Command{
 		cm, err := k8shelpers.NewConnectionManager(env, k8shelpers.WithKubeconfigPath(cmdCfg.kubeconfigPath), k8shelpers.WithLazyConnect(true))
 		cli.ExitOnError(err)
 
-		stream, err := logs.NewStream(rootCtx, cm, args, cmdCfg.streamOpts...)
+		var restCfg *rest.Config
+		probe := func(ctx context.Context) (bool, error) {
+			c, err := cm.GetOrCreateRestConfig(cmdCfg.kubecontext)
+			if err != nil {
+				return false, err
+			}
+			restCfg = c
+			return clusterapi.IsKubetailAPIAvailable(ctx, restCfg)
+		}
+		choice, err := selectBackend(rootCtx, cmdCfg.backend, probe)
 		cli.ExitOnError(err)
-		defer stream.Close()
 
-		// Start stream
-		err = stream.Start(rootCtx)
-		cli.ExitOnError(err)
+		var stream logs.Stream
+		switch choice {
+		case backendKubetail:
+			client, err := clusterapi.NewClient(restCfg)
+			cli.ExitOnError(err)
+			s := clusterapi.NewStream(client, buildClusterAPIStreamConfig(cmdCfg, args))
+			cli.ExitOnError(s.Start(rootCtx))
+			defer s.Close()
+			stream = s
+		default:
+			if cmdCfg.grep != "" {
+				fmt.Fprint(cmd.OutOrStderr(), grepKubernetesBackendWarning)
+			}
+			s, err := logs.NewStream(rootCtx, cm, args, cmdCfg.streamOpts...)
+			cli.ExitOnError(err)
+			defer s.Close()
+			cli.ExitOnError(s.Start(rootCtx))
+			stream = s
+		}
 
 		// output the logs
 		printLogs(rootCtx, cmd, cmdCfg, stream)
@@ -741,7 +841,7 @@ func addLogsCmdFlags(cmd *cobra.Command) {
 
 	//flagset.BoolP("reverse", "r", false, "List records in reverse order")
 
-	flagset.Bool("force", false, "Force command (if necessary)")
+	flagset.String(BackendFlag, "auto", "Logs backend: auto, kubetail, or kubernetes")
 
 	// Define help here to avoid re-defining 'h' shorthand
 	flagset.Bool("help", false, "help for logs")

--- a/modules/cli/cmd/logs_backend_test.go
+++ b/modules/cli/cmd/logs_backend_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectBackend_ExplicitKubernetes(t *testing.T) {
+	probeCalled := false
+	probe := func(ctx context.Context) (bool, error) {
+		probeCalled = true
+		return true, nil
+	}
+	got, err := selectBackend(context.Background(), "kubernetes", probe)
+	require.NoError(t, err)
+	assert.Equal(t, backendKubernetes, got)
+	assert.False(t, probeCalled, "probe must not be invoked when backend is explicit")
+}
+
+func TestSelectBackend_ExplicitKubetail_ErrorsWhenUnavailable(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return false, nil }
+	_, err := selectBackend(context.Background(), "kubetail", probe)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v1.api.kubetail.com")
+}
+
+func TestSelectBackend_ExplicitKubetail_ErrorsWhenProbeFails(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return false, errors.New("rbac") }
+	_, err := selectBackend(context.Background(), "kubetail", probe)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rbac")
+}
+
+func TestSelectBackend_ExplicitKubetail_OkWhenAvailable(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return true, nil }
+	got, err := selectBackend(context.Background(), "kubetail", probe)
+	require.NoError(t, err)
+	assert.Equal(t, backendKubetail, got)
+}
+
+func TestSelectBackend_AutoPicksKubetailWhenAvailable(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return true, nil }
+	got, err := selectBackend(context.Background(), "auto", probe)
+	require.NoError(t, err)
+	assert.Equal(t, backendKubetail, got)
+}
+
+func TestSelectBackend_AutoFallsBackOnUnavailable(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return false, nil }
+	got, err := selectBackend(context.Background(), "auto", probe)
+	require.NoError(t, err)
+	assert.Equal(t, backendKubernetes, got)
+}
+
+func TestSelectBackend_AutoFallsBackOnProbeError(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return false, errors.New("network") }
+	got, err := selectBackend(context.Background(), "auto", probe)
+	require.NoError(t, err, "auto must not fail loudly when probe errors")
+	assert.Equal(t, backendKubernetes, got)
+}
+
+func TestSelectBackend_RejectsUnknownValue(t *testing.T) {
+	probe := func(ctx context.Context) (bool, error) { return false, nil }
+	_, err := selectBackend(context.Background(), "weird", probe)
+	require.Error(t, err)
+}

--- a/modules/cli/cmd/logs_test.go
+++ b/modules/cli/cmd/logs_test.go
@@ -29,7 +29,7 @@ func TestLoadLogConfig(t *testing.T) {
 		assert.Equal(t, cmdCfg.allContainers, false)
 	})
 
-	t.Run("tail is zero in follow mode", func(t *testing.T) {
+	t.Run("tail defaults to 10 in follow mode (tail -f semantics)", func(t *testing.T) {
 		cmd := &cobra.Command{}
 
 		addLogsCmdFlags(cmd)
@@ -38,7 +38,18 @@ func TestLoadLogConfig(t *testing.T) {
 		cmdCfg, err := loadLogsCmdConfig(cmd)
 		assert.NoError(t, err)
 
-		assert.Equal(t, cmdCfg.tailVal, int64(0))
+		assert.Equal(t, int64(10), cmdCfg.tailVal)
+	})
+
+	t.Run("--tail=0 propagates as tailVal=0", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		addLogsCmdFlags(cmd)
+		cmd.Flags().Set("tail", "0")
+
+		cmdCfg, err := loadLogsCmdConfig(cmd)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(0), cmdCfg.tailVal)
 	})
 
 	t.Run("wrong timestamp returns an error", func(t *testing.T) {

--- a/modules/cli/go.mod
+++ b/modules/cli/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.28.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/kubetail-org/kubetail/modules/dashboard v0.0.0-00010101000000-000000000000
 	github.com/kubetail-org/kubetail/modules/shared v0.0.0-00010101000000-000000000000
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -23,6 +24,7 @@ require (
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kube-aggregator v0.35.1
 )
 
 require (
@@ -96,7 +98,6 @@ require (
 	github.com/gorilla/context v1.1.2 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/sessions v1.4.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -189,7 +190,6 @@ require (
 	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/cli-runtime v0.35.1 // indirect
 	k8s.io/component-base v0.35.1 // indirect
-	k8s.io/kube-aggregator v0.35.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
 	k8s.io/kubectl v0.35.1 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/modules/cli/internal/clusterapi/client.go
+++ b/modules/cli/internal/clusterapi/client.go
@@ -1,0 +1,588 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"k8s.io/client-go/rest"
+	clientgows "k8s.io/client-go/transport/websocket"
+
+	"github.com/kubetail-org/kubetail/modules/shared/logs"
+)
+
+// graphqlTransportWSSubprotocol is the WebSocket subprotocol the cluster-api
+// (gqlgen Websocket transport) speaks for GraphQL subscriptions.
+const graphqlTransportWSSubprotocol = "graphql-transport-ws"
+
+// graphql-transport-ws message types.
+const (
+	msgConnectionInit  = "connection_init"
+	msgConnectionAck   = "connection_ack"
+	msgConnectionError = "connection_error"
+	msgPing            = "ping"
+	msgPong            = "pong"
+	msgSubscribe       = "subscribe"
+	msgNext            = "next"
+	msgError           = "error"
+	msgComplete        = "complete"
+)
+
+// wsDialFunc opens a WebSocket connection. Replaced in tests.
+type wsDialFunc func(ctx context.Context, urlStr string, header http.Header, subprotocols []string) (*gwebsocket.Conn, error)
+
+// Client is a thin GraphQL client for the Kubetail cluster-api, intended to
+// be reached through the kube-apiserver aggregation layer (auth, TLS, and
+// routing all handled by client-go's rest transport for queries, and
+// client-go's websocket round-tripper for subscriptions).
+type Client struct {
+	httpClient *http.Client
+	endpoint   string
+	wsDial     wsDialFunc
+}
+
+// NewClient builds a Client whose HTTP transport carries the user's
+// kubeconfig credentials, with requests directed at
+//
+//	<restConfig.Host>/apis/api.kubetail.com/v1/graphql
+//
+// which the kube-apiserver routes to cluster-api via the registered
+// APIService. Subscriptions ride a WebSocket upgrade on the same path so
+// that the kube-apiserver hijacks the connection (long-running) instead of
+// applying its non-watch request deadline to a streamed POST.
+func NewClient(restConfig *rest.Config) (*Client, error) {
+	t, err := rest.TransportFor(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	host := strings.TrimRight(restConfig.Host, "/")
+	return &Client{
+		httpClient: &http.Client{Transport: t},
+		endpoint:   host + APIServicePath + "/graphql",
+		wsDial:     newClientGoWSDialer(restConfig),
+	}, nil
+}
+
+// newClientForTest constructs a Client with a caller-supplied http.Client
+// and endpoint. Used by tests to point at an httptest server. The WebSocket
+// dialer is a plain gorilla dialer that rewrites http(s) -> ws(s).
+func newClientForTest(c *http.Client, endpoint string) *Client {
+	return &Client{
+		httpClient: c,
+		endpoint:   endpoint,
+		wsDial: func(ctx context.Context, urlStr string, header http.Header, subprotocols []string) (*gwebsocket.Conn, error) {
+			wsURL, err := httpToWS(urlStr)
+			if err != nil {
+				return nil, err
+			}
+			d := &gwebsocket.Dialer{Subprotocols: subprotocols}
+			conn, _, err := d.DialContext(ctx, wsURL, header)
+			return conn, err
+		},
+	}
+}
+
+// newClientGoWSDialer returns a wsDialFunc that uses client-go's WebSocket
+// round-tripper, so the upgrade carries the same auth/TLS as a normal
+// kube-apiserver request (bearer token, exec plugins, OIDC, mTLS).
+func newClientGoWSDialer(restConfig *rest.Config) wsDialFunc {
+	return func(ctx context.Context, urlStr string, header http.Header, subprotocols []string) (*gwebsocket.Conn, error) {
+		rt, holder, err := clientgows.RoundTripperFor(restConfig)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, err
+		}
+		for k, vs := range header {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+		conn, err := clientgows.Negotiate(rt, holder, req, subprotocols...)
+		if err != nil {
+			return nil, err
+		}
+		if conn == nil {
+			return nil, fmt.Errorf("kubetail-api: websocket negotiation returned nil connection")
+		}
+		return conn, nil
+	}
+}
+
+// LogRecordsFetchVars carries the variables for a logRecordsFetch query.
+// Empty/zero values are omitted from the request.
+type LogRecordsFetchVars struct {
+	KubeContext string
+	Sources     []string
+	Mode        string // "HEAD" or "TAIL"
+	Since       string
+	Until       string
+	Grep        string
+	Limit       int
+	Cursor      string // forward-pagination cursor; sent as the `after` arg
+}
+
+// LogRecordsQueryResponse mirrors the GraphQL `LogRecordsQueryResponse`.
+type LogRecordsQueryResponse struct {
+	Records    []logs.LogRecord
+	NextCursor *string
+}
+
+const logRecordsFetchQuery = `
+query CLILogRecordsFetch(
+	$kubeContext: String,
+	$sources: [String!]!,
+	$mode: LogRecordsQueryMode,
+	$since: String,
+	$until: String,
+	$after: String,
+	$grep: String,
+	$limit: Int
+) {
+	logRecordsFetch(
+		kubeContext: $kubeContext,
+		sources: $sources,
+		mode: $mode,
+		since: $since,
+		until: $until,
+		after: $after,
+		grep: $grep,
+		limit: $limit
+	) {
+		records {
+			timestamp
+			message
+			source {
+				metadata { region zone os arch node }
+				namespace
+				podName
+				containerName
+				containerID
+			}
+		}
+		nextCursor
+	}
+}
+`
+
+// LogRecordsFetch executes a logRecordsFetch query and returns its decoded
+// response. GraphQL-level errors are surfaced as a Go error.
+func (c *Client) LogRecordsFetch(ctx context.Context, v LogRecordsFetchVars) (*LogRecordsQueryResponse, error) {
+	vars := buildFetchVariables(v)
+	var out struct {
+		LogRecordsFetch *gqlLogRecordsQueryResponse `json:"logRecordsFetch"`
+	}
+	if err := c.do(ctx, logRecordsFetchQuery, vars, &out); err != nil {
+		return nil, err
+	}
+	if out.LogRecordsFetch == nil {
+		return &LogRecordsQueryResponse{}, nil
+	}
+	resp := &LogRecordsQueryResponse{
+		Records:    make([]logs.LogRecord, 0, len(out.LogRecordsFetch.Records)),
+		NextCursor: out.LogRecordsFetch.NextCursor,
+	}
+	for _, r := range out.LogRecordsFetch.Records {
+		resp.Records = append(resp.Records, r.toLogRecord())
+	}
+	return resp, nil
+}
+
+func buildFetchVariables(v LogRecordsFetchVars) map[string]any {
+	m := map[string]any{"sources": v.Sources}
+	if v.KubeContext != "" {
+		m["kubeContext"] = v.KubeContext
+	}
+	if v.Mode != "" {
+		m["mode"] = v.Mode
+	}
+	if v.Since != "" {
+		m["since"] = v.Since
+	}
+	if v.Until != "" {
+		m["until"] = v.Until
+	}
+	if v.Cursor != "" {
+		m["after"] = v.Cursor
+	}
+	if v.Grep != "" {
+		m["grep"] = v.Grep
+	}
+	if v.Limit > 0 {
+		m["limit"] = v.Limit
+	}
+	return m
+}
+
+// do performs a single GraphQL POST and decodes data into out. Any
+// `errors` array in the response is concatenated and returned as an error.
+func (c *Client) do(ctx context.Context, query string, vars map[string]any, out any) error {
+	body, err := json.Marshal(map[string]any{"query": query, "variables": vars})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("kubetail-api: HTTP %d: %s", resp.StatusCode, truncate(string(respBytes), 256))
+	}
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []gqlError      `json:"errors"`
+	}
+	if err := json.Unmarshal(respBytes, &envelope); err != nil {
+		return fmt.Errorf("kubetail-api: decode response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		return errFromGraphQLErrors(envelope.Errors)
+	}
+	if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("kubetail-api: decode data: %w", err)
+	}
+	return nil
+}
+
+// gqlError is the standard GraphQL error shape (we only consume `message`).
+type gqlError struct {
+	Message string `json:"message"`
+}
+
+func errFromGraphQLErrors(errs []gqlError) error {
+	parts := make([]string, 0, len(errs))
+	for _, e := range errs {
+		if e.Message != "" {
+			parts = append(parts, e.Message)
+		}
+	}
+	if len(parts) == 0 {
+		return fmt.Errorf("kubetail-api: GraphQL request failed (no message)")
+	}
+	return fmt.Errorf("kubetail-api: %s", strings.Join(parts, "; "))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+type gqlLogRecord struct {
+	Timestamp time.Time    `json:"timestamp"`
+	Message   string       `json:"message"`
+	Source    gqlLogSource `json:"source"`
+}
+
+type gqlLogSource struct {
+	Metadata      gqlLogSourceMetadata `json:"metadata"`
+	Namespace     string               `json:"namespace"`
+	PodName       string               `json:"podName"`
+	ContainerName string               `json:"containerName"`
+	ContainerID   string               `json:"containerID"`
+}
+
+type gqlLogSourceMetadata struct {
+	Region string `json:"region"`
+	Zone   string `json:"zone"`
+	OS     string `json:"os"`
+	Arch   string `json:"arch"`
+	Node   string `json:"node"`
+}
+
+type gqlLogRecordsQueryResponse struct {
+	Records    []gqlLogRecord `json:"records"`
+	NextCursor *string        `json:"nextCursor"`
+}
+
+// LogRecordsFollowVars carries the variables for a logRecordsFollow
+// subscription. Empty/zero values are omitted from the request.
+type LogRecordsFollowVars struct {
+	KubeContext string
+	Sources     []string
+	Since       string
+	After       string
+	Grep        string
+}
+
+const logRecordsFollowQuery = `
+subscription CLILogRecordsFollow(
+	$kubeContext: String,
+	$sources: [String!]!,
+	$since: String,
+	$after: String,
+	$grep: String
+) {
+	logRecordsFollow(
+		kubeContext: $kubeContext,
+		sources: $sources,
+		since: $since,
+		after: $after,
+		grep: $grep
+	) {
+		timestamp
+		message
+		source {
+			metadata { region zone os arch node }
+			namespace
+			podName
+			containerName
+			containerID
+		}
+	}
+}
+`
+
+// LogRecordsFollow opens a graphql-transport-ws subscription over a
+// WebSocket against the cluster-api and returns a records channel and an
+// error channel. Both channels are closed when the subscription ends
+// (server `complete`, connection drop, or context cancellation). Per-frame
+// GraphQL errors are forwarded on the error channel and do not terminate
+// the stream.
+//
+// WebSocket is used (vs. SSE-over-POST) because the kube-apiserver hijacks
+// upgrade requests at the aggregation layer; that bypasses the apiserver's
+// non-watch request-deadline filter, which would otherwise tear down a
+// long-lived streamed response after roughly a minute.
+func (c *Client) LogRecordsFollow(ctx context.Context, v LogRecordsFollowVars) (<-chan logs.LogRecord, <-chan error) {
+	records := make(chan logs.LogRecord, 16)
+	errs := make(chan error, 4)
+
+	failClosed := func(err error) (<-chan logs.LogRecord, <-chan error) {
+		errs <- err
+		close(records)
+		close(errs)
+		return records, errs
+	}
+
+	// Pass the http(s) endpoint as-is. The default (client-go) dialer
+	// rewrites the scheme internally; the test dialer rewrites via httpToWS.
+	conn, err := c.wsDial(ctx, c.endpoint, http.Header{}, []string{graphqlTransportWSSubprotocol})
+	if err != nil {
+		return failClosed(fmt.Errorf("kubetail-api: websocket dial: %w", err))
+	}
+
+	go runGraphQLTransportWS(ctx, conn, logRecordsFollowQuery, buildFollowVariables(v), records, errs)
+	return records, errs
+}
+
+// httpToWS rewrites an http(s) endpoint into a ws(s) URL.
+func httpToWS(endpoint string) (string, error) {
+	switch {
+	case strings.HasPrefix(endpoint, "https://"):
+		return "wss://" + strings.TrimPrefix(endpoint, "https://"), nil
+	case strings.HasPrefix(endpoint, "http://"):
+		return "ws://" + strings.TrimPrefix(endpoint, "http://"), nil
+	default:
+		return "", fmt.Errorf("kubetail-api: unsupported endpoint scheme: %s", endpoint)
+	}
+}
+
+func buildFollowVariables(v LogRecordsFollowVars) map[string]any {
+	m := map[string]any{"sources": v.Sources}
+	if v.KubeContext != "" {
+		m["kubeContext"] = v.KubeContext
+	}
+	if v.Since != "" {
+		m["since"] = v.Since
+	}
+	if v.After != "" {
+		m["after"] = v.After
+	}
+	if v.Grep != "" {
+		m["grep"] = v.Grep
+	}
+	return m
+}
+
+// runGraphQLTransportWS drives a graphql-transport-ws subscription on conn
+// (https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md). It
+// completes the connection_init/connection_ack handshake, sends a single
+// `subscribe`, and forwards `next`/`error` payloads onto records/errs until
+// the server emits `complete`, the connection drops, or ctx is cancelled.
+// The conn and both channels are owned by this goroutine; all are closed
+// before it returns.
+func runGraphQLTransportWS(
+	ctx context.Context,
+	conn *gwebsocket.Conn,
+	query string,
+	variables map[string]any,
+	records chan<- logs.LogRecord,
+	errs chan<- error,
+) {
+	const subscriptionID = "1"
+
+	defer close(records)
+	defer close(errs)
+	defer conn.Close()
+
+	// Unblock a blocked ReadMessage when ctx is cancelled.
+	stopCloser := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopCloser()
+
+	pushErr := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case errs <- err:
+		case <-ctx.Done():
+		}
+	}
+
+	if err := conn.WriteJSON(map[string]any{"type": msgConnectionInit, "payload": map[string]any{}}); err != nil {
+		pushErr(fmt.Errorf("kubetail-api: connection_init: %w", err))
+		return
+	}
+
+ackLoop:
+	for {
+		var msg gqlWSMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			if ctx.Err() == nil {
+				pushErr(fmt.Errorf("kubetail-api: read connection_ack: %w", err))
+			}
+			return
+		}
+		switch msg.Type {
+		case msgConnectionAck:
+			break ackLoop
+		case msgPing:
+			_ = conn.WriteJSON(map[string]any{"type": msgPong})
+		case msgConnectionError, msgError:
+			pushErr(fmt.Errorf("kubetail-api: server rejected connection_init: %s", string(msg.Payload)))
+			return
+		}
+	}
+
+	subPayload := map[string]any{"query": query, "variables": variables}
+	if err := conn.WriteJSON(map[string]any{"id": subscriptionID, "type": msgSubscribe, "payload": subPayload}); err != nil {
+		pushErr(fmt.Errorf("kubetail-api: subscribe: %w", err))
+		return
+	}
+
+	for {
+		var msg gqlWSMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			if ctx.Err() == nil && !isExpectedCloseErr(err) {
+				pushErr(fmt.Errorf("kubetail-api: read frame: %w", err))
+			}
+			return
+		}
+		switch msg.Type {
+		case msgPing:
+			_ = conn.WriteJSON(map[string]any{"type": msgPong})
+		case msgPong:
+		case msgNext:
+			var payload struct {
+				Data *struct {
+					LogRecordsFollow *gqlLogRecord `json:"logRecordsFollow"`
+				} `json:"data"`
+				Errors []gqlError `json:"errors"`
+			}
+			if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+				pushErr(fmt.Errorf("kubetail-api: decode next payload: %w", err))
+				continue
+			}
+			if len(payload.Errors) > 0 {
+				pushErr(errFromGraphQLErrors(payload.Errors))
+				continue
+			}
+			if payload.Data != nil && payload.Data.LogRecordsFollow != nil {
+				select {
+				case records <- payload.Data.LogRecordsFollow.toLogRecord():
+				case <-ctx.Done():
+					return
+				}
+			}
+		case msgError:
+			var gqlErrs []gqlError
+			if len(msg.Payload) > 0 {
+				_ = json.Unmarshal(msg.Payload, &gqlErrs)
+			}
+			if len(gqlErrs) > 0 {
+				pushErr(errFromGraphQLErrors(gqlErrs))
+			} else {
+				pushErr(fmt.Errorf("kubetail-api: subscription error: %s", string(msg.Payload)))
+			}
+			return
+		case msgComplete:
+			return
+		}
+	}
+}
+
+// gqlWSMessage is the envelope shared by every graphql-transport-ws frame.
+// Payload is left as RawMessage so per-type decoding stays explicit.
+type gqlWSMessage struct {
+	ID      string          `json:"id,omitempty"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// isExpectedCloseErr returns true for WebSocket close frames the caller
+// shouldn't surface as errors (normal completion or our own cancellation).
+func isExpectedCloseErr(err error) bool {
+	return gwebsocket.IsCloseError(err,
+		gwebsocket.CloseNormalClosure,
+		gwebsocket.CloseGoingAway,
+		gwebsocket.CloseNoStatusReceived,
+	)
+}
+
+func (r gqlLogRecord) toLogRecord() logs.LogRecord {
+	return logs.LogRecord{
+		Timestamp: r.Timestamp,
+		Message:   r.Message,
+		Source: logs.LogSource{
+			Metadata: logs.LogSourceMetadata{
+				Region: r.Source.Metadata.Region,
+				Zone:   r.Source.Metadata.Zone,
+				OS:     r.Source.Metadata.OS,
+				Arch:   r.Source.Metadata.Arch,
+				Node:   r.Source.Metadata.Node,
+			},
+			Namespace:     r.Source.Namespace,
+			PodName:       r.Source.PodName,
+			ContainerName: r.Source.ContainerName,
+			ContainerID:   r.Source.ContainerID,
+		},
+	}
+}

--- a/modules/cli/internal/clusterapi/client_test.go
+++ b/modules/cli/internal/clusterapi/client_test.go
@@ -1,0 +1,374 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubetail-org/kubetail/modules/shared/logs"
+)
+
+func TestClient_LogRecordsFetch_SendsCorrectRequest(t *testing.T) {
+	var (
+		gotMethod   string
+		gotPath     string
+		gotAuth     string
+		gotContent  string
+		gotBodyJSON map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContent = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBodyJSON)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"logRecordsFetch": {
+					"records": [
+						{
+							"timestamp": "2024-01-02T15:04:05.123456789Z",
+							"message": "hello world",
+							"source": {
+								"metadata": {"region":"r1","zone":"z1","os":"linux","arch":"arm64","node":"n1"},
+								"namespace": "ns1",
+								"podName": "p1",
+								"containerName": "c1",
+								"containerID": "cid1"
+							}
+						}
+					],
+					"nextCursor": null
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{Transport: bearerInjector{token: "tkn-123", base: http.DefaultTransport}}
+	c := newClientForTest(httpClient, srv.URL+APIServicePath+"/graphql")
+
+	resp, err := c.LogRecordsFetch(context.Background(), LogRecordsFetchVars{
+		Sources: []string{"deployments/web"},
+		Mode:    "TAIL",
+		Limit:   100,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, APIServicePath+"/graphql", gotPath)
+	assert.Equal(t, "Bearer tkn-123", gotAuth)
+	assert.Equal(t, "application/json", gotContent)
+
+	require.NotNil(t, gotBodyJSON)
+	assert.Contains(t, gotBodyJSON, "query")
+	require.Contains(t, gotBodyJSON, "variables")
+	vars := gotBodyJSON["variables"].(map[string]any)
+	assert.Equal(t, []any{"deployments/web"}, vars["sources"])
+	assert.Equal(t, "TAIL", vars["mode"])
+	assert.EqualValues(t, 100, vars["limit"])
+
+	require.Len(t, resp.Records, 1)
+	rec := resp.Records[0]
+	assert.Equal(t, "hello world", rec.Message)
+	assert.Equal(t, "p1", rec.Source.PodName)
+	assert.Equal(t, "c1", rec.Source.ContainerName)
+	assert.Equal(t, "n1", rec.Source.Metadata.Node)
+	assert.Equal(t, 2024, rec.Timestamp.Year())
+	assert.Nil(t, resp.NextCursor)
+}
+
+func TestClient_LogRecordsFetch_PropagatesGraphQLErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"boom"}]}`))
+	}))
+	defer srv.Close()
+
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	_, err := c.LogRecordsFetch(context.Background(), LogRecordsFetchVars{Sources: []string{"x"}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "boom"), "error should mention server message: %v", err)
+}
+
+func TestClient_LogRecordsFollow_StreamsWSFrames(t *testing.T) {
+	srv := newWSTestServer(t, func(conn *gwebsocket.Conn) {
+		expectInit(t, conn)
+		writeAck(t, conn)
+		id := expectSubscribe(t, conn)
+		writeNext(t, conn, id, `{"data":{"logRecordsFollow":{"timestamp":"2024-01-02T15:04:05Z","message":"line A","source":{"metadata":{"region":"","zone":"","os":"","arch":"","node":"n1"},"namespace":"ns","podName":"p","containerName":"c","containerID":"cid"}}}}`)
+		writeNext(t, conn, id, `{"data":{"logRecordsFollow":{"timestamp":"2024-01-02T15:04:06Z","message":"line B","source":{"metadata":{"region":"","zone":"","os":"","arch":"","node":"n1"},"namespace":"ns","podName":"p","containerName":"c","containerID":"cid"}}}}`)
+		writeComplete(t, conn, id)
+	})
+	defer srv.Close()
+
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	records, errs := c.LogRecordsFollow(context.Background(), LogRecordsFollowVars{Sources: []string{"x"}})
+
+	got := drainRecords(t, records, errs, 2, 2*time.Second)
+	require.Len(t, got, 2)
+	assert.Equal(t, "line A", got[0].Message)
+	assert.Equal(t, "line B", got[1].Message)
+}
+
+func TestClient_LogRecordsFollow_NegotiatesGraphQLTransportWS(t *testing.T) {
+	srv := newWSTestServer(t, func(conn *gwebsocket.Conn) {
+		assert.Equal(t, "graphql-transport-ws", conn.Subprotocol())
+		expectInit(t, conn)
+		writeAck(t, conn)
+		id := expectSubscribe(t, conn)
+		writeComplete(t, conn, id)
+	})
+	defer srv.Close()
+
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	records, errs := c.LogRecordsFollow(context.Background(), LogRecordsFollowVars{Sources: []string{"x"}})
+	for range records {
+	}
+	for e := range errs {
+		require.NoError(t, e)
+	}
+}
+
+func TestClient_LogRecordsFollow_PassesVariables(t *testing.T) {
+	gotVars := make(chan map[string]any, 1)
+	srv := newWSTestServer(t, func(conn *gwebsocket.Conn) {
+		expectInit(t, conn)
+		writeAck(t, conn)
+
+		var sub gqlWSMessage
+		require.NoError(t, conn.ReadJSON(&sub))
+		require.Equal(t, "subscribe", sub.Type)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(sub.Payload, &payload))
+		gotVars <- payload["variables"].(map[string]any)
+		writeComplete(t, conn, sub.ID)
+	})
+	defer srv.Close()
+
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	records, errs := c.LogRecordsFollow(context.Background(), LogRecordsFollowVars{
+		Sources: []string{"deployments/web"},
+		Grep:    "GET /about",
+		After:   "2024-01-02T15:04:05Z",
+	})
+	for range records {
+	}
+	for e := range errs {
+		require.NoError(t, e)
+	}
+
+	vars := <-gotVars
+	assert.Equal(t, []any{"deployments/web"}, vars["sources"])
+	assert.Equal(t, "GET /about", vars["grep"])
+	assert.Equal(t, "2024-01-02T15:04:05Z", vars["after"])
+}
+
+func TestClient_LogRecordsFollow_ContextCancellationStopsStream(t *testing.T) {
+	srv := newWSTestServer(t, func(conn *gwebsocket.Conn) {
+		expectInit(t, conn)
+		writeAck(t, conn)
+		id := expectSubscribe(t, conn)
+		writeNext(t, conn, id, `{"data":{"logRecordsFollow":{"timestamp":"2024-01-02T15:04:05Z","message":"only","source":{"metadata":{"region":"","zone":"","os":"","arch":"","node":""},"namespace":"","podName":"","containerName":"","containerID":""}}}}`)
+		// Hold the connection open until the client closes it.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	records, errs := c.LogRecordsFollow(ctx, LogRecordsFollowVars{Sources: []string{"x"}})
+
+	select {
+	case rec, ok := <-records:
+		require.True(t, ok)
+		assert.Equal(t, "only", rec.Message)
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive first record")
+	}
+	cancel()
+
+	waitClose := func(ch <-chan struct{}, name string) {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s did not close after cancel", name)
+		}
+	}
+	rDone := make(chan struct{})
+	go func() {
+		for range records {
+		}
+		close(rDone)
+	}()
+	eDone := make(chan struct{})
+	go func() {
+		for range errs {
+		}
+		close(eDone)
+	}()
+	waitClose(rDone, "records")
+	waitClose(eDone, "errs")
+}
+
+func TestClient_LogRecordsFollow_PropagatesGraphQLErrorFrame(t *testing.T) {
+	srv := newWSTestServer(t, func(conn *gwebsocket.Conn) {
+		expectInit(t, conn)
+		writeAck(t, conn)
+		id := expectSubscribe(t, conn)
+		// graphql-transport-ws "error" carries the GraphQL errors array
+		// directly as payload and terminates the subscription.
+		require.NoError(t, conn.WriteJSON(map[string]any{
+			"id":      id,
+			"type":    "error",
+			"payload": []map[string]any{{"message": "kapow"}},
+		}))
+	})
+	defer srv.Close()
+
+	c := newClientForTest(http.DefaultClient, srv.URL+APIServicePath+"/graphql")
+	records, errs := c.LogRecordsFollow(context.Background(), LogRecordsFollowVars{Sources: []string{"x"}})
+
+	var gotErr error
+	var mu sync.Mutex
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for e := range errs {
+			if e != nil {
+				mu.Lock()
+				gotErr = e
+				mu.Unlock()
+			}
+		}
+	}()
+	for range records {
+	}
+	wg.Wait()
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "kapow")
+}
+
+// newWSTestServer wraps httptest with a gorilla upgrader that runs handle
+// once per upgraded connection. The handler is responsible for closing the
+// conn (gracefully or by returning).
+func newWSTestServer(t *testing.T, handle func(*gwebsocket.Conn)) *httptest.Server {
+	t.Helper()
+	upgrader := gwebsocket.Upgrader{
+		Subprotocols: []string{"graphql-transport-ws"},
+		CheckOrigin:  func(*http.Request) bool { return true },
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+		handle(conn)
+	}))
+}
+
+func expectInit(t *testing.T, conn *gwebsocket.Conn) {
+	t.Helper()
+	var msg gqlWSMessage
+	require.NoError(t, conn.ReadJSON(&msg))
+	require.Equal(t, "connection_init", msg.Type)
+}
+
+func writeAck(t *testing.T, conn *gwebsocket.Conn) {
+	t.Helper()
+	require.NoError(t, conn.WriteJSON(map[string]any{"type": "connection_ack"}))
+}
+
+func expectSubscribe(t *testing.T, conn *gwebsocket.Conn) string {
+	t.Helper()
+	var msg gqlWSMessage
+	require.NoError(t, conn.ReadJSON(&msg))
+	require.Equal(t, "subscribe", msg.Type)
+	require.NotEmpty(t, msg.ID)
+	return msg.ID
+}
+
+func writeNext(t *testing.T, conn *gwebsocket.Conn, id, payload string) {
+	t.Helper()
+	require.NoError(t, conn.WriteJSON(map[string]any{
+		"id":      id,
+		"type":    "next",
+		"payload": json.RawMessage(payload),
+	}))
+}
+
+func writeComplete(t *testing.T, conn *gwebsocket.Conn, id string) {
+	t.Helper()
+	require.NoError(t, conn.WriteJSON(map[string]any{"id": id, "type": "complete"}))
+}
+
+func drainRecords(t *testing.T, records <-chan logs.LogRecord, errs <-chan error, want int, timeout time.Duration) []logs.LogRecord {
+	t.Helper()
+	got := make([]logs.LogRecord, 0, want)
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for len(got) < want {
+		select {
+		case rec, ok := <-records:
+			if !ok {
+				return got
+			}
+			got = append(got, rec)
+		case e, ok := <-errs:
+			if ok && e != nil {
+				t.Fatalf("unexpected error from stream: %v", e)
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d records, got %d", want, len(got))
+		}
+	}
+	return got
+}
+
+// bearerInjector is a tiny RoundTripper that sets a static bearer token so
+// tests can verify auth-header propagation without needing a real
+// rest.Config.
+type bearerInjector struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b bearerInjector) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(r)
+}

--- a/modules/cli/internal/clusterapi/health.go
+++ b/modules/cli/internal/clusterapi/health.go
@@ -1,0 +1,75 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clusterapi provides a thin CLI-side client for the Kubetail
+// cluster-api, reachable via the kube-apiserver aggregation layer.
+package clusterapi
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+)
+
+// APIServiceName is the metadata.name of the Kubetail cluster-api APIService
+// registered with the kube-apiserver aggregation layer.
+const APIServiceName = "v1.api.kubetail.com"
+
+// APIServicePath is the path under which the cluster-api is exposed by the
+// kube-apiserver via the APIServiceName APIService.
+const APIServicePath = "/apis/api.kubetail.com/v1"
+
+// availabilityProbeTimeout caps how long IsKubetailAPIAvailable will wait
+// for the apiserver to respond before giving up.
+const availabilityProbeTimeout = 2 * time.Second
+
+// IsKubetailAPIAvailable reports whether the Kubetail cluster-api APIService
+// is registered and Available on the cluster pointed to by restConfig.
+//
+// A NotFound APIService is treated as a normal "not available" outcome
+// (returns false, nil). Other errors (network, RBAC, etc.) are surfaced so
+// callers that explicitly opt into the Kubetail backend can fail loudly.
+func IsKubetailAPIAvailable(ctx context.Context, restConfig *rest.Config) (bool, error) {
+	client, err := aggregator.NewForConfig(restConfig)
+	if err != nil {
+		return false, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, availabilityProbeTimeout)
+	defer cancel()
+	return isAvailableFromClient(probeCtx, client)
+}
+
+// isAvailableFromClient is the testable seam: it takes an aggregator
+// clientset (real or fake) and returns whether the cluster-api APIService
+// reports an Available=True condition.
+func isAvailableFromClient(ctx context.Context, client aggregator.Interface) (bool, error) {
+	apiSvc, err := client.ApiregistrationV1().APIServices().Get(ctx, APIServiceName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, c := range apiSvc.Status.Conditions {
+		if c.Type == apiregistrationv1.Available {
+			return c.Status == apiregistrationv1.ConditionTrue, nil
+		}
+	}
+	return false, nil
+}

--- a/modules/cli/internal/clusterapi/health_test.go
+++ b/modules/cli/internal/clusterapi/health_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clienttesting "k8s.io/client-go/testing"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregatorfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+)
+
+func newAPIServiceForTest(name string, conds ...apiregistrationv1.APIServiceCondition) *apiregistrationv1.APIService {
+	return &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     apiregistrationv1.APIServiceStatus{Conditions: conds},
+	}
+}
+
+func availableCond(s apiregistrationv1.ConditionStatus) apiregistrationv1.APIServiceCondition {
+	return apiregistrationv1.APIServiceCondition{Type: apiregistrationv1.Available, Status: s}
+}
+
+func TestIsKubetailAPIAvailable_ReturnsTrueWhenConditionAvailable(t *testing.T) {
+	client := aggregatorfake.NewSimpleClientset(
+		newAPIServiceForTest(APIServiceName, availableCond(apiregistrationv1.ConditionTrue)),
+	)
+	ok, err := isAvailableFromClient(context.Background(), client)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIsKubetailAPIAvailable_ReturnsFalseWhenNotFound(t *testing.T) {
+	client := aggregatorfake.NewSimpleClientset()
+	ok, err := isAvailableFromClient(context.Background(), client)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestIsKubetailAPIAvailable_ReturnsFalseWhenConditionFalse(t *testing.T) {
+	client := aggregatorfake.NewSimpleClientset(
+		newAPIServiceForTest(APIServiceName, availableCond(apiregistrationv1.ConditionFalse)),
+	)
+	ok, err := isAvailableFromClient(context.Background(), client)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestIsKubetailAPIAvailable_ReturnsFalseWhenNoAvailableCondition(t *testing.T) {
+	client := aggregatorfake.NewSimpleClientset(
+		newAPIServiceForTest(APIServiceName, apiregistrationv1.APIServiceCondition{
+			Type: "SomethingElse", Status: apiregistrationv1.ConditionTrue,
+		}),
+	)
+	ok, err := isAvailableFromClient(context.Background(), client)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestIsKubetailAPIAvailable_PropagatesNonNotFoundErrors(t *testing.T) {
+	client := aggregatorfake.NewSimpleClientset()
+	client.PrependReactor("get", "apiservices", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("boom")
+	})
+	ok, err := isAvailableFromClient(context.Background(), client)
+	require.Error(t, err)
+	assert.False(t, ok)
+
+	// Sanity: ensure NotFound is treated specially.
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "apiregistration.k8s.io", Resource: "apiservices"}, APIServiceName)
+	_ = notFound
+}

--- a/modules/cli/internal/clusterapi/stream.go
+++ b/modules/cli/internal/clusterapi/stream.go
@@ -1,0 +1,184 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterapi
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/kubetail-org/kubetail/modules/shared/logs"
+)
+
+type clientIface interface {
+	LogRecordsFetch(ctx context.Context, v LogRecordsFetchVars) (*LogRecordsQueryResponse, error)
+	LogRecordsFollow(ctx context.Context, v LogRecordsFollowVars) (<-chan logs.LogRecord, <-chan error)
+}
+
+type StreamConfig struct {
+	KubeContext string
+	Sources     []string
+	Mode        string // "HEAD" or "TAIL"
+	Since       string
+	Until       string
+	Grep        string
+	Limit       int
+	Follow      bool
+}
+
+// Stream consumes the cluster-api GraphQL endpoint and exposes a logs.Stream
+// to the CLI's printLogs.
+type Stream struct {
+	client clientIface
+	cfg    StreamConfig
+
+	out chan logs.LogRecord
+
+	mu  sync.Mutex
+	err error
+
+	cancel context.CancelFunc
+	doneCh chan struct{}
+}
+
+func NewStream(client *Client, cfg StreamConfig) *Stream {
+	return newStreamForTest(client, cfg)
+}
+
+func newStreamForTest(client clientIface, cfg StreamConfig) *Stream {
+	return &Stream{
+		client: client,
+		cfg:    cfg,
+		out:    make(chan logs.LogRecord, 64),
+		doneCh: make(chan struct{}),
+	}
+}
+
+func (s *Stream) Start(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	go s.run(ctx)
+	return nil
+}
+
+// Sources returns nil; the Kubetail API streams already-merged records and
+// printLogs falls back to header lengths for column widths when empty.
+func (s *Stream) Sources() []logs.LogSource { return nil }
+
+func (s *Stream) Records() <-chan logs.LogRecord { return s.out }
+
+func (s *Stream) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+func (s *Stream) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	<-s.doneCh
+}
+
+func (s *Stream) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err == nil {
+		s.err = err
+	}
+}
+
+func (s *Stream) run(ctx context.Context) {
+	defer close(s.out)
+	defer close(s.doneCh)
+
+	// Bootstrap fetch: HEAD paginates via NextCursor; TAIL is a single page.
+	// An empty Mode skips the bootstrap entirely (used by `-f` with no
+	// explicit --tail, where the user wants only new records).
+	cursor := ""
+	var lastTimestamp string
+	for s.cfg.Mode != "" {
+		resp, err := s.client.LogRecordsFetch(ctx, LogRecordsFetchVars{
+			KubeContext: s.cfg.KubeContext,
+			Sources:     s.cfg.Sources,
+			Mode:        s.cfg.Mode,
+			Since:       s.cfg.Since,
+			Until:       s.cfg.Until,
+			Grep:        s.cfg.Grep,
+			Limit:       s.cfg.Limit,
+			Cursor:      cursor,
+		})
+		if err != nil {
+			s.setErr(err)
+			return
+		}
+		for _, r := range resp.Records {
+			select {
+			case s.out <- r:
+			case <-ctx.Done():
+				return
+			}
+			lastTimestamp = r.Timestamp.Format(time.RFC3339Nano)
+		}
+		if s.cfg.Mode != "HEAD" || resp.NextCursor == nil || *resp.NextCursor == "" {
+			break
+		}
+		cursor = *resp.NextCursor
+	}
+
+	if !s.cfg.Follow {
+		return
+	}
+
+	// The cluster-api's logRecordsFollow subscription replays full history
+	// when no since/after is set. Anchor at the last bootstrap record (so we
+	// don't double-emit) or at "now" (so we don't replay history when the
+	// bootstrap was skipped or returned no records).
+	followAfter := lastTimestamp
+	if followAfter == "" {
+		followAfter = time.Now().Format(time.RFC3339Nano)
+	}
+	records, errs := s.client.LogRecordsFollow(ctx, LogRecordsFollowVars{
+		KubeContext: s.cfg.KubeContext,
+		Sources:     s.cfg.Sources,
+		Since:       s.cfg.Since,
+		After:       followAfter,
+		Grep:        s.cfg.Grep,
+	})
+	for records != nil || errs != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case rec, ok := <-records:
+			if !ok {
+				records = nil
+				continue
+			}
+			select {
+			case s.out <- rec:
+			case <-ctx.Done():
+				return
+			}
+		case err, ok := <-errs:
+			if !ok {
+				errs = nil
+				continue
+			}
+			if err != nil {
+				s.setErr(err)
+			}
+		}
+	}
+}

--- a/modules/cli/internal/clusterapi/stream_test.go
+++ b/modules/cli/internal/clusterapi/stream_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubetail-org/kubetail/modules/shared/logs"
+)
+
+// fakeClient lets tests drive Stream behavior without HTTP.
+type fakeClient struct {
+	fetchPages []*LogRecordsQueryResponse
+	fetchErrs  []error
+	fetchCalls int
+
+	followRecords <-chan logs.LogRecord
+	followErrs    <-chan error
+	followVars    LogRecordsFollowVars
+}
+
+func (f *fakeClient) LogRecordsFetch(ctx context.Context, _ LogRecordsFetchVars) (*LogRecordsQueryResponse, error) {
+	i := f.fetchCalls
+	f.fetchCalls++
+	if i < len(f.fetchErrs) && f.fetchErrs[i] != nil {
+		return nil, f.fetchErrs[i]
+	}
+	if i >= len(f.fetchPages) {
+		return &LogRecordsQueryResponse{}, nil
+	}
+	return f.fetchPages[i], nil
+}
+
+func (f *fakeClient) LogRecordsFollow(ctx context.Context, v LogRecordsFollowVars) (<-chan logs.LogRecord, <-chan error) {
+	f.followVars = v
+	return f.followRecords, f.followErrs
+}
+
+func mkRecord(msg string) logs.LogRecord {
+	return logs.LogRecord{Timestamp: time.Now(), Message: msg}
+}
+
+func TestStream_ImplementsLogStream(t *testing.T) {
+	var _ logs.Stream = (*Stream)(nil)
+}
+
+func TestStream_HeadModePaginatesUntilCursorNil(t *testing.T) {
+	cur := "cursor-1"
+	fc := &fakeClient{
+		fetchPages: []*LogRecordsQueryResponse{
+			{Records: []logs.LogRecord{mkRecord("a"), mkRecord("b")}, NextCursor: &cur},
+			{Records: []logs.LogRecord{mkRecord("c")}, NextCursor: nil},
+		},
+	}
+	s := newStreamForTest(fc, StreamConfig{Mode: "HEAD", Sources: []string{"x"}, Limit: 2})
+
+	require.NoError(t, s.Start(context.Background()))
+	got := drainAll(t, s, 2*time.Second)
+	require.NoError(t, s.Err())
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", got[0].Message)
+	assert.Equal(t, "c", got[2].Message)
+	assert.Equal(t, 2, fc.fetchCalls)
+}
+
+func TestStream_TailModeSingleFetch(t *testing.T) {
+	fc := &fakeClient{
+		fetchPages: []*LogRecordsQueryResponse{
+			{Records: []logs.LogRecord{mkRecord("x"), mkRecord("y")}, NextCursor: nil},
+		},
+	}
+	s := newStreamForTest(fc, StreamConfig{Mode: "TAIL", Sources: []string{"x"}, Limit: 10})
+
+	require.NoError(t, s.Start(context.Background()))
+	got := drainAll(t, s, 2*time.Second)
+	require.NoError(t, s.Err())
+	require.Len(t, got, 2)
+	assert.Equal(t, 1, fc.fetchCalls, "tail should not paginate")
+}
+
+func TestStream_FollowAfterFetch(t *testing.T) {
+	rec := make(chan logs.LogRecord, 2)
+	errs := make(chan error, 1)
+	rec <- mkRecord("live-1")
+	rec <- mkRecord("live-2")
+	close(rec)
+	close(errs)
+
+	fc := &fakeClient{
+		fetchPages: []*LogRecordsQueryResponse{
+			{Records: []logs.LogRecord{mkRecord("past")}, NextCursor: nil},
+		},
+		followRecords: rec,
+		followErrs:    errs,
+	}
+	s := newStreamForTest(fc, StreamConfig{Mode: "TAIL", Sources: []string{"x"}, Limit: 10, Follow: true})
+
+	require.NoError(t, s.Start(context.Background()))
+	got := drainAll(t, s, 2*time.Second)
+	require.NoError(t, s.Err())
+	require.Len(t, got, 3)
+	assert.Equal(t, "past", got[0].Message)
+	assert.Equal(t, "live-2", got[2].Message)
+}
+
+func TestStream_FollowOnlyMode_SkipsBootstrapFetch(t *testing.T) {
+	rec := make(chan logs.LogRecord, 1)
+	errs := make(chan error, 1)
+	rec <- mkRecord("live")
+	close(rec)
+	close(errs)
+
+	fc := &fakeClient{
+		fetchPages:    []*LogRecordsQueryResponse{{Records: []logs.LogRecord{mkRecord("backlog")}}},
+		followRecords: rec,
+		followErrs:    errs,
+	}
+	s := newStreamForTest(fc, StreamConfig{Sources: []string{"x"}, Follow: true /* Mode left empty */})
+
+	require.NoError(t, s.Start(context.Background()))
+	got := drainAll(t, s, 2*time.Second)
+	require.NoError(t, s.Err())
+	require.Len(t, got, 1)
+	assert.Equal(t, "live", got[0].Message)
+	assert.Equal(t, 0, fc.fetchCalls, "follow-only mode must not call Fetch")
+	// Without an anchor the cluster-api logRecordsFollow subscription replays
+	// full history. Stream must default After to "now" when bootstrap is
+	// skipped.
+	assert.NotEmpty(t, fc.followVars.After, "follow-only mode must anchor After at 'now'")
+}
+
+func TestStream_FollowAfterFetch_AnchorsAtBootstrapTimestamp(t *testing.T) {
+	bootstrapTs := time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC)
+	rec := make(chan logs.LogRecord, 1)
+	errs := make(chan error, 1)
+	close(rec)
+	close(errs)
+
+	fc := &fakeClient{
+		fetchPages: []*LogRecordsQueryResponse{
+			{Records: []logs.LogRecord{{Timestamp: bootstrapTs, Message: "past"}}, NextCursor: nil},
+		},
+		followRecords: rec,
+		followErrs:    errs,
+	}
+	s := newStreamForTest(fc, StreamConfig{Sources: []string{"x"}, Mode: "TAIL", Limit: 1, Follow: true})
+
+	require.NoError(t, s.Start(context.Background()))
+	_ = drainAll(t, s, 2*time.Second)
+	assert.Equal(t, bootstrapTs.Format(time.RFC3339Nano), fc.followVars.After,
+		"follow must resume after the last bootstrap record's timestamp")
+}
+
+func TestStream_FetchErrorIsRecorded(t *testing.T) {
+	fc := &fakeClient{
+		fetchErrs: []error{errors.New("rbac denied")},
+	}
+	s := newStreamForTest(fc, StreamConfig{Mode: "TAIL", Sources: []string{"x"}, Limit: 10})
+
+	require.NoError(t, s.Start(context.Background()))
+	_ = drainAll(t, s, 2*time.Second)
+	require.Error(t, s.Err())
+	assert.Contains(t, s.Err().Error(), "rbac denied")
+}
+
+func drainAll(t *testing.T, s *Stream, timeout time.Duration) []logs.LogRecord {
+	t.Helper()
+	var got []logs.LogRecord
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case rec, ok := <-s.Records():
+			if !ok {
+				return got
+			}
+			got = append(got, rec)
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for records, got %d so far", len(got))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--backend` flag (`auto|kubernetes|kubetail`) to `kubetail logs` so the CLI
can stream logs through the cluster-api aggregation layer when it is available,
and falls back to the Kubernetes `pods/log` endpoint otherwise. The kubetail
backend uses a `graphql-transport-ws` upgrade, which the apiserver hijacks and
routes outside the 60s non-watch deadline that previously broke long-running
SSE-over-POST streams through aggregation.

`--grep` no longer requires `--force`. When grep runs against the Kubernetes
backend the CLI now prints a one-line warning explaining that filtering
happens client-side and pointing at `kubetail cluster install` for node-local
filtering via the Kubetail API.

## Key Changes

- New `--backend` flag on `kubetail logs` with `auto` (probe APIService), `kubetail`, and `kubernetes` values; `auto` falls back silently on probe error, `kubetail` surfaces unavailability loudly.
- New `modules/cli/internal/clusterapi/` package: REST-config-aware GraphQL client, APIService health probe, and a `Stream` implementation backed by `graphql-transport-ws`.
- Drop the `--force` gate on `--grep`; warn when grep runs on the Kubernetes backend.
- e2e: shared `log_producer` session fixture (busybox emitter), `test_cli.py` parametrized over both backends for `--tail` and `--follow`, and `test_cluster_api_websocket_auth.py` pinning the apiserver websocket auth-gate behavior.
- Bump `gorilla/websocket` and `k8s.io/kube-aggregator` from indirect to direct in `modules/cli/go.mod`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused