### PR TITLE
🎣 Fix thin-border selection bug and refactor code

### DIFF
--- a/dashboard-ui/src/pages/console/main.test.tsx
+++ b/dashboard-ui/src/pages/console/main.test.tsx
@@ -201,6 +201,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      anchorCol: undefined as ViewerColumn | undefined,
       isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
@@ -261,6 +262,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      anchorCol: undefined as ViewerColumn | undefined,
       isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
@@ -337,6 +339,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      anchorCol: undefined as ViewerColumn | undefined,
       isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),
@@ -372,62 +375,6 @@ describe('Main', () => {
       expect(messageCell.classList.contains('select-none')).toBe(true);
     });
 
-    it('single selected cell has all 4 edge shadows', () => {
-      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      const shadow = messageCell.style.boxShadow;
-      expect(shadow).toContain('inset 0 2px 0 0'); // top
-      expect(shadow).toContain('inset 0 -2px 0 0'); // bottom
-      expect(shadow).toContain('inset 2px 0 0 0'); // left
-      expect(shadow).toContain('inset -2px 0 0 0'); // right
-    });
-
-    it('non-selected cells have no boxShadow', () => {
-      render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} />);
-      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
-      expect(timestampCell.style.boxShadow).toBe('');
-    });
-
-    it('adjacent selected cells share edges (no inner border)', () => {
-      render(
-        <RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />,
-      );
-      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      // Timestamp: has left edge, no right edge (Message is adjacent)
-      expect(timestampCell.style.boxShadow).toContain('inset 2px 0 0 0'); // left
-      expect(timestampCell.style.boxShadow).not.toContain('inset -2px 0 0 0'); // no right
-      // Message: no left edge (Timestamp is adjacent), has right edge
-      expect(messageCell.style.boxShadow).not.toContain('inset 2px 0 0 0'); // no left
-      expect(messageCell.style.boxShadow).toContain('inset -2px 0 0 0'); // right
-    });
-
-    it('cell with selectedCellColsAbove has no top border', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          selectedCellCols={new Set([ViewerColumn.Message])}
-          selectedCellColsAbove={new Set([ViewerColumn.Message])}
-        />,
-      );
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      expect(messageCell.style.boxShadow).not.toContain('inset 0 2px 0 0'); // no top
-      expect(messageCell.style.boxShadow).toContain('inset 0 -2px 0 0'); // bottom
-    });
-
-    it('cell with selectedCellColsBelow has no bottom border', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          selectedCellCols={new Set([ViewerColumn.Message])}
-          selectedCellColsBelow={new Set([ViewerColumn.Message])}
-        />,
-      );
-      const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
-      expect(messageCell.style.boxShadow).toContain('inset 0 2px 0 0'); // top
-      expect(messageCell.style.boxShadow).not.toContain('inset 0 -2px 0 0'); // no bottom
-    });
-
     it('selected cell in text-select mode has userSelect text style', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCellTextSelectable />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
@@ -456,56 +403,6 @@ describe('Main', () => {
       render(<RecordRow {...defaultProps} selectedCellCols={new Set([ViewerColumn.Message])} isCursorText={false} />);
       const messageCell = document.querySelector('[data-col-id="Message"]') as HTMLElement;
       expect(messageCell.classList.contains('cursor-default')).toBe(true);
-    });
-
-    it('ColorDot cell has selection box-shadow when both neighbors are selected', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
-          selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
-        />,
-      );
-      const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
-      expect(colorDotCell.style.boxShadow).not.toBe('');
-    });
-
-    it('ColorDot cell has no selection box-shadow when only one neighbor is selected', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
-          selectedCellCols={new Set([ViewerColumn.Message])}
-        />,
-      );
-      const colorDotCell = document.querySelector('[data-col-id="Color Dot"]') as HTMLElement;
-      expect(colorDotCell.style.boxShadow).toBe('');
-    });
-
-    it('selected cell adjacent to ColorDot has no inner border when other side also selected', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
-          selectedCellCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
-        />,
-      );
-      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
-      // Timestamp should NOT have a right border since Message (across ColorDot) is also selected
-      expect(timestampCell.style.boxShadow).not.toContain('inset -2px 0 0 0');
-    });
-
-    it('selected cell adjacent to ColorDot has border when other side is not selected', () => {
-      render(
-        <RecordRow
-          {...defaultProps}
-          visibleCols={new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message])}
-          selectedCellCols={new Set([ViewerColumn.Timestamp])}
-        />,
-      );
-      const timestampCell = document.querySelector('[data-col-id="Timestamp"]') as HTMLElement;
-      // Timestamp SHOULD have a right border since Message is not selected
-      expect(timestampCell.style.boxShadow).toContain('inset -2px 0 0 0');
     });
   });
 
@@ -543,6 +440,7 @@ describe('Main', () => {
       selectedCellCols: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsAbove: undefined as Set<ViewerColumn> | undefined,
       selectedCellColsBelow: undefined as Set<ViewerColumn> | undefined,
+      anchorCol: undefined as ViewerColumn | undefined,
       isCursorText: true,
       isCellTextSelectable: false,
       measureElement: vi.fn(),

--- a/dashboard-ui/src/pages/console/main.tsx
+++ b/dashboard-ui/src/pages/console/main.tsx
@@ -32,7 +32,8 @@ import type {
 } from '@/components/widgets/log-viewer';
 
 import { CellContextMenu } from './context-menu';
-import { useSelection } from './selection';
+import { SelectionOverlay } from './selection-overlay';
+import { hasMultipleSelectedCells, useSelection } from './selection';
 import { PageContext, ViewerColumn } from './shared';
 import { isFollowAtom, isWrapAtom, visibleColsAtom } from './state';
 
@@ -41,6 +42,9 @@ const DEFAULT_INITIAL_POSITION = { type: 'tail' } satisfies LogViewerInitialPosi
 const BATCH_SIZE_INITIAL = 300;
 const BATCH_SIZE_REGULAR = 250;
 const LOG_RECORD_ROW_HEIGHT = 24;
+// Width of the leading Pos column. Used both to build the row's grid template
+// and by SelectionOverlay to position cell rects — the two must match.
+const POS_COL_WIDTH = 48;
 const HAS_MORE_BEFORE_ROW_HEIGHT = 24;
 const HAS_MORE_AFTER_ROW_HEIGHT = 24;
 const IS_REFRESHING_ROW_HEIGHT = 24;
@@ -102,6 +106,11 @@ function useMeasureWidths() {
 
   const pendingRef = useRef(newDefaultWidths());
   const measuredRef = useRef(new WeakSet<Element>());
+  // Tracks which fields changed since the last flush so we only swap the
+  // affected reference. A new colWidths Map reference busts RecordRow's memo
+  // for every row, so reusing it when only maxRowWidth changed avoids a
+  // cascade of unrelated re-renders during scroll-driven measurement.
+  const dirtyRef = useRef({ maxRowWidth: false, colWidths: false });
 
   const rafIDRef = useRef<number | null>(null);
 
@@ -118,10 +127,14 @@ function useMeasureWidths() {
     rafIDRef.current = requestAnimationFrame(() => {
       rafIDRef.current = null;
       const pending = pendingRef.current;
-      setWidths({
-        maxRowWidth: pending.maxRowWidth,
-        colWidths: new Map(pending.colWidths),
-      });
+      const dirty = dirtyRef.current;
+      if (!dirty.maxRowWidth && !dirty.colWidths) return;
+      setWidths((prev) => ({
+        maxRowWidth: dirty.maxRowWidth ? pending.maxRowWidth : prev.maxRowWidth,
+        colWidths: dirty.colWidths ? new Map(pending.colWidths) : prev.colWidths,
+      }));
+      dirty.maxRowWidth = false;
+      dirty.colWidths = false;
     });
   }, []);
 
@@ -134,6 +147,7 @@ function useMeasureWidths() {
       const next = Math.max(el.scrollWidth, prev);
       if (next !== prev) {
         pendingRef.current.maxRowWidth = next;
+        dirtyRef.current.maxRowWidth = true;
         flush();
       }
     },
@@ -160,6 +174,7 @@ function useMeasureWidths() {
       const next = Math.max(contentWidth + CELL_HORIZONTAL_PADDING_PX, prev ?? 0);
       if (next !== prev) {
         pendingColWidths.set(col, next);
+        dirtyRef.current.colWidths = true;
         flush();
       }
     },
@@ -173,6 +188,7 @@ function useMeasureWidths() {
     }
     pendingRef.current = newDefaultWidths();
     measuredRef.current = new WeakSet();
+    dirtyRef.current = { maxRowWidth: false, colWidths: false };
     setWidths(newDefaultWidths);
     setTriggerID((id) => id + 1);
   }, []);
@@ -382,24 +398,10 @@ const getAttribute = (record: LogRecord, col: ViewerColumn, timezone: string, ti
 };
 
 function selectionBoxShadow(isTop: boolean, isBottom: boolean): string | undefined {
-  if (isTop && isBottom) return 'inset 0 1px 0 0 var(--color-blue-500), inset 0 -1px 0 0 var(--color-blue-500)';
-  if (isTop) return 'inset 0 1px 0 0 var(--color-blue-500)';
-  if (isBottom) return 'inset 0 -1px 0 0 var(--color-blue-500)';
+  if (isTop && isBottom) return 'inset 0 2px 0 0 var(--color-blue-500), inset 0 -2px 0 0 var(--color-blue-500)';
+  if (isTop) return 'inset 0 2px 0 0 var(--color-blue-500)';
+  if (isBottom) return 'inset 0 -2px 0 0 var(--color-blue-500)';
   return undefined;
-}
-
-function cellSelectionBoxShadow(
-  isTop: boolean,
-  isBottom: boolean,
-  isLeft: boolean,
-  isRight: boolean,
-): string | undefined {
-  const shadows: string[] = [];
-  if (isTop) shadows.push('inset 0 2px 0 0 var(--color-blue-500)');
-  if (isBottom) shadows.push('inset 0 -2px 0 0 var(--color-blue-500)');
-  if (isLeft) shadows.push('inset 2px 0 0 0 var(--color-blue-500)');
-  if (isRight) shadows.push('inset -2px 0 0 0 var(--color-blue-500)');
-  return shadows.length > 0 ? shadows.join(', ') : undefined;
 }
 
 type RecordRowProps = {
@@ -417,6 +419,7 @@ type RecordRowProps = {
   selectedCellCols: Set<ViewerColumn> | undefined;
   selectedCellColsAbove: Set<ViewerColumn> | undefined;
   selectedCellColsBelow: Set<ViewerColumn> | undefined;
+  anchorCol: ViewerColumn | undefined;
   isCursorText: boolean;
   isCellTextSelectable: boolean;
   measureElement: (node: Element | null) => void;
@@ -442,6 +445,7 @@ export const RecordRow = memo(
     selectedCellCols,
     selectedCellColsAbove,
     selectedCellColsBelow,
+    anchorCol,
     isCursorText,
     isCellTextSelectable,
     measureElement,
@@ -495,36 +499,6 @@ export const RecordRow = memo(
         cellBg = isTimestamp ? 'bg-chrome-200' : row.index % 2 !== 0 && 'bg-chrome-100';
       }
 
-      // ColorDot is visually selected when both adjacent columns are selected
-      const isColorDotVisuallySelected =
-        isColorDot &&
-        i > 0 &&
-        i < colsArray.length - 1 &&
-        (selectedCellCols?.has(colsArray[i - 1]) ?? false) &&
-        (selectedCellCols?.has(colsArray[i + 1]) ?? false);
-
-      let cellShadow: string | undefined;
-      if (isCellSelected) {
-        const isEdgeTop = !selectedCellColsAbove?.has(col);
-        const isEdgeBottom = !selectedCellColsBelow?.has(col);
-        // Skip over ColorDot when checking adjacent selected cells
-        let prevIdx = i - 1;
-        if (prevIdx >= 0 && colsArray[prevIdx] === ViewerColumn.ColorDot) prevIdx -= 1;
-        let nextIdx = i + 1;
-        if (nextIdx < colsArray.length && colsArray[nextIdx] === ViewerColumn.ColorDot) nextIdx += 1;
-        const isEdgeLeft = prevIdx < 0 || !selectedCellCols!.has(colsArray[prevIdx]);
-        const isEdgeRight = nextIdx >= colsArray.length || !selectedCellCols!.has(colsArray[nextIdx]);
-        cellShadow = cellSelectionBoxShadow(isEdgeTop, isEdgeBottom, isEdgeLeft, isEdgeRight);
-      } else if (isColorDotVisuallySelected) {
-        const aboveAlsoVisual =
-          (selectedCellColsAbove?.has(colsArray[i - 1]) ?? false) &&
-          (selectedCellColsAbove?.has(colsArray[i + 1]) ?? false);
-        const belowAlsoVisual =
-          (selectedCellColsBelow?.has(colsArray[i - 1]) ?? false) &&
-          (selectedCellColsBelow?.has(colsArray[i + 1]) ?? false);
-        cellShadow = cellSelectionBoxShadow(!aboveAlsoVisual, !belowAlsoVisual, false, false);
-      }
-
       const isNativeTextSelectable = isCellSelected && isCellTextSelectable;
 
       const cellClassName = cn(
@@ -542,7 +516,6 @@ export const RecordRow = memo(
           userSelect: 'text' as const,
           WebkitUserSelect: 'text' as const,
         }),
-        ...(cellShadow && { boxShadow: cellShadow }),
       };
 
       els.push(
@@ -586,7 +559,7 @@ export const RecordRow = memo(
         data-row-key={row.key}
         role="row"
         aria-selected={isSelected}
-        className={cn('absolute top-0 left-0 grid leading-6 group', selectedCellCols && 'z-10')}
+        className="absolute top-0 left-0 grid leading-6 group"
         style={{
           gridTemplateColumns: gridTemplate,
           minWidth: isWrap ? '100%' : maxRowWidth || '100%',
@@ -597,6 +570,18 @@ export const RecordRow = memo(
         }}
       >
         {els}
+        {selectedCellCols && (
+          <SelectionOverlay
+            selectedCols={selectedCellCols}
+            selectedColsAbove={selectedCellColsAbove}
+            selectedColsBelow={selectedCellColsBelow}
+            anchorCol={anchorCol}
+            visibleCols={visibleCols}
+            colWidths={colWidths}
+            posColWidth={POS_COL_WIDTH}
+            rowWidth={maxRowWidth}
+          />
+        )}
       </div>
     );
   },
@@ -616,6 +601,7 @@ export const RecordRow = memo(
     if (prev.selectedCellCols !== next.selectedCellCols) return false;
     if (prev.selectedCellColsAbove !== next.selectedCellColsAbove) return false;
     if (prev.selectedCellColsBelow !== next.selectedCellColsBelow) return false;
+    if (prev.anchorCol !== next.anchorCol) return false;
     if (prev.isCursorText !== next.isCursorText && (prev.selectedCellCols || next.selectedCellCols)) return false;
     if (prev.isCellTextSelectable !== next.isCellTextSelectable && (prev.selectedCellCols || next.selectedCellCols))
       return false;
@@ -654,6 +640,7 @@ export const Main = () => {
     selectionTopKeys,
     selectionBottomKeys,
     selectedCells,
+    anchorCell,
     isTextSelectMode,
     isCursorText,
     handleRowMouseDown,
@@ -664,10 +651,14 @@ export const Main = () => {
   // Generate grid template
   const gridTemplate = useMemo(
     () =>
-      // Key column (auto) + visible columns
-      `3rem ${[...visibleCols].map((col) => (col === ViewerColumn.Message ? '1fr' : 'auto')).join(' ')}`,
+      // Pos column + visible columns. Message uses `1fr` to fill remaining
+      // width; the rest are content-sized. Pos width must match POS_COL_WIDTH
+      // because SelectionOverlay uses it to position cell rects.
+      `${POS_COL_WIDTH}px ${[...visibleCols].map((col) => (col === ViewerColumn.Message ? '1fr' : 'auto')).join(' ')}`,
     [visibleCols],
   );
+
+  const isMultiCellSelection = hasMultipleSelectedCells(selectedCells);
 
   // Reset column widths and selection when loading new data
   useEffect(() => {
@@ -798,6 +789,9 @@ export const Main = () => {
                     selectedCellCols={selectedCells.get(virtualRow.key)}
                     selectedCellColsAbove={selectedCells.get(virtualRow.key - 1)}
                     selectedCellColsBelow={selectedCells.get(virtualRow.key + 1)}
+                    anchorCol={
+                      isMultiCellSelection && anchorCell?.rowKey === virtualRow.key ? anchorCell.col : undefined
+                    }
                     isCursorText={isCursorText}
                     isCellTextSelectable={isTextSelectMode && selectedCells.has(virtualRow.key)}
                     measureRowElement={measureRowElement}

--- a/dashboard-ui/src/pages/console/selection-overlay.test.tsx
+++ b/dashboard-ui/src/pages/console/selection-overlay.test.tsx
@@ -1,0 +1,172 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render } from '@testing-library/react';
+
+import { SelectionOverlay } from './selection-overlay';
+import { ViewerColumn } from './shared';
+
+const POS_COL_WIDTH = 48;
+
+function rectFor(col: ViewerColumn) {
+  return document.querySelector<HTMLElement>(`[data-overlay-col="${col}"]`);
+}
+
+function anchorRect() {
+  return document.querySelector<HTMLElement>('[data-overlay-anchor="true"]');
+}
+
+const defaults = {
+  visibleCols: new Set([ViewerColumn.Timestamp, ViewerColumn.ColorDot, ViewerColumn.Message]),
+  colWidths: new Map<ViewerColumn, number>([
+    [ViewerColumn.Timestamp, 100],
+    [ViewerColumn.ColorDot, 20],
+    [ViewerColumn.Message, 400],
+  ]),
+  posColWidth: POS_COL_WIDTH,
+  rowWidth: 0,
+  selectedColsAbove: undefined as Set<ViewerColumn> | undefined,
+  selectedColsBelow: undefined as Set<ViewerColumn> | undefined,
+  anchorCol: undefined as ViewerColumn | undefined,
+};
+
+describe('SelectionOverlay', () => {
+  it('renders one rect with all 4 borders for an isolated selected cell', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Message])} />);
+    const r = rectFor(ViewerColumn.Message);
+    expect(r).not.toBeNull();
+    expect(r!.style.borderTopWidth).toBe('2px');
+    expect(r!.style.borderBottomWidth).toBe('2px');
+    expect(r!.style.borderLeftWidth).toBe('2px');
+    expect(r!.style.borderRightWidth).toBe('2px');
+  });
+
+  it('horizontally adjacent selected cells share an edge (no inner border)', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />);
+    const ts = rectFor(ViewerColumn.Timestamp);
+    const msg = rectFor(ViewerColumn.Message);
+    expect(ts!.style.borderLeftWidth).toBe('2px');
+    expect(ts!.style.borderRightWidth).toBe('0px');
+    expect(msg!.style.borderLeftWidth).toBe('0px');
+    expect(msg!.style.borderRightWidth).toBe('2px');
+  });
+
+  it('cell with same column selected above has no top border', () => {
+    render(
+      <SelectionOverlay
+        {...defaults}
+        selectedCols={new Set([ViewerColumn.Message])}
+        selectedColsAbove={new Set([ViewerColumn.Message])}
+      />,
+    );
+    const r = rectFor(ViewerColumn.Message);
+    expect(r!.style.borderTopWidth).toBe('0px');
+    expect(r!.style.borderBottomWidth).toBe('2px');
+  });
+
+  it('cell with same column selected below has no bottom border', () => {
+    render(
+      <SelectionOverlay
+        {...defaults}
+        selectedCols={new Set([ViewerColumn.Message])}
+        selectedColsBelow={new Set([ViewerColumn.Message])}
+      />,
+    );
+    const r = rectFor(ViewerColumn.Message);
+    expect(r!.style.borderTopWidth).toBe('2px');
+    expect(r!.style.borderBottomWidth).toBe('0px');
+  });
+
+  it('ColorDot is included with top/bottom borders when both neighbors selected', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />);
+    const dot = rectFor(ViewerColumn.ColorDot);
+    expect(dot).not.toBeNull();
+    expect(dot!.style.borderTopWidth).toBe('2px');
+    expect(dot!.style.borderBottomWidth).toBe('2px');
+    expect(dot!.style.borderLeftWidth).toBe('0px');
+    expect(dot!.style.borderRightWidth).toBe('0px');
+  });
+
+  it('ColorDot is not included when only one neighbor is selected', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Message])} />);
+    expect(rectFor(ViewerColumn.ColorDot)).toBeNull();
+  });
+
+  it('ColorDot has no top border when both neighbors selected above (continuous run)', () => {
+    render(
+      <SelectionOverlay
+        {...defaults}
+        selectedCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
+        selectedColsAbove={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])}
+      />,
+    );
+    const dot = rectFor(ViewerColumn.ColorDot);
+    expect(dot!.style.borderTopWidth).toBe('0px');
+    expect(dot!.style.borderBottomWidth).toBe('2px');
+  });
+
+  it('skips ColorDot when computing left/right adjacency', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Timestamp, ViewerColumn.Message])} />);
+    const ts = rectFor(ViewerColumn.Timestamp);
+    expect(ts!.style.borderRightWidth).toBe('0px');
+  });
+
+  it('positions rects from colWidths and posColWidth, height fills row', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Message])} />);
+    const r = rectFor(ViewerColumn.Message);
+    // x = posColWidth (48) + Timestamp (100) + ColorDot (20) = 168
+    expect(r!.style.left).toBe('168px');
+    expect(r!.style.width).toBe('400px');
+    // The rect fills the row's height by stretching top→bottom of its parent.
+    expect(r!.style.top).toBe('0px');
+    expect(r!.style.bottom).toBe('0px');
+  });
+
+  it('renders nothing when selectedCols is empty', () => {
+    const { container } = render(<SelectionOverlay {...defaults} selectedCols={new Set()} />);
+    expect(container.querySelectorAll('[data-overlay-col]').length).toBe(0);
+  });
+
+  it('renders an anchor rect with full 4-side border when anchorCol is set', () => {
+    render(
+      <SelectionOverlay
+        {...defaults}
+        selectedCols={new Set([ViewerColumn.Message])}
+        anchorCol={ViewerColumn.Message}
+      />,
+    );
+    const a = anchorRect();
+    expect(a).not.toBeNull();
+    expect(a!.style.borderTopWidth).toBe('2px');
+    expect(a!.style.borderBottomWidth).toBe('2px');
+    expect(a!.style.borderLeftWidth).toBe('2px');
+    expect(a!.style.borderRightWidth).toBe('2px');
+  });
+
+  it('anchor includes a corner-dot indicator', () => {
+    render(
+      <SelectionOverlay
+        {...defaults}
+        selectedCols={new Set([ViewerColumn.Message])}
+        anchorCol={ViewerColumn.Message}
+      />,
+    );
+    expect(document.querySelector('[data-overlay-anchor-dot]')).not.toBeNull();
+  });
+
+  it('does not render anchor rect when anchorCol is undefined', () => {
+    render(<SelectionOverlay {...defaults} selectedCols={new Set([ViewerColumn.Message])} />);
+    expect(anchorRect()).toBeNull();
+  });
+});

--- a/dashboard-ui/src/pages/console/selection-overlay.tsx
+++ b/dashboard-ui/src/pages/console/selection-overlay.tsx
@@ -1,0 +1,202 @@
+// Copyright 2024 The Kubetail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { memo, useMemo } from 'react';
+
+import { isSelectableViewerColumn } from './selection';
+import { ViewerColumn } from './shared';
+
+const BORDER_WIDTH = '2px';
+const BORDER_COLOR = 'var(--color-blue-500)';
+
+type Edges = { top: boolean; bottom: boolean; left: boolean; right: boolean };
+
+type SelectionRect = {
+  col: ViewerColumn;
+  x: number;
+  w: number;
+  edges: Edges;
+};
+
+type Props = {
+  selectedCols: Set<ViewerColumn>;
+  selectedColsAbove: Set<ViewerColumn> | undefined;
+  selectedColsBelow: Set<ViewerColumn> | undefined;
+  // The anchor's column when the anchor is in this row, otherwise undefined.
+  // The anchor's rect is drawn with all four borders + a corner-dot indicator.
+  anchorCol: ViewerColumn | undefined;
+  visibleCols: Set<ViewerColumn>;
+  colWidths: Map<ViewerColumn, number>;
+  posColWidth: number;
+  // Total rendered width of the row. Required for accurate Message-column
+  // positioning — Message uses `1fr` in the grid, so its rendered width is
+  // `rowWidth − Pos − sum(other cols)`. Pass 0 when not yet measured; the
+  // overlay falls back to the Message column's measured content width.
+  rowWidth: number;
+};
+
+function computeRowSelectionRects(
+  selectedCols: Set<ViewerColumn>,
+  selectedColsAbove: Set<ViewerColumn> | undefined,
+  selectedColsBelow: Set<ViewerColumn> | undefined,
+  visibleCols: Set<ViewerColumn>,
+  colWidths: Map<ViewerColumn, number>,
+  posColWidth: number,
+  rowWidth: number,
+): SelectionRect[] {
+  const cols = [...visibleCols];
+  const selectableCols = cols.filter(isSelectableViewerColumn);
+
+  // Message uses `1fr` in the row's grid template, so its rendered width is
+  // `rowWidth − Pos − sum(other cols)` rather than its measured colWidth.
+  const measuredMessage = colWidths.get(ViewerColumn.Message) ?? 0;
+  let widthOfNonMessageCols = posColWidth;
+  cols.forEach((c) => {
+    if (c !== ViewerColumn.Message) widthOfNonMessageCols += colWidths.get(c) ?? 0;
+  });
+  const stretchedMessage =
+    visibleCols.has(ViewerColumn.Message) && rowWidth > 0
+      ? Math.max(measuredMessage, rowWidth - widthOfNonMessageCols)
+      : measuredMessage;
+
+  const widthOf = (col: ViewerColumn) => (col === ViewerColumn.Message ? stretchedMessage : (colWidths.get(col) ?? 0));
+
+  // x-offset per visible column, including the leading Pos column.
+  const colX = new Map<ViewerColumn, number>();
+  let x = posColWidth;
+  cols.forEach((col) => {
+    colX.set(col, x);
+    x += widthOf(col);
+  });
+
+  // For ColorDot: "selected here" means both selectable neighbors are selected
+  // in `selSet` (continuous-run rule). For other columns: ordinary membership.
+  const isSelectedIn = (selSet: Set<ViewerColumn> | undefined, i: number): boolean => {
+    if (!selSet) return false;
+    const col = cols[i];
+    if (col === ViewerColumn.ColorDot) {
+      return i > 0 && i < cols.length - 1 && selSet.has(cols[i - 1]) && selSet.has(cols[i + 1]);
+    }
+    return selSet.has(col);
+  };
+
+  const out: SelectionRect[] = [];
+  cols.forEach((col, i) => {
+    if (!isSelectedIn(selectedCols, i)) return;
+
+    if (col === ViewerColumn.ColorDot) {
+      // ColorDot acts as an interior connector — only top/bottom edges.
+      out.push({
+        col,
+        x: colX.get(col) ?? 0,
+        w: widthOf(col),
+        edges: {
+          top: !isSelectedIn(selectedColsAbove, i),
+          bottom: !isSelectedIn(selectedColsBelow, i),
+          left: false,
+          right: false,
+        },
+      });
+      return;
+    }
+
+    // Left/right adjacency hops over ColorDot via the selectable-only list.
+    const sIdx = selectableCols.indexOf(col);
+    const leftCol = sIdx > 0 ? selectableCols[sIdx - 1] : undefined;
+    const rightCol = sIdx < selectableCols.length - 1 ? selectableCols[sIdx + 1] : undefined;
+
+    out.push({
+      col,
+      x: colX.get(col) ?? 0,
+      w: widthOf(col),
+      edges: {
+        top: !isSelectedIn(selectedColsAbove, i),
+        bottom: !isSelectedIn(selectedColsBelow, i),
+        left: leftCol === undefined || !selectedCols.has(leftCol),
+        right: rightCol === undefined || !selectedCols.has(rightCol),
+      },
+    });
+  });
+
+  return out;
+}
+
+function rectStyle(x: number, w: number, edges: Edges): React.CSSProperties {
+  return {
+    position: 'absolute',
+    left: `${x}px`,
+    top: '0px',
+    bottom: '0px',
+    width: `${w}px`,
+    boxSizing: 'border-box',
+    borderStyle: 'solid',
+    borderColor: BORDER_COLOR,
+    borderTopWidth: edges.top ? BORDER_WIDTH : '0px',
+    borderBottomWidth: edges.bottom ? BORDER_WIDTH : '0px',
+    borderLeftWidth: edges.left ? BORDER_WIDTH : '0px',
+    borderRightWidth: edges.right ? BORDER_WIDTH : '0px',
+  };
+}
+
+const ALL_EDGES: Edges = { top: true, bottom: true, left: true, right: true };
+
+// Borders are real CSS borders on empty divs (not inset box-shadows) to avoid
+// Firefox's stacked-shadow rendering quirk and to keep the chrome painting as
+// a normal layer above the cell content.
+export const SelectionOverlay = memo(
+  ({
+    selectedCols,
+    selectedColsAbove,
+    selectedColsBelow,
+    anchorCol,
+    visibleCols,
+    colWidths,
+    posColWidth,
+    rowWidth,
+  }: Props) => {
+    const rects = useMemo(
+      () =>
+        computeRowSelectionRects(
+          selectedCols,
+          selectedColsAbove,
+          selectedColsBelow,
+          visibleCols,
+          colWidths,
+          posColWidth,
+          rowWidth,
+        ),
+      [selectedCols, selectedColsAbove, selectedColsBelow, visibleCols, colWidths, posColWidth, rowWidth],
+    );
+
+    return (
+      <div className="pointer-events-none absolute inset-0">
+        {rects.map((r) => {
+          const isAnchor = r.col === anchorCol;
+          return (
+            <div
+              key={r.col}
+              data-overlay-col={r.col}
+              {...(isAnchor && { 'data-overlay-anchor': 'true' })}
+              style={rectStyle(r.x, r.w, isAnchor ? ALL_EDGES : r.edges)}
+            >
+              {isAnchor && (
+                <span data-overlay-anchor-dot aria-hidden className="absolute right-0 bottom-0 size-1.5 bg-blue-500" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  },
+);

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -27,15 +27,14 @@ import {
   computeCellRange,
   useSelection,
   useSelectionState,
-  useRowDrag,
   useCellDrag,
   useSelectionKeyboard,
 } from './selection';
 import { ViewerColumn } from './shared';
 import {
+  anchorCellAtom,
   isCursorTextAtom,
   isTextSelectModeAtom,
-  lastClickedCellAtom,
   lastClickedKeyAtom,
   selectedCellsAtom,
   selectedKeysAtom,
@@ -768,24 +767,79 @@ describe('useSelection', () => {
       );
     });
 
-    it('removes cell from selection with meta+click when already selected', () => {
-      const { result } = renderUseSelection();
+    it('cmd+click on the only selected cell clears selection and anchor', () => {
+      const { result, store } = renderUseSelection();
 
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(new Map());
+      expect(store.get(anchorCellAtom)).toBeNull();
     });
 
-    it('removes cell and cleans up empty row entry', () => {
-      const { result } = renderUseSelection();
+    it('cmd+click on a non-anchor cell removes it and leaves the anchor unchanged', () => {
+      const { result, store } = renderUseSelection();
 
+      // Click (0, Message) → anchor=(0, Message). Cmd+click (1, Pod) → anchor moves to (1, Pod).
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent()));
       act(() => result.current.handleCellMouseDown(1, ViewerColumn.Pod, clickEvent({ metaKey: true })));
-      // Now remove the only cell in row 0
+      // Cmd+click (0, Message) — toggling off a non-anchor cell. Anchor stays at (1, Pod).
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
       expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Pod])]]));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 1, col: ViewerColumn.Pod });
+    });
+
+    it('cmd+click on the anchor moves the anchor to the next selected cell on the right', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Build selection {(5, Pod), (5, Message)} with anchor at (5, Pod).
+      // Container is intentionally unselected so the next-right search must skip it.
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Message, clickEvent()));
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 5, col: ViewerColumn.Pod });
+
+      // Cmd+click on anchor (5, Pod) — anchor jumps right past the unselected Container to Message.
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map([[5, new Set([ViewerColumn.Message])]]));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 5, col: ViewerColumn.Message });
+    });
+
+    it('cmd+click on the anchor wraps to the next row when no selected cell remains to the right', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Selection {(5, Pod), (6, Pod)}, anchor at (5, Pod).
+      act(() => result.current.handleCellMouseDown(6, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 5, col: ViewerColumn.Pod });
+
+      // Cmd+click anchor (5, Pod) — no selected cell to the right in row 5, so wrap to row 6.
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Pod, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map([[6, new Set([ViewerColumn.Pod])]]));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 6, col: ViewerColumn.Pod });
+    });
+
+    it('cmd+click on the anchor wraps around to the first selected cell when at the end', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Selection {(4, Pod), (5, Message)}, anchor at (5, Message) (the last cell in reading order).
+      act(() => result.current.handleCellMouseDown(4, ViewerColumn.Pod, clickEvent()));
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Message, clickEvent({ metaKey: true })));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 5, col: ViewerColumn.Message });
+
+      // Cmd+click anchor (5, Message) — nothing later, wrap to first selected cell.
+      act(() => result.current.handleCellMouseDown(5, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(result.current.selectedCells).toEqual(new Map([[4, new Set([ViewerColumn.Pod])]]));
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 4, col: ViewerColumn.Pod });
     });
 
     it('adds cell with ctrl+click', () => {
@@ -887,48 +941,47 @@ describe('useSelection', () => {
       );
     });
 
-    it('shift+click after cmd+click is additive to existing selection', () => {
+    it('shift+click after cmd+click replaces selection with rectangle from new anchor', () => {
       const { result } = renderUseSelection((store) => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
       });
 
-      // Select a cell, then Cmd+click another
+      // Click (0, Pod), then Cmd+click (0, Message) — anchor moves to (0, Message)
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
       act(() => {
         fireEvent.mouseUp(document);
       });
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Message, clickEvent({ metaKey: true })));
 
-      // Shift+click should add the range to existing selection, not replace it
+      // Shift+click replaces with rectangle from anchor (0, Message) to (2, Message).
+      // The previously-selected (0, Pod) cell is dropped — this is spreadsheet behavior.
       act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
-          [0, new Set([ViewerColumn.Pod, ViewerColumn.Message])],
+          [0, new Set([ViewerColumn.Message])],
           [1, new Set([ViewerColumn.Message])],
           [2, new Set([ViewerColumn.Message])],
         ]),
       );
     });
 
-    it('shift+click merges range columns with existing columns in same row', () => {
+    it('shift+click replaces selection — does not merge with prior columns on the same row', () => {
       const { result } = renderUseSelection((store) => {
         store.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
       });
 
-      // Select Pod in row 0
+      // Click (0, Pod), then Cmd+click (1, Container) — anchor moves to (1, Container)
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
       act(() => {
         fireEvent.mouseUp(document);
       });
-      // Cmd+click Container in row 1 (sets new anchor to row 1, Container)
       act(() => result.current.handleCellMouseDown(1, ViewerColumn.Container, clickEvent({ metaKey: true })));
-      // Shift+click Message in row 2 — range is Container+Message in rows 1-2, merged with existing
+      // Shift+click (2, Message) — replaces with rectangle (1,Container)↔(2,Message)
       act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
 
       expect(result.current.selectedCells).toEqual(
         new Map([
-          [0, new Set([ViewerColumn.Pod])],
           [1, new Set([ViewerColumn.Container, ViewerColumn.Message])],
           [2, new Set([ViewerColumn.Container, ViewerColumn.Message])],
         ]),
@@ -1383,12 +1436,15 @@ describe('useSelection', () => {
       });
     });
 
-    it('sets lastClickedCell on mouseup', () => {
+    it('sets anchor cell on mousedown (drag start), not on mouseup', () => {
       const { result, store } = renderUseSelection((s) => {
         s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
       });
 
       act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+
+      // Anchor is set immediately on mousedown — the start of the drag.
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
 
       mockElementFromPoint.mockReturnValue(makeCellEl(2, ViewerColumn.Message));
       act(() => {
@@ -1400,7 +1456,42 @@ describe('useSelection', () => {
         fireEvent.mouseUp(document);
       });
 
-      expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 2, col: ViewerColumn.Message });
+      // Anchor stays at the drag-start cell (A), not the drag-end cell (B).
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+    });
+
+    it('shift+click does not move the anchor', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      // Plain click on (0, Pod) — anchor becomes (0, Pod).
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+
+      // Shift+click on (2, Message) — extends range, but anchor must stay at (0, Pod).
+      act(() => result.current.handleCellMouseDown(2, ViewerColumn.Message, clickEvent({ shiftKey: true })));
+
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+    });
+
+    it('ctrl/cmd+click moves the anchor to the toggled cell', () => {
+      const { result, store } = renderUseSelection((s) => {
+        s.set(visibleColsAtom, new Set([ViewerColumn.Pod, ViewerColumn.Container, ViewerColumn.Message]));
+      });
+
+      act(() => result.current.handleCellMouseDown(0, ViewerColumn.Pod, clickEvent()));
+      act(() => {
+        fireEvent.mouseUp(document);
+      });
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+
+      act(() => result.current.handleCellMouseDown(1, ViewerColumn.Message, clickEvent({ metaKey: true })));
+
+      expect(store.get(anchorCellAtom)).toEqual({ rowKey: 1, col: ViewerColumn.Message });
     });
 
     it('modifier mousedown does not start drag', () => {
@@ -1836,33 +1927,6 @@ describe('useSelectionState', () => {
   });
 });
 
-describe('useRowDrag', () => {
-  it('selects a single row on plain mousedown', () => {
-    const { result } = renderWithState((state) => useRowDrag(state));
-
-    act(() => result.current.handleRowMouseDown(1, clickEvent()));
-    act(() => {
-      fireEvent.mouseUp(document);
-    });
-
-    expect(result.current.selectionTopKeys).toEqual(new Set([1]));
-    expect(result.current.selectionBottomKeys).toEqual(new Set([1]));
-  });
-
-  it('computes selection boundaries for contiguous range', () => {
-    const { result } = renderWithState((state) => useRowDrag(state));
-
-    act(() => result.current.handleRowMouseDown(0, clickEvent()));
-    act(() => {
-      fireEvent.mouseUp(document);
-    });
-    act(() => result.current.handleRowMouseDown(2, clickEvent({ shiftKey: true })));
-
-    expect(result.current.selectionTopKeys).toEqual(new Set([0]));
-    expect(result.current.selectionBottomKeys).toEqual(new Set([2]));
-  });
-});
-
 describe('useCellDrag', () => {
   it('selects a cell on click', () => {
     const { result, store } = renderWithState((state) => useCellDrag(state));
@@ -2087,7 +2151,7 @@ describe('useSelectionKeyboard', () => {
 
     act(() => {
       store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Pod])]]));
-      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Pod });
+      store.set(anchorCellAtom, { rowKey: 0, col: ViewerColumn.Pod });
     });
 
     act(() => {
@@ -2095,7 +2159,7 @@ describe('useSelectionKeyboard', () => {
     });
 
     expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
-    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
+    expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
   });
 
   it('moves selected cell left to the previous selectable column', () => {
@@ -2105,7 +2169,7 @@ describe('useSelectionKeyboard', () => {
 
     act(() => {
       store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
-      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(anchorCellAtom, { rowKey: 0, col: ViewerColumn.Message });
     });
 
     act(() => {
@@ -2113,7 +2177,7 @@ describe('useSelectionKeyboard', () => {
     });
 
     expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Pod])]]));
-    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
+    expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Pod });
   });
 
   it('moves selected cell down to the same column on the next row', () => {
@@ -2121,7 +2185,7 @@ describe('useSelectionKeyboard', () => {
 
     act(() => {
       store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
-      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(anchorCellAtom, { rowKey: 0, col: ViewerColumn.Message });
     });
 
     act(() => {
@@ -2129,7 +2193,7 @@ describe('useSelectionKeyboard', () => {
     });
 
     expect(result.current.selectedCells).toEqual(new Map([[1, new Set([ViewerColumn.Message])]]));
-    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 1, col: ViewerColumn.Message });
+    expect(store.get(anchorCellAtom)).toEqual({ rowKey: 1, col: ViewerColumn.Message });
   });
 
   it('keeps selected cell unchanged when arrow key has no target cell', () => {
@@ -2137,7 +2201,7 @@ describe('useSelectionKeyboard', () => {
 
     act(() => {
       store.set(selectedCellsAtom, new Map([[0, new Set([ViewerColumn.Message])]]));
-      store.set(lastClickedCellAtom, { rowKey: 0, col: ViewerColumn.Message });
+      store.set(anchorCellAtom, { rowKey: 0, col: ViewerColumn.Message });
     });
 
     act(() => {
@@ -2145,6 +2209,6 @@ describe('useSelectionKeyboard', () => {
     });
 
     expect(result.current.selectedCells).toEqual(new Map([[0, new Set([ViewerColumn.Message])]]));
-    expect(store.get(lastClickedCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
+    expect(store.get(anchorCellAtom)).toEqual({ rowKey: 0, col: ViewerColumn.Message });
   });
 });

--- a/dashboard-ui/src/pages/console/selection.test.tsx
+++ b/dashboard-ui/src/pages/console/selection.test.tsx
@@ -1886,7 +1886,7 @@ describe('useSelection', () => {
 });
 
 describe('useSelectionState', () => {
-  it('returns atom values and setters', () => {
+  it('returns atom values and a store handle', () => {
     const { result } = renderWithState((state) => state);
 
     expect(result.current.selectedKeys).toEqual(new Set());
@@ -1894,8 +1894,8 @@ describe('useSelectionState', () => {
     expect(result.current.visibleCols).toEqual(new Set([ViewerColumn.Message]));
     expect(result.current.isTextSelectMode).toBe(false);
     expect(result.current.isCursorText).toBe(false);
-    expect(typeof result.current.setSelectedKeys).toBe('function');
-    expect(typeof result.current.setSelectedCells).toBe('function');
+    expect(typeof result.current.store.get).toBe('function');
+    expect(typeof result.current.store.set).toBe('function');
   });
 
   it('clearSelection resets all state', () => {

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -154,8 +154,8 @@ export function computeCellRange(
   visibleCols: Set<ViewerColumn>,
 ): Map<number, Set<ViewerColumn>> {
   const cols = [...visibleCols].filter(isSelectableViewerColumn);
-  const anchorIdx = cols.indexOf(anchor.col);
-  const targetIdx = cols.indexOf(target.col);
+  const anchorIdx = isSelectableViewerColumn(anchor.col) ? cols.indexOf(anchor.col) : -1;
+  const targetIdx = isSelectableViewerColumn(target.col) ? cols.indexOf(target.col) : -1;
 
   if (anchorIdx === -1 || targetIdx === -1) {
     return new Map([[target.rowKey, new Set([target.col])]]);
@@ -206,7 +206,7 @@ function nextSelectedCellInReadingOrder(
   });
   if (ordered.length === 0) return null;
 
-  const afterColIdx = cols.indexOf(after.col);
+  const afterColIdx = isSelectableViewerColumn(after.col) ? cols.indexOf(after.col) : -1;
   const next = ordered.find((cell) => {
     const cellColIdx = cols.indexOf(cell.col);
     return cell.rowKey > after.rowKey || (cell.rowKey === after.rowKey && cellColIdx > afterColIdx);
@@ -312,6 +312,68 @@ function selectSingleCell(store: Store, cell: { rowKey: number; col: ViewerColum
   store.set(anchorCellAtom, cell);
 }
 
+/**
+ * Run a document-level drag: register mousemove/mouseup, coalesce moves into
+ * one rAF, and tear down via an AbortController. The caller plugs in:
+ *
+ * - `resolveTarget` — mouse coords → drag target (or null if not over one).
+ * - `isSameTarget` — skip redundant `onMove` calls for the same target.
+ * - `onMove` — runs once per distinct target, rAF-throttled.
+ * - `onCommit` — runs at mouseup with the most recent target. If the user
+ *   never moved, it receives `initialTarget` (so a click-without-drag still
+ *   commits the press location).
+ */
+function startDocumentDrag<T>(args: {
+  initialTarget: T;
+  resolveTarget: (x: number, y: number) => T | null;
+  isSameTarget: (a: T, b: T) => boolean;
+  onMove: (target: T) => void;
+  onCommit: (lastTarget: T) => void;
+  abortRef: React.RefObject<AbortController | null>;
+}) {
+  const { initialTarget, resolveTarget, isSameTarget, onMove, onCommit, abortRef } = args;
+
+  let rafId: number | null = null;
+  let pendingX = 0;
+  let pendingY = 0;
+  let lastTarget: T = initialTarget;
+
+  const processMove = () => {
+    rafId = null;
+    const target = resolveTarget(pendingX, pendingY);
+    if (target === null) return;
+    if (isSameTarget(target, lastTarget)) return;
+    lastTarget = target;
+    onMove(target);
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    e.preventDefault();
+    pendingX = e.clientX;
+    pendingY = e.clientY;
+    if (rafId === null) rafId = requestAnimationFrame(processMove);
+  };
+
+  const onMouseUp = (e: MouseEvent) => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+      pendingX = e.clientX;
+      pendingY = e.clientY;
+      processMove();
+    }
+    onCommit(lastTarget);
+    abortRef.current?.abort();
+    abortRef.current = null;
+  };
+
+  abortRef.current?.abort();
+  abortRef.current = new AbortController();
+  const { signal } = abortRef.current;
+  document.addEventListener('mousemove', onMouseMove, { signal });
+  document.addEventListener('mouseup', onMouseUp, { signal });
+}
+
 export function useSelectionState() {
   const store = useStore();
   const visibleCols = useAtomValue(visibleColsAtom);
@@ -364,9 +426,6 @@ export function useSelectionState() {
 export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
   const { store, dragAbortRef } = state;
 
-  const dragStartKeyRef = useRef<number | null>(null);
-  const dragEndKeyRef = useRef<number | null>(null);
-
   const handleRowMouseDown = useCallback(
     (key: number, event: React.MouseEvent) => {
       // Modifier clicks don't start a drag
@@ -384,61 +443,29 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
         return;
       }
 
-      dragStartKeyRef.current = key;
-      dragEndKeyRef.current = key;
       store.set(selectedKeysAtom, new Set([key]));
       clearCellSelection(store);
 
-      let rafId: number | null = null;
-      let pendingX = 0;
-      let pendingY = 0;
-
-      const processMove = () => {
-        rafId = null;
-        if (dragStartKeyRef.current === null) return;
-        const el = document.elementFromPoint(pendingX, pendingY);
-        const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
-        if (!rowEl) return;
-        const endKey = Number(rowEl.dataset.rowKey);
-        if (Number.isNaN(endKey) || endKey === dragEndKeyRef.current) return;
-        dragEndKeyRef.current = endKey;
-        const minKey = Math.min(dragStartKeyRef.current, endKey);
-        const maxKey = Math.max(dragStartKeyRef.current, endKey);
-        const next = new Set<number>();
-        for (let k = minKey; k <= maxKey; k += 1) next.add(k);
-        store.set(selectedKeysAtom, next);
-      };
-
-      const onMouseMove = (e: MouseEvent) => {
-        if (dragStartKeyRef.current === null) return;
-        e.preventDefault();
-        pendingX = e.clientX;
-        pendingY = e.clientY;
-        if (rafId !== null) return;
-        rafId = requestAnimationFrame(processMove);
-      };
-
-      const onMouseUp = (e: MouseEvent) => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-          rafId = null;
-          pendingX = e.clientX;
-          pendingY = e.clientY;
-          processMove();
-        }
-        store.set(lastClickedKeyAtom, dragEndKeyRef.current);
-        dragStartKeyRef.current = null;
-        dragEndKeyRef.current = null;
-        dragAbortRef.current?.abort();
-        dragAbortRef.current = null;
-      };
-
-      dragAbortRef.current?.abort();
-      dragAbortRef.current = new AbortController();
-      const { signal } = dragAbortRef.current;
-
-      document.addEventListener('mousemove', onMouseMove, { signal });
-      document.addEventListener('mouseup', onMouseUp, { signal });
+      startDocumentDrag<number>({
+        initialTarget: key,
+        resolveTarget: (x, y) => {
+          const el = document.elementFromPoint(x, y);
+          const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
+          if (!rowEl) return null;
+          const k = Number(rowEl.dataset.rowKey);
+          return Number.isNaN(k) ? null : k;
+        },
+        isSameTarget: (a, b) => a === b,
+        onMove: (endKey) => {
+          const minKey = Math.min(key, endKey);
+          const maxKey = Math.max(key, endKey);
+          const next = new Set<number>();
+          for (let k = minKey; k <= maxKey; k += 1) next.add(k);
+          store.set(selectedKeysAtom, next);
+        },
+        onCommit: (endKey) => store.set(lastClickedKeyAtom, endKey),
+        abortRef: dragAbortRef,
+      });
     },
     [store, dragAbortRef],
   );
@@ -466,9 +493,6 @@ function useSelectionEdges(selectedKeys: Set<number>) {
 
 export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
   const { store, visibleCols, dragAbortRef, scheduleCursorText } = state;
-
-  const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
-  const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
 
   const handleCellMouseDown = useCallback(
     (rowKey: number, col: ViewerColumn, event: React.MouseEvent) => {
@@ -528,8 +552,6 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       }
 
       const start = { rowKey, col };
-      cellDragStartRef.current = start;
-      cellDragEndRef.current = start;
       // Set anchor at drag-start (not drag-end) so a later Shift+click extends
       // from where the user began the selection.
       selectSingleCell(store, start);
@@ -537,57 +559,26 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       store.set(isTextSelectModeAtom, false);
       store.set(isCursorTextAtom, false);
 
-      let rafId: number | null = null;
-      let pendingX = 0;
-      let pendingY = 0;
-
-      const processMove = () => {
-        rafId = null;
-        if (cellDragStartRef.current === null) return;
-        const el = document.elementFromPoint(pendingX, pendingY);
-        const cellEl = el?.closest('[data-col-id]') as HTMLElement | null;
-        const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
-        if (!cellEl || !rowEl) return;
-        const endRowKey = Number(rowEl.dataset.rowKey);
-        const endCol = cellEl.dataset.colId as ViewerColumn | undefined;
-        if (Number.isNaN(endRowKey) || !endCol || endCol === ViewerColumn.ColorDot) return;
-        const end = { rowKey: endRowKey, col: endCol };
-        if (end.rowKey === cellDragEndRef.current?.rowKey && end.col === cellDragEndRef.current?.col) return;
-        cellDragEndRef.current = end;
-        store.set(selectedCellsAtom, computeCellRange(cellDragStartRef.current, end, visibleCols));
-      };
-
-      const onMouseMove = (e: MouseEvent) => {
-        if (cellDragStartRef.current === null) return;
-        e.preventDefault();
-        pendingX = e.clientX;
-        pendingY = e.clientY;
-        if (rafId !== null) return;
-        rafId = requestAnimationFrame(processMove);
-      };
-
-      const onMouseUp = (e: MouseEvent) => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-          rafId = null;
-          pendingX = e.clientX;
-          pendingY = e.clientY;
-          processMove();
-        }
-        if (cellDragEndRef.current) store.set(isTextSelectModeAtom, true);
-        cellDragStartRef.current = null;
-        cellDragEndRef.current = null;
-        dragAbortRef.current?.abort();
-        dragAbortRef.current = null;
-        scheduleCursorText();
-      };
-
-      dragAbortRef.current?.abort();
-      dragAbortRef.current = new AbortController();
-      const { signal } = dragAbortRef.current;
-
-      document.addEventListener('mousemove', onMouseMove, { signal });
-      document.addEventListener('mouseup', onMouseUp, { signal });
+      startDocumentDrag<{ rowKey: number; col: ViewerColumn }>({
+        initialTarget: start,
+        resolveTarget: (x, y) => {
+          const el = document.elementFromPoint(x, y);
+          const cellEl = el?.closest('[data-col-id]') as HTMLElement | null;
+          const rowEl = el?.closest('[data-row-key]') as HTMLElement | null;
+          if (!cellEl || !rowEl) return null;
+          const endRowKey = Number(rowEl.dataset.rowKey);
+          const endCol = cellEl.dataset.colId as ViewerColumn | undefined;
+          if (Number.isNaN(endRowKey) || !endCol || endCol === ViewerColumn.ColorDot) return null;
+          return { rowKey: endRowKey, col: endCol };
+        },
+        isSameTarget: (a, b) => a.rowKey === b.rowKey && a.col === b.col,
+        onMove: (end) => store.set(selectedCellsAtom, computeCellRange(start, end, visibleCols)),
+        onCommit: () => {
+          store.set(isTextSelectModeAtom, true);
+          scheduleCursorText();
+        },
+        abortRef: dragAbortRef,
+      });
     },
     [store, visibleCols, dragAbortRef, scheduleCursorText],
   );

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -75,10 +75,6 @@ export function getPlainAttribute(
   }
 }
 
-/**
- * formatRow - Formats a single record as tab-separated column values.
- * ColorDot is skipped. When filter is provided, only matching columns are included.
- */
 function formatRow(
   record: LogRecord,
   visibleCols: Set<ViewerColumn>,
@@ -95,10 +91,6 @@ function formatRow(
   return parts.join('\t');
 }
 
-/**
- * formatRowsForCopy - Formats an array of log records as copyable text.
- * Columns are tab-separated, rows are newline-separated. ColorDot is skipped.
- */
 export function formatRowsForCopy(
   records: LogRecord[],
   visibleCols: Set<ViewerColumn>,
@@ -108,11 +100,6 @@ export function formatRowsForCopy(
   return records.map((record) => formatRow(record, visibleCols, timezone, timestampFormat)).join('\n');
 }
 
-/**
- * formatCellsForCopy - Formats selected cells as copyable text.
- * Columns are tab-separated within a row, rows are newline-separated. ColorDot is skipped.
- * Rows are sorted by key ascending; only selected columns (in visibleCols order) are included.
- */
 export function formatCellsForCopy(
   selectedCells: Map<number, Set<ViewerColumn>>,
   visibleCols: Set<ViewerColumn>,

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -26,7 +26,7 @@ import { ViewerColumn } from './shared';
 import {
   isCursorTextAtom,
   isTextSelectModeAtom,
-  lastClickedCellAtom,
+  anchorCellAtom,
   lastClickedKeyAtom,
   selectedCellsAtom,
   selectedKeysAtom,
@@ -35,7 +35,7 @@ import {
 
 type SelectableViewerColumn = Exclude<ViewerColumn, ViewerColumn.ColorDot>;
 
-function isSelectableViewerColumn(col: ViewerColumn): col is SelectableViewerColumn {
+export function isSelectableViewerColumn(col: ViewerColumn): col is SelectableViewerColumn {
   return col !== ViewerColumn.ColorDot;
 }
 
@@ -133,6 +133,18 @@ export function formatCellsForCopy(
 }
 
 /**
+ * hasMultipleSelectedCells - True when the selection contains more than one
+ * cell (across one or many rows). Used to decide whether anchor markers add
+ * useful information — for a single-cell selection the per-edge borders
+ * already convey the cell's identity.
+ */
+export function hasMultipleSelectedCells(selectedCells: Map<number, Set<ViewerColumn>>): boolean {
+  if (selectedCells.size > 1) return true;
+  const only = selectedCells.values().next().value;
+  return only !== undefined && only.size > 1;
+}
+
+/**
  * computeCellRange - Pure function that computes a rectangular cell selection between two cells.
  * If either anchor or target is ColorDot, returns just the target cell.
  */
@@ -141,7 +153,7 @@ export function computeCellRange(
   target: { rowKey: number; col: ViewerColumn },
   visibleCols: Set<ViewerColumn>,
 ): Map<number, Set<ViewerColumn>> {
-  const cols: ViewerColumn[] = [...visibleCols].filter((c) => c !== ViewerColumn.ColorDot);
+  const cols = [...visibleCols].filter(isSelectableViewerColumn);
   const anchorIdx = cols.indexOf(anchor.col);
   const targetIdx = cols.indexOf(target.col);
 
@@ -154,38 +166,62 @@ export function computeCellRange(
   const minCol = Math.min(anchorIdx, targetIdx);
   const maxCol = Math.max(anchorIdx, targetIdx);
 
+  // Every row in the rectangle has the same selected cols, so share a single
+  // Set across all entries. This keeps row-level Set references stable when
+  // the col span doesn't change (only the row span grows/shrinks during a
+  // drag) — which lets RecordRow's memo skip rows whose selection didn't
+  // actually change frame-to-frame.
+  const colSet = new Set<ViewerColumn>();
+  for (let c = minCol; c <= maxCol; c += 1) colSet.add(cols[c]);
+
   const result = new Map<number, Set<ViewerColumn>>();
-  for (let r = minRow; r <= maxRow; r += 1) {
-    const colSet = new Set<ViewerColumn>();
-    for (let c = minCol; c <= maxCol; c += 1) {
-      colSet.add(cols[c]);
-    }
-    result.set(r, colSet);
-  }
+  for (let r = minRow; r <= maxRow; r += 1) result.set(r, colSet);
   return result;
 }
 
-function getActiveSelectedCell(
+/**
+ * nextSelectedCellInReadingOrder - Returns the selected cell that comes after
+ * `after` in spreadsheet reading order (left-to-right within a row, then
+ * top-to-bottom across rows), wrapping around to the first selected cell when
+ * `after` is past the end. Returns null when nothing is selected.
+ *
+ * `after` does not need to be in `selectedCells` — typical use is to find the
+ * next anchor right after deselecting the current one, where `after` is the
+ * just-deselected cell.
+ */
+function nextSelectedCellInReadingOrder(
   selectedCells: Map<number, Set<ViewerColumn>>,
-  lastClickedCell: { rowKey: number; col: ViewerColumn } | null,
+  after: { rowKey: number; col: ViewerColumn },
   visibleCols: Set<ViewerColumn>,
 ): { rowKey: number; col: ViewerColumn } | null {
-  if (lastClickedCell && selectedCells.get(lastClickedCell.rowKey)?.has(lastClickedCell.col)) {
-    return lastClickedCell;
-  }
+  if (selectedCells.size === 0) return null;
 
   const cols = [...visibleCols].filter(isSelectableViewerColumn);
-  const rowKey = [...selectedCells.keys()].sort((a, b) => a - b)[0];
-  if (rowKey === undefined) return null;
+  const sortedRows = [...selectedCells.keys()].sort((a, b) => a - b);
 
-  const selectedCols = selectedCells.get(rowKey);
-  const col = cols.find((c) => selectedCols?.has(c));
-  return col ? { rowKey, col } : null;
+  // Flatten selection into reading order.
+  const ordered = sortedRows.flatMap((rowKey) => {
+    const rowCols = selectedCells.get(rowKey);
+    return rowCols ? cols.filter((c) => rowCols.has(c)).map((col) => ({ rowKey, col })) : [];
+  });
+  if (ordered.length === 0) return null;
+
+  const afterColIdx = cols.indexOf(after.col);
+  const next = ordered.find((cell) => {
+    const cellColIdx = cols.indexOf(cell.col);
+    return cell.rowKey > after.rowKey || (cell.rowKey === after.rowKey && cellColIdx > afterColIdx);
+  });
+  // Past the last cell → wrap to the first.
+  return next ?? ordered[0];
 }
 
-function getAdjacentSelectedCell(
+const ARROW_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'] as const;
+type ArrowKey = (typeof ARROW_KEYS)[number];
+const isArrowKey = (key: string): key is ArrowKey => (ARROW_KEYS as readonly string[]).includes(key);
+
+function getCellInArrowDirection(
   activeCell: { rowKey: number; col: ViewerColumn },
-  key: string,
+  key: ArrowKey,
   visibleCols: Set<ViewerColumn>,
   virtualizer: LogViewerVirtualizer,
 ): { rowKey: number; col: ViewerColumn } | null {
@@ -256,46 +292,52 @@ export function useSelectionState() {
   const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
   const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
   const [selectedCells, setSelectedCells] = useAtom(selectedCellsAtom);
-  const [lastClickedCell, setLastClickedCell] = useAtom(lastClickedCellAtom);
+  const [anchorCell, setAnchorCell] = useAtom(anchorCellAtom);
   const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
   const [isCursorText, setIsCursorText] = useAtom(isCursorTextAtom);
 
   const selectedKeysRef = useRef(selectedKeys);
   const lastClickedKeyRef = useRef(lastClickedKey);
   const selectedCellsRef = useRef(selectedCells);
-  const lastClickedCellRef = useRef(lastClickedCell);
+  const anchorCellRef = useRef(anchorCell);
   const isTextSelectModeRef = useRef(isTextSelectMode);
   const dragAbortRef = useRef<AbortController | null>(null);
   const cursorTextPendingRef = useRef(false);
+  // Long-lived controller for the cursor-text one-shot mousemove listener.
+  // Aborted on unmount so a click immediately followed by unmount doesn't
+  // leak a listener that fires on the next mousemove anywhere in the doc.
+  const cursorTextAbortRef = useRef<AbortController | null>(null);
   const scheduleCursorText = useCallback(() => {
     if (cursorTextPendingRef.current) return;
     cursorTextPendingRef.current = true;
+    if (!cursorTextAbortRef.current) cursorTextAbortRef.current = new AbortController();
     document.addEventListener(
       'mousemove',
       () => {
         cursorTextPendingRef.current = false;
         setIsCursorText(true);
       },
-      { once: true },
+      { once: true, signal: cursorTextAbortRef.current.signal },
     );
   }, [setIsCursorText]);
+  useEffect(() => () => cursorTextAbortRef.current?.abort(), []);
 
   useEffect(() => {
     selectedKeysRef.current = selectedKeys;
     lastClickedKeyRef.current = lastClickedKey;
     selectedCellsRef.current = selectedCells;
-    lastClickedCellRef.current = lastClickedCell;
+    anchorCellRef.current = anchorCell;
     isTextSelectModeRef.current = isTextSelectMode;
-  }, [selectedKeys, lastClickedKey, selectedCells, lastClickedCell, isTextSelectMode]);
+  }, [selectedKeys, lastClickedKey, selectedCells, anchorCell, isTextSelectMode]);
 
   const clearSelection = useCallback(() => {
     setSelectedKeys(new Set());
     setLastClickedKey(null);
     setSelectedCells(new Map());
-    setLastClickedCell(null);
+    setAnchorCell(null);
     setIsTextSelectMode(false);
     setIsCursorText(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setLastClickedCell, setIsTextSelectMode, setIsCursorText]);
+  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setAnchorCell, setIsTextSelectMode, setIsCursorText]);
 
   return {
     visibleCols,
@@ -304,7 +346,8 @@ export function useSelectionState() {
     setLastClickedKey,
     selectedCells,
     setSelectedCells,
-    setLastClickedCell,
+    anchorCell,
+    setAnchorCell,
     isTextSelectMode,
     setIsTextSelectMode,
     isCursorText,
@@ -312,7 +355,7 @@ export function useSelectionState() {
     selectedKeysRef,
     lastClickedKeyRef,
     selectedCellsRef,
-    lastClickedCellRef,
+    anchorCellRef,
     isTextSelectModeRef,
     dragAbortRef,
     clearSelection,
@@ -322,11 +365,10 @@ export function useSelectionState() {
 
 export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
   const {
-    selectedKeys,
     setSelectedKeys,
     setLastClickedKey,
     setSelectedCells,
-    setLastClickedCell,
+    setAnchorCell,
     setIsTextSelectMode,
     setIsCursorText,
     selectedKeysRef,
@@ -337,17 +379,6 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
 
   const dragStartKeyRef = useRef<number | null>(null);
   const dragEndKeyRef = useRef<number | null>(null);
-
-  const { selectionTopKeys, selectionBottomKeys } = useMemo(() => {
-    if (selectedKeys.size === 0) return { selectionTopKeys: selectedKeys, selectionBottomKeys: selectedKeys };
-    const top = new Set<number>();
-    const bottom = new Set<number>();
-    selectedKeys.forEach((k) => {
-      if (!selectedKeys.has(k - 1)) top.add(k);
-      if (!selectedKeys.has(k + 1)) bottom.add(k);
-    });
-    return { selectionTopKeys: top, selectionBottomKeys: bottom };
-  }, [selectedKeys]);
 
   const handleRowMouseDown = useCallback(
     (key: number, event: React.MouseEvent) => {
@@ -363,7 +394,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
         setSelectedKeys(next);
         setLastClickedKey(key);
         if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
-        setLastClickedCell(null);
+        setAnchorCell(null);
         setIsTextSelectMode(false);
         setIsCursorText(false);
         return;
@@ -373,7 +404,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
       dragEndKeyRef.current = key;
       setSelectedKeys(new Set([key]));
       if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
-      setLastClickedCell(null);
+      setAnchorCell(null);
       setIsTextSelectMode(false);
       setIsCursorText(false);
 
@@ -432,7 +463,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
       setSelectedKeys,
       setLastClickedKey,
       setSelectedCells,
-      setLastClickedCell,
+      setAnchorCell,
       setIsTextSelectMode,
       setIsCursorText,
       selectedKeysRef,
@@ -442,7 +473,25 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
     ],
   );
 
-  return { handleRowMouseDown, selectionTopKeys, selectionBottomKeys };
+  return { handleRowMouseDown };
+}
+
+/**
+ * useSelectionEdges — For each selected row, derives whether it's the top
+ * and/or bottom edge of a contiguous selection run. RecordRow uses this to
+ * decide whether to draw the row-level selection borders.
+ */
+function useSelectionEdges(selectedKeys: Set<number>) {
+  return useMemo(() => {
+    if (selectedKeys.size === 0) return { selectionTopKeys: selectedKeys, selectionBottomKeys: selectedKeys };
+    const top = new Set<number>();
+    const bottom = new Set<number>();
+    selectedKeys.forEach((k) => {
+      if (!selectedKeys.has(k - 1)) top.add(k);
+      if (!selectedKeys.has(k + 1)) bottom.add(k);
+    });
+    return { selectionTopKeys: top, selectionBottomKeys: bottom };
+  }, [selectedKeys]);
 }
 
 export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
@@ -451,12 +500,12 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
     setSelectedKeys,
     setLastClickedKey,
     setSelectedCells,
-    setLastClickedCell,
+    setAnchorCell,
     setIsTextSelectMode,
     setIsCursorText,
     selectedKeysRef,
     selectedCellsRef,
-    lastClickedCellRef,
+    anchorCellRef,
     isTextSelectModeRef,
     dragAbortRef,
     scheduleCursorText,
@@ -476,18 +525,17 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       if (isContextClick) return;
 
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
-        if (event.shiftKey && lastClickedCellRef.current !== null) {
-          const range = computeCellRange(lastClickedCellRef.current, { rowKey, col }, visibleCols);
-          const merged = new Map(selectedCellsRef.current);
-          range.forEach((cols, rk) => {
-            const existing = merged.get(rk);
-            merged.set(rk, existing ? new Set([...existing, ...cols]) : cols);
-          });
-          setSelectedCells(merged);
+        if (event.shiftKey && anchorCellRef.current !== null) {
+          // Spreadsheet behavior: Shift+click replaces the selection with a
+          // rectangle from the anchor to the click target. Prior selection
+          // (including disjoint cells from Cmd+click) is discarded.
+          const range = computeCellRange(anchorCellRef.current, { rowKey, col }, visibleCols);
+          setSelectedCells(range);
         } else if (event.metaKey || event.ctrlKey) {
           const next = new Map(selectedCellsRef.current);
           const newCols = new Set(next.get(rowKey) ?? []);
-          if (newCols.has(col)) {
+          const wasSelected = newCols.has(col);
+          if (wasSelected) {
             newCols.delete(col);
           } else {
             newCols.add(col);
@@ -498,12 +546,20 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
             next.set(rowKey, newCols);
           }
           setSelectedCells(next);
-          if (lastClickedCellRef.current?.rowKey !== rowKey || lastClickedCellRef.current?.col !== col) {
-            setLastClickedCell({ rowKey, col });
+
+          // Spreadsheet anchor invariant: anchor must point to a selected cell
+          // (or be null when the selection is empty).
+          if (!wasSelected) {
+            setAnchorCell({ rowKey, col });
+          } else {
+            const isAnchor = anchorCellRef.current?.rowKey === rowKey && anchorCellRef.current?.col === col;
+            if (isAnchor) {
+              setAnchorCell(nextSelectedCellInReadingOrder(next, { rowKey, col }, visibleCols));
+            }
           }
         } else {
           setSelectedCells(new Map([[rowKey, new Set([col])]]));
-          setLastClickedCell({ rowKey, col });
+          setAnchorCell({ rowKey, col });
         }
 
         if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
@@ -524,6 +580,9 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       cellDragStartRef.current = start;
       cellDragEndRef.current = start;
       setSelectedCells(new Map([[rowKey, new Set([col])]]));
+      // Set anchor at drag-start (not drag-end) so a later Shift+click extends
+      // from where the user began the selection.
+      setAnchorCell(start);
       if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
       setLastClickedKey(null);
       setIsTextSelectMode(false);
@@ -566,11 +625,7 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
           pendingY = e.clientY;
           processMove();
         }
-        const end = cellDragEndRef.current;
-        if (end) {
-          setLastClickedCell(end);
-          setIsTextSelectMode(true);
-        }
+        if (cellDragEndRef.current) setIsTextSelectMode(true);
         cellDragStartRef.current = null;
         cellDragEndRef.current = null;
         dragAbortRef.current?.abort();
@@ -588,14 +643,14 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
     [
       visibleCols,
       setSelectedCells,
-      setLastClickedCell,
+      setAnchorCell,
       setSelectedKeys,
       setLastClickedKey,
       setIsTextSelectMode,
       setIsCursorText,
       selectedKeysRef,
       selectedCellsRef,
-      lastClickedCellRef,
+      anchorCellRef,
       isTextSelectModeRef,
       dragAbortRef,
       scheduleCursorText,
@@ -613,9 +668,9 @@ export function useSelectionKeyboard(
     visibleCols,
     selectedKeysRef,
     selectedCellsRef,
-    lastClickedCellRef,
+    anchorCellRef,
     setSelectedCells,
-    setLastClickedCell,
+    setAnchorCell,
     setIsTextSelectMode,
     setIsCursorText,
     clearSelection,
@@ -660,28 +715,27 @@ export function useSelectionKeyboard(
         }
       }
 
-      if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      if (isArrowKey(e.key)) {
         if (e.metaKey || e.ctrlKey || e.altKey) return;
 
-        const cells = selectedCellsRef.current;
-        if (cells.size === 0) return;
+        // Anchor is always a selected cell or null (the cmd+click branch
+        // maintains this invariant), so it doubles as the keyboard cursor.
+        const activeCell = anchorCellRef.current;
+        if (!activeCell) return;
 
         const v = virtualizerRef.current;
         if (!v) return;
 
-        const activeCell = getActiveSelectedCell(cells, lastClickedCellRef.current, visibleCols);
-        if (!activeCell) return;
-
-        const nextCell = getAdjacentSelectedCell(activeCell, e.key, visibleCols, v);
+        const nextCell = getCellInArrowDirection(activeCell, e.key, visibleCols, v);
         if (!nextCell) return;
 
         e.preventDefault();
         window.getSelection()?.removeAllRanges();
         const nextCells = new Map([[nextCell.rowKey, new Set([nextCell.col])]]);
         selectedCellsRef.current = nextCells;
-        lastClickedCellRef.current = nextCell;
+        anchorCellRef.current = nextCell;
         setSelectedCells(nextCells);
-        setLastClickedCell(nextCell);
+        setAnchorCell(nextCell);
         setIsTextSelectMode(true);
         setIsCursorText(false);
       }
@@ -696,9 +750,9 @@ export function useSelectionKeyboard(
     clearSelection,
     selectedKeysRef,
     selectedCellsRef,
-    lastClickedCellRef,
+    anchorCellRef,
     setSelectedCells,
-    setLastClickedCell,
+    setAnchorCell,
     setIsTextSelectMode,
     setIsCursorText,
     virtualizerRef,
@@ -707,9 +761,10 @@ export function useSelectionKeyboard(
 
 export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {
   const state = useSelectionState();
-  const { handleRowMouseDown, selectionTopKeys, selectionBottomKeys } = useRowDrag(state);
+  const { handleRowMouseDown } = useRowDrag(state);
   const { handleCellMouseDown } = useCellDrag(state);
   useSelectionKeyboard(state, virtualizerRef);
+  const { selectionTopKeys, selectionBottomKeys } = useSelectionEdges(state.selectedKeys);
 
   // Clean up drag listeners on unmount
   useEffect(
@@ -724,6 +779,7 @@ export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualize
     selectionTopKeys,
     selectionBottomKeys,
     selectedCells: state.selectedCells,
+    anchorCell: state.anchorCell,
     isTextSelectMode: state.isTextSelectMode,
     isCursorText: state.isCursorText,
     handleRowMouseDown,

--- a/dashboard-ui/src/pages/console/selection.ts
+++ b/dashboard-ui/src/pages/console/selection.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue, useStore } from 'jotai';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { stripAnsi } from 'fancy-ansi';
@@ -287,20 +287,40 @@ export function computeSelection({
   return new Set([clickedKey]);
 }
 
-export function useSelectionState() {
-  const visibleCols = useAtomValue(visibleColsAtom);
-  const [selectedKeys, setSelectedKeys] = useAtom(selectedKeysAtom);
-  const [lastClickedKey, setLastClickedKey] = useAtom(lastClickedKeyAtom);
-  const [selectedCells, setSelectedCells] = useAtom(selectedCellsAtom);
-  const [anchorCell, setAnchorCell] = useAtom(anchorCellAtom);
-  const [isTextSelectMode, setIsTextSelectMode] = useAtom(isTextSelectModeAtom);
-  const [isCursorText, setIsCursorText] = useAtom(isCursorTextAtom);
+type Store = ReturnType<typeof useStore>;
 
-  const selectedKeysRef = useRef(selectedKeys);
-  const lastClickedKeyRef = useRef(lastClickedKey);
-  const selectedCellsRef = useRef(selectedCells);
-  const anchorCellRef = useRef(anchorCell);
-  const isTextSelectModeRef = useRef(isTextSelectMode);
+/** Reset row-selection state. No-op write on selectedKeysAtom is skipped. */
+function clearRowSelection(store: Store) {
+  if (store.get(selectedKeysAtom).size > 0) store.set(selectedKeysAtom, new Set());
+  store.set(lastClickedKeyAtom, null);
+}
+
+/**
+ * Reset cell-selection state, including the text-select / cursor-text flags
+ * (those modes only exist while a cell selection is active).
+ */
+function clearCellSelection(store: Store) {
+  if (store.get(selectedCellsAtom).size > 0) store.set(selectedCellsAtom, new Map());
+  store.set(anchorCellAtom, null);
+  store.set(isTextSelectModeAtom, false);
+  store.set(isCursorTextAtom, false);
+}
+
+/** Replace the cell selection with a single cell and move the anchor to it. */
+function selectSingleCell(store: Store, cell: { rowKey: number; col: ViewerColumn }) {
+  store.set(selectedCellsAtom, new Map([[cell.rowKey, new Set([cell.col])]]));
+  store.set(anchorCellAtom, cell);
+}
+
+export function useSelectionState() {
+  const store = useStore();
+  const visibleCols = useAtomValue(visibleColsAtom);
+  const selectedKeys = useAtomValue(selectedKeysAtom);
+  const selectedCells = useAtomValue(selectedCellsAtom);
+  const anchorCell = useAtomValue(anchorCellAtom);
+  const isTextSelectMode = useAtomValue(isTextSelectModeAtom);
+  const isCursorText = useAtomValue(isCursorTextAtom);
+
   const dragAbortRef = useRef<AbortController | null>(null);
   const cursorTextPendingRef = useRef(false);
   // Long-lived controller for the cursor-text one-shot mousemove listener.
@@ -315,48 +335,26 @@ export function useSelectionState() {
       'mousemove',
       () => {
         cursorTextPendingRef.current = false;
-        setIsCursorText(true);
+        store.set(isCursorTextAtom, true);
       },
       { once: true, signal: cursorTextAbortRef.current.signal },
     );
-  }, [setIsCursorText]);
+  }, [store]);
   useEffect(() => () => cursorTextAbortRef.current?.abort(), []);
 
-  useEffect(() => {
-    selectedKeysRef.current = selectedKeys;
-    lastClickedKeyRef.current = lastClickedKey;
-    selectedCellsRef.current = selectedCells;
-    anchorCellRef.current = anchorCell;
-    isTextSelectModeRef.current = isTextSelectMode;
-  }, [selectedKeys, lastClickedKey, selectedCells, anchorCell, isTextSelectMode]);
-
   const clearSelection = useCallback(() => {
-    setSelectedKeys(new Set());
-    setLastClickedKey(null);
-    setSelectedCells(new Map());
-    setAnchorCell(null);
-    setIsTextSelectMode(false);
-    setIsCursorText(false);
-  }, [setSelectedKeys, setLastClickedKey, setSelectedCells, setAnchorCell, setIsTextSelectMode, setIsCursorText]);
+    clearRowSelection(store);
+    clearCellSelection(store);
+  }, [store]);
 
   return {
+    store,
     visibleCols,
     selectedKeys,
-    setSelectedKeys,
-    setLastClickedKey,
     selectedCells,
-    setSelectedCells,
     anchorCell,
-    setAnchorCell,
     isTextSelectMode,
-    setIsTextSelectMode,
     isCursorText,
-    setIsCursorText,
-    selectedKeysRef,
-    lastClickedKeyRef,
-    selectedCellsRef,
-    anchorCellRef,
-    isTextSelectModeRef,
     dragAbortRef,
     clearSelection,
     scheduleCursorText,
@@ -364,18 +362,7 @@ export function useSelectionState() {
 }
 
 export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
-  const {
-    setSelectedKeys,
-    setLastClickedKey,
-    setSelectedCells,
-    setAnchorCell,
-    setIsTextSelectMode,
-    setIsCursorText,
-    selectedKeysRef,
-    lastClickedKeyRef,
-    selectedCellsRef,
-    dragAbortRef,
-  } = state;
+  const { store, dragAbortRef } = state;
 
   const dragStartKeyRef = useRef<number | null>(null);
   const dragEndKeyRef = useRef<number | null>(null);
@@ -385,28 +372,22 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
       // Modifier clicks don't start a drag
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
         const next = computeSelection({
-          prev: selectedKeysRef.current,
+          prev: store.get(selectedKeysAtom),
           clickedKey: key,
           shiftKey: event.shiftKey,
           metaOrCtrlKey: event.metaKey || event.ctrlKey,
-          lastClickedKey: lastClickedKeyRef.current,
+          lastClickedKey: store.get(lastClickedKeyAtom),
         });
-        setSelectedKeys(next);
-        setLastClickedKey(key);
-        if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
-        setAnchorCell(null);
-        setIsTextSelectMode(false);
-        setIsCursorText(false);
+        store.set(selectedKeysAtom, next);
+        store.set(lastClickedKeyAtom, key);
+        clearCellSelection(store);
         return;
       }
 
       dragStartKeyRef.current = key;
       dragEndKeyRef.current = key;
-      setSelectedKeys(new Set([key]));
-      if (selectedCellsRef.current.size > 0) setSelectedCells(new Map());
-      setAnchorCell(null);
-      setIsTextSelectMode(false);
-      setIsCursorText(false);
+      store.set(selectedKeysAtom, new Set([key]));
+      clearCellSelection(store);
 
       let rafId: number | null = null;
       let pendingX = 0;
@@ -425,7 +406,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
         const maxKey = Math.max(dragStartKeyRef.current, endKey);
         const next = new Set<number>();
         for (let k = minKey; k <= maxKey; k += 1) next.add(k);
-        setSelectedKeys(next);
+        store.set(selectedKeysAtom, next);
       };
 
       const onMouseMove = (e: MouseEvent) => {
@@ -445,7 +426,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
           pendingY = e.clientY;
           processMove();
         }
-        setLastClickedKey(dragEndKeyRef.current);
+        store.set(lastClickedKeyAtom, dragEndKeyRef.current);
         dragStartKeyRef.current = null;
         dragEndKeyRef.current = null;
         dragAbortRef.current?.abort();
@@ -459,18 +440,7 @@ export function useRowDrag(state: ReturnType<typeof useSelectionState>) {
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [
-      setSelectedKeys,
-      setLastClickedKey,
-      setSelectedCells,
-      setAnchorCell,
-      setIsTextSelectMode,
-      setIsCursorText,
-      selectedKeysRef,
-      lastClickedKeyRef,
-      selectedCellsRef,
-      dragAbortRef,
-    ],
+    [store, dragAbortRef],
   );
 
   return { handleRowMouseDown };
@@ -495,21 +465,7 @@ function useSelectionEdges(selectedKeys: Set<number>) {
 }
 
 export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
-  const {
-    visibleCols,
-    setSelectedKeys,
-    setLastClickedKey,
-    setSelectedCells,
-    setAnchorCell,
-    setIsTextSelectMode,
-    setIsCursorText,
-    selectedKeysRef,
-    selectedCellsRef,
-    anchorCellRef,
-    isTextSelectModeRef,
-    dragAbortRef,
-    scheduleCursorText,
-  } = state;
+  const { store, visibleCols, dragAbortRef, scheduleCursorText } = state;
 
   const cellDragStartRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
   const cellDragEndRef = useRef<{ rowKey: number; col: ViewerColumn } | null>(null);
@@ -525,14 +481,14 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       if (isContextClick) return;
 
       if (event.shiftKey || event.metaKey || event.ctrlKey) {
-        if (event.shiftKey && anchorCellRef.current !== null) {
+        const anchor = store.get(anchorCellAtom);
+        if (event.shiftKey && anchor !== null) {
           // Spreadsheet behavior: Shift+click replaces the selection with a
           // rectangle from the anchor to the click target. Prior selection
           // (including disjoint cells from Cmd+click) is discarded.
-          const range = computeCellRange(anchorCellRef.current, { rowKey, col }, visibleCols);
-          setSelectedCells(range);
+          store.set(selectedCellsAtom, computeCellRange(anchor, { rowKey, col }, visibleCols));
         } else if (event.metaKey || event.ctrlKey) {
-          const next = new Map(selectedCellsRef.current);
+          const next = new Map(store.get(selectedCellsAtom));
           const newCols = new Set(next.get(rowKey) ?? []);
           const wasSelected = newCols.has(col);
           if (wasSelected) {
@@ -545,48 +501,41 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
           } else {
             next.set(rowKey, newCols);
           }
-          setSelectedCells(next);
+          store.set(selectedCellsAtom, next);
 
           // Spreadsheet anchor invariant: anchor must point to a selected cell
           // (or be null when the selection is empty).
           if (!wasSelected) {
-            setAnchorCell({ rowKey, col });
-          } else {
-            const isAnchor = anchorCellRef.current?.rowKey === rowKey && anchorCellRef.current?.col === col;
-            if (isAnchor) {
-              setAnchorCell(nextSelectedCellInReadingOrder(next, { rowKey, col }, visibleCols));
-            }
+            store.set(anchorCellAtom, { rowKey, col });
+          } else if (anchor?.rowKey === rowKey && anchor?.col === col) {
+            store.set(anchorCellAtom, nextSelectedCellInReadingOrder(next, { rowKey, col }, visibleCols));
           }
         } else {
-          setSelectedCells(new Map([[rowKey, new Set([col])]]));
-          setAnchorCell({ rowKey, col });
+          selectSingleCell(store, { rowKey, col });
         }
 
-        if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
-        setLastClickedKey(null);
-        setIsTextSelectMode(true);
-        setIsCursorText(false);
+        clearRowSelection(store);
+        store.set(isTextSelectModeAtom, true);
+        store.set(isCursorTextAtom, false);
         scheduleCursorText();
         window.getSelection()?.removeAllRanges();
         return;
       }
 
       // In text-select mode on a selected cell, let the browser handle it
-      if (isTextSelectModeRef.current && selectedCellsRef.current.get(rowKey)?.has(col)) {
+      if (store.get(isTextSelectModeAtom) && store.get(selectedCellsAtom).get(rowKey)?.has(col)) {
         return;
       }
 
       const start = { rowKey, col };
       cellDragStartRef.current = start;
       cellDragEndRef.current = start;
-      setSelectedCells(new Map([[rowKey, new Set([col])]]));
       // Set anchor at drag-start (not drag-end) so a later Shift+click extends
       // from where the user began the selection.
-      setAnchorCell(start);
-      if (selectedKeysRef.current.size > 0) setSelectedKeys(new Set());
-      setLastClickedKey(null);
-      setIsTextSelectMode(false);
-      setIsCursorText(false);
+      selectSingleCell(store, start);
+      clearRowSelection(store);
+      store.set(isTextSelectModeAtom, false);
+      store.set(isCursorTextAtom, false);
 
       let rafId: number | null = null;
       let pendingX = 0;
@@ -605,7 +554,7 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
         const end = { rowKey: endRowKey, col: endCol };
         if (end.rowKey === cellDragEndRef.current?.rowKey && end.col === cellDragEndRef.current?.col) return;
         cellDragEndRef.current = end;
-        setSelectedCells(computeCellRange(cellDragStartRef.current, end, visibleCols));
+        store.set(selectedCellsAtom, computeCellRange(cellDragStartRef.current, end, visibleCols));
       };
 
       const onMouseMove = (e: MouseEvent) => {
@@ -625,7 +574,7 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
           pendingY = e.clientY;
           processMove();
         }
-        if (cellDragEndRef.current) setIsTextSelectMode(true);
+        if (cellDragEndRef.current) store.set(isTextSelectModeAtom, true);
         cellDragStartRef.current = null;
         cellDragEndRef.current = null;
         dragAbortRef.current?.abort();
@@ -640,21 +589,7 @@ export function useCellDrag(state: ReturnType<typeof useSelectionState>) {
       document.addEventListener('mousemove', onMouseMove, { signal });
       document.addEventListener('mouseup', onMouseUp, { signal });
     },
-    [
-      visibleCols,
-      setSelectedCells,
-      setAnchorCell,
-      setSelectedKeys,
-      setLastClickedKey,
-      setIsTextSelectMode,
-      setIsCursorText,
-      selectedKeysRef,
-      selectedCellsRef,
-      anchorCellRef,
-      isTextSelectModeRef,
-      dragAbortRef,
-      scheduleCursorText,
-    ],
+    [store, visibleCols, dragAbortRef, scheduleCursorText],
   );
 
   return { handleCellMouseDown };
@@ -664,17 +599,7 @@ export function useSelectionKeyboard(
   state: ReturnType<typeof useSelectionState>,
   virtualizerRef: React.RefObject<LogViewerVirtualizer | null>,
 ) {
-  const {
-    visibleCols,
-    selectedKeysRef,
-    selectedCellsRef,
-    anchorCellRef,
-    setSelectedCells,
-    setAnchorCell,
-    setIsTextSelectMode,
-    setIsCursorText,
-    clearSelection,
-  } = state;
+  const { store, visibleCols, clearSelection } = state;
   const [timezone] = useTimezone();
   const [timestampFormat] = useTimestampFormat();
 
@@ -693,7 +618,7 @@ export function useSelectionKeyboard(
         const nativeSel = window.getSelection();
         if (nativeSel && !nativeSel.isCollapsed) return;
 
-        const cells = selectedCellsRef.current;
+        const cells = store.get(selectedCellsAtom);
         if (cells.size > 0) {
           e.preventDefault();
           const v = virtualizerRef.current;
@@ -704,11 +629,12 @@ export function useSelectionKeyboard(
         }
 
         // Copy selected rows as TSV
-        if (selectedKeysRef.current.size > 0) {
+        const keys = store.get(selectedKeysAtom);
+        if (keys.size > 0) {
           e.preventDefault();
           const v = virtualizerRef.current;
           if (!v) return;
-          const sorted = [...selectedKeysRef.current].sort((a, b) => a - b);
+          const sorted = [...keys].sort((a, b) => a - b);
           const records = sorted.map((k) => v.getRecord(k)).filter((r): r is LogRecord => r !== undefined);
           const text = formatRowsForCopy(records, visibleCols, timezone, timestampFormat);
           navigator.clipboard.writeText(text);
@@ -720,7 +646,7 @@ export function useSelectionKeyboard(
 
         // Anchor is always a selected cell or null (the cmd+click branch
         // maintains this invariant), so it doubles as the keyboard cursor.
-        const activeCell = anchorCellRef.current;
+        const activeCell = store.get(anchorCellAtom);
         if (!activeCell) return;
 
         const v = virtualizerRef.current;
@@ -731,32 +657,15 @@ export function useSelectionKeyboard(
 
         e.preventDefault();
         window.getSelection()?.removeAllRanges();
-        const nextCells = new Map([[nextCell.rowKey, new Set([nextCell.col])]]);
-        selectedCellsRef.current = nextCells;
-        anchorCellRef.current = nextCell;
-        setSelectedCells(nextCells);
-        setAnchorCell(nextCell);
-        setIsTextSelectMode(true);
-        setIsCursorText(false);
+        selectSingleCell(store, nextCell);
+        store.set(isTextSelectModeAtom, true);
+        store.set(isCursorTextAtom, false);
       }
     };
 
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [
-    visibleCols,
-    timezone,
-    timestampFormat,
-    clearSelection,
-    selectedKeysRef,
-    selectedCellsRef,
-    anchorCellRef,
-    setSelectedCells,
-    setAnchorCell,
-    setIsTextSelectMode,
-    setIsCursorText,
-    virtualizerRef,
-  ]);
+  }, [store, visibleCols, timezone, timestampFormat, clearSelection, virtualizerRef]);
 }
 
 export function useSelection(virtualizerRef: React.RefObject<LogViewerVirtualizer | null>) {

--- a/dashboard-ui/src/pages/console/state.ts
+++ b/dashboard-ui/src/pages/console/state.ts
@@ -32,7 +32,7 @@ export const lastClickedKeyAtom = atom<number | null>(null);
 
 export const selectedCellsAtom = atom<Map<number, Set<ViewerColumn>>>(new Map());
 
-export const lastClickedCellAtom = atom<{ rowKey: number; col: ViewerColumn } | null>(null);
+export const anchorCellAtom = atom<{ rowKey: number; col: ViewerColumn } | null>(null);
 
 export const isTextSelectModeAtom = atom(false);
 


### PR DESCRIPTION
## Summary

Fixes a long-standing visual bug where cell-selection borders rendered
as thin (1px-looking) lines at the edges of non-rectangular selections —
especially visible on the "step" boundaries of L-shaped selections built
via Cmd+click.

The root cause was per-cell inset box-shadows: stacked inset shadows
have a sub-pixel rendering quirk (most prominent in Firefox), and
adjacent selected rows raced for shared boundary pixels via z-index,
with each "fix" exposing a new mismatch on the other side. Replacing
inset shadows with a real overlay layer eliminates the conflict
entirely — the selection chrome paints as one layer above all cells,
with no row-vs-row painting race.

Along the way, a few related cleanups in the selection subsystem.

## Key Changes

- **Overlay-based selection borders.** New `SelectionOverlay` component
  lives inside each `RecordRow` and draws per-edge real CSS borders on
  absolutely-positioned empty divs. The anchor cell renders as the same
  rect with all four borders forced and a corner-dot indicator. ColorDot
  becomes a clean interior connector when both selectable neighbors are
  selected. `cell-styles.ts` and its tests are deleted.
- **Selection state migrated to Jotai's `useStore()`.** The five
  `useRef` mirrors plus the syncing `useEffect` in `useSelectionState`
  are gone; handlers read via `store.get(atom)` and write via
  `store.set(atom, v)`. This also eliminates a foot-gun in the
  arrow-key handler that required manually pre-writing refs to defeat
  React's batching lag.
- **Shared drag-loop helper.** `useRowDrag` and `useCellDrag` each had
  ~25 lines of identical `requestAnimationFrame` coalescing,
  `AbortController` lifecycle, and `mousemove`/`mouseup` wiring.
  Lifted into `startDocumentDrag<T>`; each caller plugs in its own
  `resolveTarget` / `onMove` / `onCommit`.
- **Spreadsheet-anchor invariant.** Renamed `lastClickedCell` to
  `anchorCell` and tightened the rule: the anchor always points at a
  selected cell (or null). Cmd+clicking the anchor now moves it to the
  next selected cell in reading order. Shift+click replaces the
  selection with a rectangle from the anchor (was: merged with prior
  selection).
- **Per-row drag perf.** `computeCellRange` now shares a single col
  `Set` across all rows in a drag rectangle so unchanged rows keep
  reference-stable selection sets and skip re-render via `RecordRow`'s
  memo.
- **Width-measurement cascade fix.** `useMeasureWidths` only allocates
  a new `colWidths` Map when widths actually changed (was: every flush
  invalidated every `RecordRow` memo).
- **Smaller cleanups.** Extract `clearRowSelection` /
  `clearCellSelection` / `selectSingleCell` helpers; bind the
  cursor-text one-shot listener to an `AbortController` cleaned up on
  unmount; `ARROW_KEYS` constant + `isArrowKey` type guard; export and
  reuse `isSelectableViewerColumn`; drop redundant JSDoc on copy
  formatters.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused