### PR TITLE
test(shared): replace time.sleep with channel sync in syncgroup tests

### DIFF
--- a/modules/shared/util/syncgroup_test.go
+++ b/modules/shared/util/syncgroup_test.go
@@ -132,8 +132,10 @@ func TestSyncGroupLoadOrComputeWithContext(t *testing.T) {
 		// Cancel context immediately
 		cancel()
 
+		release := make(chan struct{})
+		defer close(release)
 		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key2", func() (int, error) {
-			time.Sleep(100 * time.Millisecond)
+			<-release
 			return 99, nil
 		})
 
@@ -146,8 +148,10 @@ func TestSyncGroupLoadOrComputeWithContext(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 
+		release := make(chan struct{})
+		defer close(release)
 		result, loaded, err := g.LoadOrComputeWithContext(ctx, "key3", func() (int, error) {
-			time.Sleep(50 * time.Millisecond)
+			<-release
 			return 99, nil
 		})
 


### PR DESCRIPTION

## ✨ Replace time.sleep with channel sync in syncgroup tests


## Summary

The SyncGroup tests were using time.Sleep to simulate slow compute functions in context cancellation and timeout scenarios. This is fragile since the delays are arbitrary and can cause flaky tests on slow machines. The tests now block on a channel that is closed via defer when the subtest exits. (changes added according to the rules from claude.md)

## Key Changes

Replace time.Sleep(100 * time.Millisecond) in the context cancellation subtest with a channel block (<-release)
Replace time.Sleep(50 * time.Millisecond) in the context timeout subtest with a channel block (<-release)
Both channels are closed via defer close(release), cleanly unblocking the compute goroutine after the test returns


p.s.
guys i've found this small bug with my tool archcheck that allows to parse rules from claude.md and enforce them. look in my profile it's the pinned one 