### PR TITLE
🎣 Remove invalid --upload flag from cosign sign in release workflow

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -276,7 +276,6 @@ jobs:
           cosign sign \
             --yes \
             -r \
-            --upload=${{needs.config.outputs.dry_run == 'false'}} \
             kubetail/$IMAGE_NAME@${{ steps.digest.outputs.digest }}
 
           if [ "$IS_LATEST" = "true" ]; then
@@ -284,7 +283,6 @@ jobs:
             cosign sign \
               --yes \
               -r \
-              --upload=${{needs.config.outputs.dry_run == 'false'}} \
               kubetail/$IMAGE_NAME@${{ steps.digest.outputs.digest_latest }}
           fi
 
@@ -298,7 +296,6 @@ jobs:
           cosign sign \
             --yes \
             -r \
-            --upload=${{needs.config.outputs.dry_run == 'false'}} \
             ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME@${{ steps.digest.outputs.digest }}
 
           if [ "$IS_LATEST" = "true" ]; then
@@ -306,6 +303,5 @@ jobs:
             cosign sign \
               --yes \
               -r \
-              --upload=${{needs.config.outputs.dry_run == 'false'}} \
               ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME@${{ steps.digest.outputs.digest_latest }}
           fi


### PR DESCRIPTION
## Summary

The `release-docker` workflow passed `--upload=<bool>` to `cosign sign`, but `--upload` is not a valid flag for `cosign sign` (it exists on `cosign attest`). This caused signing steps to fail. Dry-run behavior is already controlled by the surrounding job conditions, so the flag isn't needed.

## Key Changes

- Drop `--upload=...` from all four `cosign sign` invocations (Docker Hub + GHCR, primary + latest tags) in `.github/workflows/release-docker.yml`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused