### PR TITLE
✨ Address CodeQL alert and bump dependencies for CVEs

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2082,9 +2082,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/rgkl/Cargo.toml
+++ b/crates/rgkl/Cargo.toml
@@ -30,7 +30,7 @@ grep-printer = "0.2.2"
 grep-regex = "0.1.13"
 grep-searcher = "0.1.14"
 memchr = "2.7.5"
-rand = "0.9.2"
+rand = "0.9.4"
 regex = "1.11.1"
 rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -106,6 +106,7 @@
       "immutable": "^4.3.8",
       "napi-postinstall": "^0.3.2",
       "picomatch": "^4.0.4",
+      "postcss": "^8.5.10",
       "rollup": "^4.59.0",
       "synckit": "^0.11.11",
       "tmp": "^0.2.5",

--- a/dashboard-ui/pnpm-lock.yaml
+++ b/dashboard-ui/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   immutable: ^4.3.8
   napi-postinstall: ^0.3.2
   picomatch: ^4.0.4
+  postcss: ^8.5.10
   rollup: ^4.59.0
   synckit: ^0.11.11
   tmp: ^0.2.5
@@ -3804,8 +3805,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -8355,7 +8356,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -9047,7 +9048,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/e2e/test_zero_trust.py
+++ b/e2e/test_zero_trust.py
@@ -226,6 +226,7 @@ class TestClusterAPIAggregationGate:
             + f"{_AGGREGATED_BASE}/graphql"
         )
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # silence CodeQL; we're testing mTLS gate, not TLS version
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
 
@@ -314,6 +315,7 @@ def cluster_agent_local_port(cluster_api_url):
 class TestClusterAgentMTLSGate:
     def test_tls_without_client_cert_rejected(self, cluster_agent_local_port):
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # silence CodeQL; we're testing mTLS gate, not TLS version
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         with socket.create_connection(("127.0.0.1", cluster_agent_local_port), timeout=5) as raw:

--- a/modules/cli/go.mod
+++ b/modules/cli/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/modules/cli/go.sum
+++ b/modules/cli/go.sum
@@ -287,8 +287,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Summary

Resolves a CodeQL "insecure SSL/TLS version" alert in the e2e zero-trust tests and bumps several dependencies flagged by security advisories to their patched versions.

## Key Changes

- **e2e tests**: Pin `ctx.minimum_version = TLSv1_2` on the SSLContexts used to probe the cluster-api aggregation gate and cluster-agent mTLS gate. The TLS version is irrelevant to these tests (the handshakes are expected to fail), but pinning it silences CodeQL.
- **dashboard-ui**: Add `postcss ^8.5.10` to the pnpm overrides; lockfile resolves to `8.5.14`.
- **modules/cli**: Bump indirect dependency `github.com/moby/spdystream` from `v0.5.0` to `v0.5.1`.
- **crates**: Bump `rustls-webpki` from `0.103.10` to `0.103.13` (lockfile only) and `rand` from `0.9.2` to `0.9.4`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused