### PR TITLE
🎣 Bump kubetail backend probe timeout to 5s

### DIFF
--- a/modules/cli/cmd/logs.go
+++ b/modules/cli/cmd/logs.go
@@ -739,7 +739,7 @@ var logsCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			probeCtx, cancel := context.WithTimeout(rootCtx, 2*time.Second)
+			probeCtx, cancel := context.WithTimeout(rootCtx, 5*time.Second)
 			defer cancel()
 			if err := client.Ping(probeCtx); err != nil {
 				return err


### PR DESCRIPTION
## Summary

The `kubetail logs` command probes the cluster-api endpoint before committing to the kubetail backend so a blackholed aggregated APIService can't stall backend auto-selection. The previous 2s budget was too tight for slower clusters where the apiserver/aggregation layer can take longer to respond, causing spurious silent fallback to the Kubernetes backend under `--backend=auto`.

## Key Changes

- Raise the cluster-api `Ping` probe timeout in `cmd/logs.go` from 2s to 5s.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused