### PR TITLE
✨ Add background update check with notification

### DIFF
--- a/modules/cli/cmd/root.go
+++ b/modules/cli/cmd/root.go
@@ -15,15 +15,20 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubetail-org/kubetail/modules/shared/logging"
+
+	"github.com/kubetail-org/kubetail/modules/cli/internal/updatecheck"
+	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
 )
 
 const (
@@ -33,6 +38,11 @@ const (
 )
 
 var version = "dev" // default version for local builds
+
+// waitForRefresh and cachedUpdateOpts are set by PersistentPreRunE and consumed by
+// PersistentPostRunE so resolveUpdateCheckOptions runs only once per command invocation.
+var waitForRefresh func() = func() {}
+var cachedUpdateOpts *updatecheck.Options
 
 // getCommandDisplayName determines the CLI display name based on how it's invoked
 func getCommandDisplayName() string {
@@ -48,6 +58,35 @@ func getCommandDisplayName() string {
 	return "kubetail"
 }
 
+func resolveUpdateCheckOptions(cmd *cobra.Command) (updatecheck.Options, bool) {
+	rootFlags := cmd.Root().PersistentFlags()
+	configPath, _ := rootFlags.GetString("config")
+	v := viper.New()
+	v.BindPFlag("general.kubeconfig", rootFlags.Lookup(KubeconfigFlag))
+	var kubeconfigPath string
+	if cfg, err := config.NewConfig(configPath, v); err == nil && cfg != nil {
+		kubeconfigPath = cfg.General.KubeconfigPath
+	}
+	// --kube-context is a local flag on each subcommand, not a root persistent flag.
+	kubeContext, _ := cmd.Flags().GetString(KubeContextFlag)
+	cliCacheFile, err := updatecheck.DefaultCLICacheFile()
+	if err != nil {
+		return updatecheck.Options{}, false
+	}
+	helmCacheFile, err := updatecheck.DefaultHelmCacheFile()
+	if err != nil {
+		return updatecheck.Options{}, false
+	}
+	return updatecheck.Options{
+		CLICacheFile:      cliCacheFile,
+		HelmCacheFile:     helmCacheFile,
+		CurrentCLIVersion: version,
+		KubeconfigPath:    kubeconfigPath,
+		KubeContext:       kubeContext,
+		CacheTTL:          updatecheck.DefaultCacheTTL,
+	}, true
+}
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "kubetail",
@@ -55,6 +94,22 @@ var rootCmd = &cobra.Command{
 	Short:   "Kubetail - Kubernetes logging utility",
 	Annotations: map[string]string{
 		cobra.CommandDisplayNameAnnotation: getCommandDisplayName(),
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if opts, ok := resolveUpdateCheckOptions(cmd); ok {
+			cachedUpdateOpts = &opts
+			waitForRefresh = updatecheck.TriggerRefreshIfStale(opts)
+		}
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		waitForRefresh()
+		if cachedUpdateOpts != nil {
+			for _, n := range updatecheck.Notify(*cachedUpdateOpts) {
+				fmt.Fprint(os.Stderr, colorizeWarning(os.Stderr, n.Message))
+			}
+		}
+		return nil
 	},
 }
 

--- a/modules/cli/go.mod
+++ b/modules/cli/go.mod
@@ -9,6 +9,7 @@ replace github.com/kubetail-org/kubetail/modules/shared => ../shared
 replace github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.8.0
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.28.0
@@ -22,6 +23,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
+	helm.sh/helm/v3 v3.20.2
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
 	k8s.io/klog/v2 v2.130.1
@@ -34,7 +36,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
@@ -183,7 +184,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.20.2 // indirect
 	k8s.io/api v0.35.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect

--- a/modules/cli/internal/updatecheck/updatecheck.go
+++ b/modules/cli/internal/updatecheck/updatecheck.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	DefaultCacheTTL   = 12 * time.Hour
+	DefaultCacheTTL  = 12 * time.Hour
 	cliCacheVersion  = 1
 	helmCacheVersion = 1
 )
@@ -157,7 +157,6 @@ func Notify(opts Options) []Notification {
 	kubeContext := resolveKubeContext(opts.KubeconfigPath, opts.KubeContext)
 	return buildNotifications(cliCache, helmCache, opts.CurrentCLIVersion, kubeContext)
 }
-
 
 // RefreshCLICache fetches the latest CLI version and writes it to the CLI cache file.
 func RefreshCLICache(opts Options) error {

--- a/modules/cli/internal/updatecheck/updatecheck.go
+++ b/modules/cli/internal/updatecheck/updatecheck.go
@@ -1,0 +1,393 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updatecheck
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	semver "github.com/Masterminds/semver/v3"
+	helmrelease "helm.sh/helm/v3/pkg/release"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubetail-org/kubetail/modules/cli/pkg/config"
+	"github.com/kubetail-org/kubetail/modules/shared/helm"
+	"github.com/kubetail-org/kubetail/modules/shared/versioncheck"
+)
+
+const (
+	DefaultCacheTTL   = 12 * time.Hour
+	cliCacheVersion  = 1
+	helmCacheVersion = 1
+)
+
+// CLICache matches the UpdateState shape used in the dashboard-ui localStorage.
+type CLICache struct {
+	SchemaVersion   int      `json:"schemaVersion"`
+	LatestVersion   string   `json:"latestVersion,omitempty"`
+	FetchedAt       *int64   `json:"fetchedAt,omitempty"`
+	DismissedAt     *int64   `json:"dismissedAt,omitempty"`
+	SkippedVersions []string `json:"skippedVersions,omitempty"`
+}
+
+// ClusterCacheEntry stores the installed helm chart version for a specific kube context.
+type ClusterCacheEntry struct {
+	CurrentVersion  string   `json:"currentVersion,omitempty"`
+	FetchedAt       *int64   `json:"fetchedAt,omitempty"`
+	DismissedAt     *int64   `json:"dismissedAt,omitempty"`
+	SkippedVersions []string `json:"skippedVersions,omitempty"`
+}
+
+// HelmCache stores the latest upstream helm chart version (shared across all contexts)
+// and per-context installed versions in Clusters.
+type HelmCache struct {
+	SchemaVersion int                          `json:"schemaVersion"`
+	LatestVersion string                       `json:"latestVersion,omitempty"`
+	FetchedAt     *int64                       `json:"fetchedAt,omitempty"`
+	Clusters      map[string]ClusterCacheEntry `json:"clusters,omitempty"`
+}
+
+type Notification struct {
+	Message string
+}
+
+type helmLister interface {
+	ListReleases() ([]*helmrelease.Release, error)
+}
+
+type Options struct {
+	CLICacheFile      string
+	HelmCacheFile     string
+	CurrentCLIVersion string
+	KubeconfigPath    string
+	KubeContext       string
+	CacheTTL          time.Duration
+	Checker           versioncheck.Checker
+	HelmLister        helmLister
+	// Runner executes background refresh tasks. Defaults to a goroutine.
+	// Tests can inject a synchronous runner to control execution.
+	Runner func(func())
+}
+
+func defaultCacheFile(name string) (string, error) {
+	dir, err := config.DefaultCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}
+
+func DefaultCLICacheFile() (string, error) {
+	return defaultCacheFile("cli-update-check.json")
+}
+
+func DefaultHelmCacheFile() (string, error) {
+	return defaultCacheFile("cluster-update-check.json")
+}
+
+// TriggerRefreshIfStale checks if either cache is stale, fires background
+// goroutines to refresh them, and returns a function that blocks until all
+// launched goroutines complete. Call the returned function (with a deadline if
+// needed) before the process exits to ensure the cache is written.
+func TriggerRefreshIfStale(opts Options) func() {
+	if opts.CurrentCLIVersion == "dev" {
+		return func() {}
+	}
+	if opts.CacheTTL == 0 {
+		opts.CacheTTL = DefaultCacheTTL
+	}
+	run := opts.Runner
+	if run == nil {
+		run = func(f func()) { go f() }
+	}
+
+	var wg sync.WaitGroup
+
+	cliCache, _ := readCLICache(opts.CLICacheFile)
+	var cliFetchedAt *int64
+	if cliCache != nil {
+		cliFetchedAt = cliCache.FetchedAt
+	}
+	if isStale(cliFetchedAt, opts.CacheTTL) {
+		wg.Add(1)
+		run(func() { defer wg.Done(); _ = RefreshCLICache(opts) })
+	}
+
+	helmCache, _ := readHelmCache(opts.HelmCacheFile)
+	kubeContext := resolveKubeContext(opts.KubeconfigPath, opts.KubeContext)
+	var latestHelmFetchedAt, clusterFetchedAt *int64
+	if helmCache != nil {
+		latestHelmFetchedAt = helmCache.FetchedAt
+		if entry, ok := helmCache.Clusters[kubeContext]; ok {
+			clusterFetchedAt = entry.FetchedAt
+		}
+	}
+	if isStale(latestHelmFetchedAt, opts.CacheTTL) || isStale(clusterFetchedAt, opts.CacheTTL) {
+		wg.Add(1)
+		run(func() { defer wg.Done(); _ = RefreshHelmCache(opts) })
+	}
+
+	return wg.Wait
+}
+
+// Notify reads the cache files and returns any pending update notifications.
+func Notify(opts Options) []Notification {
+	if opts.CurrentCLIVersion == "dev" {
+		return nil
+	}
+	cliCache, _ := readCLICache(opts.CLICacheFile)
+	helmCache, _ := readHelmCache(opts.HelmCacheFile)
+	kubeContext := resolveKubeContext(opts.KubeconfigPath, opts.KubeContext)
+	return buildNotifications(cliCache, helmCache, opts.CurrentCLIVersion, kubeContext)
+}
+
+
+// RefreshCLICache fetches the latest CLI version and writes it to the CLI cache file.
+func RefreshCLICache(opts Options) error {
+	checker := opts.Checker
+	if checker == nil {
+		checker = versioncheck.NewChecker()
+	}
+
+	var latestVersion string
+	if info, err := checker.GetLatestCLIVersion(); err == nil {
+		latestVersion = info.Version
+	}
+
+	existing, _ := readCLICache(opts.CLICacheFile)
+	fetchedAt := time.Now().UnixMilli()
+	c := &CLICache{
+		SchemaVersion: cliCacheVersion,
+		LatestVersion: latestVersion,
+		FetchedAt:     &fetchedAt,
+	}
+	if existing != nil {
+		c.DismissedAt = existing.DismissedAt
+		c.SkippedVersions = existing.SkippedVersions
+	}
+
+	return writeJSONCache(opts.CLICacheFile, c)
+}
+
+// RefreshHelmCache fetches the latest Helm chart version and the installed version
+// for the current kube context, then writes the result to the Helm cache file.
+func RefreshHelmCache(opts Options) error {
+	checker := opts.Checker
+	if checker == nil {
+		checker = versioncheck.NewChecker()
+	}
+
+	kubeContext := resolveKubeContext(opts.KubeconfigPath, opts.KubeContext)
+
+	var (
+		latestVersion  string
+		currentVersion string
+		wg             sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if info, err := checker.GetLatestHelmChartVersion(); err == nil {
+			latestVersion = info.Version
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		lister := opts.HelmLister
+		if lister == nil {
+			lister = helm.NewClient(helm.WithKubeconfigPath(opts.KubeconfigPath), helm.WithKubeContext(kubeContext))
+		}
+		currentVersion = getInstalledHelmChartVersion(lister)
+	}()
+	wg.Wait()
+
+	cache, _ := readHelmCache(opts.HelmCacheFile)
+	if cache == nil {
+		cache = &HelmCache{}
+	}
+	if cache.Clusters == nil {
+		cache.Clusters = make(map[string]ClusterCacheEntry)
+	}
+
+	fetchedAt := time.Now().UnixMilli()
+	cache.SchemaVersion = helmCacheVersion
+	cache.LatestVersion = latestVersion
+	cache.FetchedAt = &fetchedAt
+
+	existingCluster := cache.Clusters[kubeContext]
+	cache.Clusters[kubeContext] = ClusterCacheEntry{
+		CurrentVersion:  currentVersion,
+		FetchedAt:       &fetchedAt,
+		DismissedAt:     existingCluster.DismissedAt,
+		SkippedVersions: existingCluster.SkippedVersions,
+	}
+
+	return writeJSONCache(opts.HelmCacheFile, cache)
+}
+
+func readJSONFile[T any](path string) (*T, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func readCLICache(path string) (*CLICache, error) {
+	c, err := readJSONFile[CLICache](path)
+	if c != nil && c.SchemaVersion != cliCacheVersion {
+		return nil, nil
+	}
+	return c, err
+}
+
+func readHelmCache(path string) (*HelmCache, error) {
+	c, err := readJSONFile[HelmCache](path)
+	if c != nil && c.SchemaVersion != helmCacheVersion {
+		return nil, nil
+	}
+	return c, err
+}
+
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".update-check-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func writeJSONCache(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(path, data)
+}
+
+func isStale(fetchedAt *int64, ttl time.Duration) bool {
+	return fetchedAt == nil || time.Since(time.UnixMilli(*fetchedAt)) > ttl
+}
+
+func compareVersions(current, latest string) bool {
+	if current == "" || latest == "" {
+		return false
+	}
+	c, err := semver.NewVersion(current)
+	if err != nil {
+		return false
+	}
+	l, err := semver.NewVersion(latest)
+	if err != nil {
+		return false
+	}
+	return l.GreaterThan(c)
+}
+
+func buildNotifications(cliCache *CLICache, helmCache *HelmCache, currentCLIVersion, kubeContext string) []Notification {
+	var notes []Notification
+
+	if cliCache != nil && compareVersions(currentCLIVersion, cliCache.LatestVersion) {
+		notes = append(notes, Notification{
+			Message: fmt.Sprintf(
+				"Warning: A new version of the kubetail CLI is available (%s > %s). See https://kubetail.com/docs/install to upgrade.\n",
+				cliCache.LatestVersion, currentCLIVersion,
+			),
+		})
+	}
+
+	if helmCache == nil {
+		return notes
+	}
+	if entry, ok := helmCache.Clusters[kubeContext]; ok && entry.CurrentVersion != "" && compareVersions(entry.CurrentVersion, helmCache.LatestVersion) {
+		notes = append(notes, Notification{
+			Message: fmt.Sprintf(
+				"Warning: A new version of the Kubetail API is available (%s > %s). To upgrade, run: kubetail cluster upgrade\n",
+				helmCache.LatestVersion, entry.CurrentVersion,
+			),
+		})
+	}
+
+	return notes
+}
+
+// resolveKubeContext returns kubeContext if non-empty, otherwise reads the
+// current-context from the kubeconfig so the cache key is always an actual name.
+func resolveKubeContext(kubeconfigPath, kubeContext string) string {
+	if kubeContext != "" {
+		return kubeContext
+	}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		loadingRules.ExplicitPath = kubeconfigPath
+	}
+	cfg, err := loadingRules.Load()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.CurrentContext
+}
+
+// getInstalledHelmChartVersion returns the oldest installed kubetail chart version
+// across all namespaces. Oldest is used so the notification reflects the release
+// most in need of upgrading when multiple installations exist.
+func getInstalledHelmChartVersion(lister helmLister) string {
+	releases, err := lister.ListReleases()
+	if err != nil {
+		return ""
+	}
+	var oldest *semver.Version
+	for _, rel := range releases {
+		if rel.Chart == nil || rel.Chart.Metadata == nil || rel.Chart.Metadata.Version == "" {
+			continue
+		}
+		v, err := semver.NewVersion(rel.Chart.Metadata.Version)
+		if err != nil {
+			continue
+		}
+		if oldest == nil || v.LessThan(oldest) {
+			oldest = v
+		}
+	}
+	if oldest == nil {
+		return ""
+	}
+	return oldest.Original()
+}

--- a/modules/cli/internal/updatecheck/updatecheck_test.go
+++ b/modules/cli/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,532 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updatecheck
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	helmrelease "helm.sh/helm/v3/pkg/release"
+
+	"github.com/kubetail-org/kubetail/modules/shared/versioncheck"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestReadWriteCLICache_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli-update-check.json")
+
+	fetchedAt := time.Now().UnixMilli()
+	c := &CLICache{
+		SchemaVersion:   cliCacheVersion,
+		LatestVersion:   "1.2.3",
+		FetchedAt:       &fetchedAt,
+		SkippedVersions: []string{"1.1.0"},
+	}
+
+	require.NoError(t, writeJSONCache(path, c))
+
+	got, err := readCLICache(path)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, c.LatestVersion, got.LatestVersion)
+	assert.Equal(t, *c.FetchedAt, *got.FetchedAt)
+	assert.Equal(t, c.SkippedVersions, got.SkippedVersions)
+}
+
+func TestReadCLICache_MissingFile(t *testing.T) {
+	got, err := readCLICache(filepath.Join(t.TempDir(), "nonexistent.json"))
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestReadCLICache_SchemaMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cli.json")
+	require.NoError(t, writeJSONCache(path, &CLICache{SchemaVersion: 999, LatestVersion: "1.0.0"}))
+	got, err := readCLICache(path)
+	assert.NoError(t, err)
+	assert.Nil(t, got, "mismatched schema version should be treated as missing")
+}
+
+func TestReadHelmCache_SchemaMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "helm.json")
+	require.NoError(t, writeJSONCache(path, &HelmCache{SchemaVersion: 999, LatestVersion: "1.0.0"}))
+	got, err := readHelmCache(path)
+	assert.NoError(t, err)
+	assert.Nil(t, got, "mismatched schema version should be treated as missing")
+}
+
+func TestReadWriteHelmCache_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "helm-update-check.json")
+
+	fetchedAt := time.Now().UnixMilli()
+	cache := &HelmCache{
+		SchemaVersion: helmCacheVersion,
+		LatestVersion: "1.0.0",
+		FetchedAt:     &fetchedAt,
+		Clusters: map[string]ClusterCacheEntry{
+			"ctx-a": {CurrentVersion: "0.9.0", FetchedAt: &fetchedAt},
+			"ctx-b": {CurrentVersion: "1.0.0", FetchedAt: ptr(fetchedAt - 1000)},
+		},
+	}
+
+	require.NoError(t, writeJSONCache(path, cache))
+
+	got, err := readHelmCache(path)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, cache.LatestVersion, got.LatestVersion)
+	assert.Equal(t, cache.Clusters["ctx-a"].CurrentVersion, got.Clusters["ctx-a"].CurrentVersion)
+	assert.Equal(t, *cache.Clusters["ctx-b"].FetchedAt, *got.Clusters["ctx-b"].FetchedAt)
+}
+
+func TestReadHelmCache_MissingFile(t *testing.T) {
+	got, err := readHelmCache(filepath.Join(t.TempDir(), "nonexistent.json"))
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"1.0.0", "1.2.3", true},
+		{"1.9.0", "1.10.0", true}, // important: 10 > 9
+		{"1.2.3", "1.2.3", false}, // equal
+		{"1.2.3", "1.0.0", false}, // current is newer
+		{"", "1.0.0", false},      // empty current
+		{"1.0.0", "", false},      // empty latest
+		{"bad", "1.0.0", false},   // invalid current
+		{"1.0.0", "bad", false},   // invalid latest
+	}
+
+	for _, tc := range cases {
+		got := compareVersions(tc.current, tc.latest)
+		assert.Equal(t, tc.want, got, "compareVersions(%q, %q)", tc.current, tc.latest)
+	}
+}
+
+func TestIsStale(t *testing.T) {
+	ttl := time.Hour
+
+	assert.True(t, isStale(nil, ttl), "nil fetchedAt should be stale")
+
+	fresh := time.Now().UnixMilli()
+	assert.False(t, isStale(&fresh, ttl), "just-written entry should not be stale")
+
+	old := time.Now().Add(-2 * time.Hour).UnixMilli()
+	assert.True(t, isStale(&old, ttl), "2h-old entry with 1h TTL should be stale")
+}
+
+func helmCache(latestVersion string, fetchedAt int64, clusters map[string]ClusterCacheEntry) *HelmCache {
+	return &HelmCache{LatestVersion: latestVersion, FetchedAt: &fetchedAt, Clusters: clusters}
+}
+
+func TestBuildNotifications(t *testing.T) {
+	fetchedAt := time.Now().UnixMilli()
+
+	cases := []struct {
+		name              string
+		cliCache          *CLICache
+		helmCache         *HelmCache
+		currentCLIVersion string
+		kubeContext       string
+		wantCount         int
+		wantCLI           bool
+		wantHelm          bool
+	}{
+		{
+			name:              "cli update available",
+			cliCache:          &CLICache{LatestVersion: "1.2.3", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("0.9.0", fetchedAt, map[string]ClusterCacheEntry{"": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			wantCount:         1,
+			wantCLI:           true,
+		},
+		{
+			name:              "cli up to date",
+			cliCache:          &CLICache{LatestVersion: "1.2.3", FetchedAt: &fetchedAt},
+			currentCLIVersion: "1.2.3",
+			wantCount:         0,
+		},
+		{
+			name:              "helm update available",
+			cliCache:          &CLICache{LatestVersion: "1.0.0", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("1.0.0", fetchedAt, map[string]ClusterCacheEntry{"": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			wantCount:         1,
+			wantHelm:          true,
+		},
+		{
+			name:              "helm not installed",
+			cliCache:          &CLICache{LatestVersion: "1.0.0", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("1.0.0", fetchedAt, map[string]ClusterCacheEntry{"": {CurrentVersion: ""}}),
+			currentCLIVersion: "1.0.0",
+			wantCount:         0,
+		},
+		{
+			name:              "helm latest unknown",
+			cliCache:          &CLICache{LatestVersion: "1.0.0", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("", fetchedAt, map[string]ClusterCacheEntry{"": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			wantCount:         0,
+		},
+		{
+			name:              "both updates available",
+			cliCache:          &CLICache{LatestVersion: "1.2.3", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("1.0.0", fetchedAt, map[string]ClusterCacheEntry{"": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			wantCount:         2,
+			wantCLI:           true,
+			wantHelm:          true,
+		},
+		{
+			name:              "nil caches",
+			cliCache:          nil,
+			helmCache:         nil,
+			currentCLIVersion: "1.0.0",
+			wantCount:         0,
+		},
+		{
+			name:              "helm update for specific context",
+			cliCache:          &CLICache{LatestVersion: "1.0.0", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("1.0.0", fetchedAt, map[string]ClusterCacheEntry{"prod": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			kubeContext:       "prod",
+			wantCount:         1,
+			wantHelm:          true,
+		},
+		{
+			name:              "helm entry for different context is ignored",
+			cliCache:          &CLICache{LatestVersion: "1.0.0", FetchedAt: &fetchedAt},
+			helmCache:         helmCache("1.0.0", fetchedAt, map[string]ClusterCacheEntry{"prod": {CurrentVersion: "0.9.0"}}),
+			currentCLIVersion: "1.0.0",
+			kubeContext:       "staging",
+			wantCount:         0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			notes := buildNotifications(tc.cliCache, tc.helmCache, tc.currentCLIVersion, tc.kubeContext)
+			assert.Len(t, notes, tc.wantCount)
+
+			if tc.wantCLI {
+				found := false
+				for _, n := range notes {
+					if strings.Contains(n.Message, "kubetail CLI") {
+						found = true
+						assert.Contains(t, n.Message, "kubetail.com/docs/install")
+					}
+				}
+				assert.True(t, found, "expected CLI notification")
+			}
+			if tc.wantHelm {
+				found := false
+				for _, n := range notes {
+					if strings.Contains(n.Message, "Kubetail API") {
+						found = true
+						assert.Contains(t, n.Message, "kubetail cluster upgrade")
+					}
+				}
+				assert.True(t, found, "expected Helm notification")
+			}
+		})
+	}
+}
+
+type mockChecker struct {
+	callCount int
+}
+
+func newMockChecker() *mockChecker {
+	return &mockChecker{}
+}
+
+func (m *mockChecker) GetLatestCLIVersion() (*versioncheck.VersionInfo, error) {
+	m.callCount++
+	return &versioncheck.VersionInfo{Version: "9.9.9"}, nil
+}
+
+func (m *mockChecker) GetLatestHelmChartVersion() (*versioncheck.VersionInfo, error) {
+	return &versioncheck.VersionInfo{Version: "9.9.9"}, nil
+}
+
+var syncRunner = func(f func()) { f() }
+
+func TestTriggerRefreshIfStale_DevBuild(t *testing.T) {
+	checker := newMockChecker()
+	TriggerRefreshIfStale(Options{
+		CLICacheFile:      filepath.Join(t.TempDir(), "cli.json"),
+		HelmCacheFile:     filepath.Join(t.TempDir(), "helm.json"),
+		CurrentCLIVersion: "dev",
+		CacheTTL:          time.Hour,
+		Checker:           checker,
+		Runner:            syncRunner,
+	})
+	assert.Equal(t, 0, checker.callCount, "dev build should not trigger refresh")
+}
+
+func TestTriggerRefreshIfStale_StaleCache_LaunchesRefresh(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "cli.json")
+
+	oldMs := time.Now().Add(-25 * time.Hour).UnixMilli()
+	require.NoError(t, writeJSONCache(cliPath, &CLICache{SchemaVersion: cliCacheVersion, LatestVersion: "1.0.0", FetchedAt: &oldMs}))
+
+	checker := newMockChecker()
+	TriggerRefreshIfStale(Options{
+		CLICacheFile:      cliPath,
+		HelmCacheFile:     filepath.Join(dir, "helm.json"),
+		CurrentCLIVersion: "1.0.0",
+		CacheTTL:          time.Hour,
+		Checker:           checker,
+		Runner:            syncRunner,
+	})
+
+	assert.Equal(t, 1, checker.callCount, "expected CLI refresh to run")
+}
+
+func TestTriggerRefreshIfStale_FreshCache_NoRefresh(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "cli.json")
+	helmPath := filepath.Join(dir, "helm.json")
+
+	freshMs := time.Now().UnixMilli()
+	require.NoError(t, writeJSONCache(cliPath, &CLICache{SchemaVersion: cliCacheVersion, LatestVersion: "1.0.0", FetchedAt: &freshMs}))
+	require.NoError(t, writeJSONCache(helmPath, &HelmCache{
+		SchemaVersion: helmCacheVersion,
+		LatestVersion: "1.0.0",
+		FetchedAt:     &freshMs,
+		Clusters:      map[string]ClusterCacheEntry{"my-ctx": {CurrentVersion: "1.0.0", FetchedAt: &freshMs}},
+	}))
+
+	checker := newMockChecker()
+	TriggerRefreshIfStale(Options{
+		CLICacheFile:      cliPath,
+		HelmCacheFile:     helmPath,
+		CurrentCLIVersion: "1.0.0",
+		KubeContext:       "my-ctx",
+		CacheTTL:          time.Hour,
+		Checker:           checker,
+		Runner:            syncRunner,
+	})
+
+	assert.Equal(t, 0, checker.callCount, "expected no background refresh for fresh cache")
+}
+
+func TestResolveKubeContext(t *testing.T) {
+	t.Run("explicit context is returned as-is", func(t *testing.T) {
+		assert.Equal(t, "prod", resolveKubeContext("", "prod"))
+	})
+
+	t.Run("empty context reads current-context from kubeconfig", func(t *testing.T) {
+		kubeconfig := `
+apiVersion: v1
+kind: Config
+current-context: default-ctx
+contexts:
+- name: default-ctx
+  context:
+    cluster: default-cluster
+    user: default-user
+clusters: []
+users: []
+`
+		f, err := os.CreateTemp(t.TempDir(), "kubeconfig-*.yaml")
+		require.NoError(t, err)
+		_, err = f.WriteString(kubeconfig)
+		require.NoError(t, err)
+		f.Close()
+
+		assert.Equal(t, "default-ctx", resolveKubeContext(f.Name(), ""))
+	})
+
+	t.Run("missing kubeconfig returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", resolveKubeContext(filepath.Join(t.TempDir(), "nonexistent"), ""))
+	})
+}
+
+func TestNotify_DevBuild(t *testing.T) {
+	notes := Notify(Options{
+		CLICacheFile:      filepath.Join(t.TempDir(), "cli.json"),
+		HelmCacheFile:     filepath.Join(t.TempDir(), "helm.json"),
+		CurrentCLIVersion: "dev",
+	})
+	assert.Empty(t, notes)
+}
+
+func TestNotify_ReturnsNotificationFromCache(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "cli.json")
+
+	freshMs := time.Now().UnixMilli()
+	require.NoError(t, writeJSONCache(cliPath, &CLICache{SchemaVersion: cliCacheVersion, LatestVersion: "2.0.0", FetchedAt: &freshMs}))
+
+	notes := Notify(Options{
+		CLICacheFile:      cliPath,
+		HelmCacheFile:     filepath.Join(dir, "helm.json"),
+		CurrentCLIVersion: "1.0.0",
+	})
+	require.Len(t, notes, 1)
+	assert.Contains(t, notes[0].Message, "kubetail CLI")
+}
+
+func TestNotify_EmptyCache_NoNotification(t *testing.T) {
+	notes := Notify(Options{
+		CLICacheFile:      filepath.Join(t.TempDir(), "cli.json"),
+		HelmCacheFile:     filepath.Join(t.TempDir(), "helm.json"),
+		CurrentCLIVersion: "1.0.0",
+	})
+	assert.Empty(t, notes)
+}
+
+// mockHelmLister is a helmLister that returns a fixed list of releases.
+type mockHelmLister struct {
+	releases []*helmrelease.Release
+	err      error
+}
+
+func (m *mockHelmLister) ListReleases() ([]*helmrelease.Release, error) {
+	return m.releases, m.err
+}
+
+func makeRelease(name, namespace, version string) *helmrelease.Release {
+	return &helmrelease.Release{
+		Name:      name,
+		Namespace: namespace,
+		Chart: &helmchart.Chart{
+			Metadata: &helmchart.Metadata{Version: version},
+		},
+	}
+}
+
+func TestGetInstalledHelmChartVersion(t *testing.T) {
+	cases := []struct {
+		name     string
+		releases []*helmrelease.Release
+		err      error
+		want     string
+	}{
+		{
+			name:     "no releases",
+			releases: nil,
+			want:     "",
+		},
+		{
+			name:     "list error",
+			err:      errors.New("connection refused"),
+			want:     "",
+		},
+		{
+			name:     "single release",
+			releases: []*helmrelease.Release{makeRelease("kubetail", "kubetail-system", "0.22.0")},
+			want:     "0.22.0",
+		},
+		{
+			name: "multiple releases same namespace",
+			releases: []*helmrelease.Release{
+				makeRelease("kubetail", "kubetail-system", "0.22.0"),
+				makeRelease("kubetail-2", "kubetail-system", "0.21.0"),
+			},
+			want: "0.21.0",
+		},
+		{
+			name: "multiple releases different namespaces",
+			releases: []*helmrelease.Release{
+				makeRelease("kubetail", "kubetail-system", "0.23.0"),
+				makeRelease("kubetail", "monitoring", "0.20.0"),
+			},
+			want: "0.20.0",
+		},
+		{
+			name: "multiple releases different names and namespaces",
+			releases: []*helmrelease.Release{
+				makeRelease("my-kubetail", "team-a", "0.22.0"),
+				makeRelease("kubetail-prod", "team-b", "0.19.0"),
+				makeRelease("kubetail", "kubetail-system", "0.23.0"),
+			},
+			want: "0.19.0",
+		},
+		{
+			name: "release with empty version is skipped",
+			releases: []*helmrelease.Release{
+				makeRelease("kubetail", "kubetail-system", ""),
+				makeRelease("kubetail-2", "kubetail-system", "0.22.0"),
+			},
+			want: "0.22.0",
+		},
+		{
+			name: "release with invalid version is skipped",
+			releases: []*helmrelease.Release{
+				makeRelease("kubetail", "kubetail-system", "not-a-version"),
+				makeRelease("kubetail-2", "kubetail-system", "0.22.0"),
+			},
+			want: "0.22.0",
+		},
+		{
+			name: "release with nil chart is skipped",
+			releases: []*helmrelease.Release{
+				{Name: "kubetail", Namespace: "kubetail-system", Chart: nil},
+				makeRelease("kubetail-2", "kubetail-system", "0.22.0"),
+			},
+			want: "0.22.0",
+		},
+		{
+			name: "all releases invalid",
+			releases: []*helmrelease.Release{
+				makeRelease("kubetail", "kubetail-system", ""),
+				makeRelease("kubetail-2", "kubetail-system", "bad"),
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := &mockHelmLister{releases: tc.releases, err: tc.err}
+			assert.Equal(t, tc.want, getInstalledHelmChartVersion(lister))
+		})
+	}
+}
+
+func TestDefaultCLICacheFile(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	path, err := DefaultCLICacheFile()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".kubetail", "cache", "cli-update-check.json"), path)
+}
+
+func TestDefaultHelmCacheFile(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	path, err := DefaultHelmCacheFile()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".kubetail", "cache", "cluster-update-check.json"), path)
+}

--- a/modules/cli/internal/updatecheck/updatecheck_test.go
+++ b/modules/cli/internal/updatecheck/updatecheck_test.go
@@ -437,9 +437,9 @@ func TestGetInstalledHelmChartVersion(t *testing.T) {
 			want:     "",
 		},
 		{
-			name:     "list error",
-			err:      errors.New("connection refused"),
-			want:     "",
+			name: "list error",
+			err:  errors.New("connection refused"),
+			want: "",
 		},
 		{
 			name:     "single release",

--- a/modules/cli/pkg/config/config.go
+++ b/modules/cli/pkg/config/config.go
@@ -98,6 +98,14 @@ func DefaultLocalStorageDir() (string, error) {
 	return filepath.Join(home, ".kubetail"), nil
 }
 
+func DefaultCacheDir() (string, error) {
+	dir, err := DefaultLocalStorageDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cache"), nil
+}
+
 func DefaultConfigPath(format string) (string, error) {
 	dir, err := DefaultLocalStorageDir()
 	if err != nil {

--- a/modules/cli/pkg/config/config_test.go
+++ b/modules/cli/pkg/config/config_test.go
@@ -51,6 +51,14 @@ commands:
     tail: 30
 `
 
+func TestDefaultCacheDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	dir, err := DefaultCacheDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".kubetail", "cache"), dir)
+}
+
 func TestDefaultCLIConfig(t *testing.T) {
 	cfg := DefaultCLIConfig()
 	assert.NotNil(t, cfg)


### PR DESCRIPTION
## Summary

Adds an opt-out background update check to the CLI so users are notified when a newer release is available. The check polls the GitHub releases API in the background while the user's command runs and prints a one-line notification on exit if a newer version is found.

## Key Changes

- New `modules/cli/internal/updatecheck` package implementing the GitHub release lookup, semver comparison, on-disk caching, and async refresh, with full unit test coverage.
- Wired into the root command via `PersistentPreRunE`/`PersistentPostRunE` so the check runs once per invocation without blocking command execution.
- Added a `general.update_check` config option (enabled by default) to allow disabling the behavior.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused