### PR TITLE
✨ Add bats tests and shellcheck for install script.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,80 @@ jobs:
         working-directory: ./dashboard-ui
         run: pnpm lint
 
+  install-script-shellcheck:
+    name: Install script · shellcheck
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck scripts/install.sh
+
   ###########################
   # Test jobs
   ###########################
+
+  install-script-bats:
+    name: Install script · bats
+    needs:
+      - install-script-shellcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - linux
+          - macos-15
+          - macos-26
+          - windows
+        arch:
+          - amd64
+          - arm64
+        include:
+          - os: linux
+            arch: amd64
+            runner: ubuntu-24.04
+          - os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - os: macos-15
+            arch: amd64
+            runner: macos-15-intel
+          - os: macos-15
+            arch: arm64
+            runner: macos-15
+          - os: macos-26
+            arch: arm64
+            runner: macos-26
+          - os: windows
+            arch: amd64
+            runner: windows-2025
+          - os: windows
+            arch: arm64
+            runner: windows-11-arm
+        exclude:
+          - os: macos-26
+            arch: amd64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install bats (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+      - name: Install bats (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bats-core
+      - name: Install bats (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: npm install -g bats
+      - name: Run bats
+        run: bats scripts/
+        shell: bash
 
   go-test:
     name: Go · Test

--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -1,0 +1,368 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2031
+
+install_sh_source() {
+  KB_INSTALL_SH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/install.sh"
+  # shellcheck source=/dev/null
+  source "$KB_INSTALL_SH"
+}
+
+mock_uname_bin() {
+  local d="${1:?mock bin dir}"
+  mkdir -p "$d"
+  cat >"$d/uname" <<'EOF'
+#!/usr/bin/env sh
+case "${1-}" in
+  -s) printf '%s\n' "${UNAME_S:?}" ;;
+  -m) printf '%s\n' "${UNAME_M:?}" ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$d/uname"
+}
+
+mock_curl_bin() {
+  local d="${1:?mock bin dir}"
+  mkdir -p "$d"
+  cat >"$d/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+dest=""
+url=""
+want_dest=false
+for a in "$@"; do
+  if [ "$want_dest" = true ]; then
+    dest="$a"
+    want_dest=false
+    continue
+  fi
+  case "$a" in
+    -o | --output) want_dest=true ;;
+    --output=*)
+      dest="${a#--output=}"
+      ;;
+    http://* | https://*) url="$a" ;;
+  esac
+done
+if [ -z "$dest" ] || [ -z "$url" ]; then
+  echo "mock curl: missing output dest or url: $*" >&2
+  exit 100
+fi
+base="${url##*/}"
+base="${base%%\?*}"
+case "$base" in
+  SHA256SUMS)
+    if command -v sha256sum >/dev/null 2>&1; then
+      hash=$(printf '%s' "${KUBETAIL_TEST_PAYLOAD:?}" | sha256sum | awk '{print $1}')
+    else
+      hash=$(printf '%s' "${KUBETAIL_TEST_PAYLOAD:?}" | shasum -a 256 | awk '{print $1}')
+    fi
+    bn="${KUBETAIL_TEST_BINARY_NAME:?}"
+    printf '%s  %s\n' "$hash" "$bn" >"$dest"
+    ;;
+  *)
+    printf '%s' "${KUBETAIL_TEST_PAYLOAD:?}" >"$dest"
+    ;;
+esac
+EOF
+  chmod +x "$d/curl"
+}
+
+mock_curl_bad_checksum_bin() {
+  local d="${1:?mock bin dir}"
+  mkdir -p "$d"
+  cat >"$d/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+dest=""
+url=""
+want_dest=false
+for a in "$@"; do
+  if [ "$want_dest" = true ]; then
+    dest="$a"
+    want_dest=false
+    continue
+  fi
+  case "$a" in
+    -o | --output) want_dest=true ;;
+    --output=*)
+      dest="${a#--output=}"
+      ;;
+    http://* | https://*) url="$a" ;;
+  esac
+done
+base="${url##*/}"
+base="${base%%\?*}"
+case "$base" in
+  SHA256SUMS)
+    printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "${KUBETAIL_TEST_BINARY_NAME:?}" >"$dest"
+    ;;
+  *)
+    printf '%s' "${KUBETAIL_TEST_PAYLOAD:?}" >"$dest"
+    ;;
+esac
+EOF
+  chmod +x "$d/curl"
+}
+
+sha256_tool_available() {
+  command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1
+}
+
+is_windows() {
+  case "$(uname -s)" in
+    MINGW* | CYGWIN* | MSYS*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+setup() {
+  unset KUBETAIL_INSTALL_DIR KUBETAIL_REPO_URL KUBETAIL_TEST_PAYLOAD KUBETAIL_TEST_BINARY_NAME || true
+  install_sh_source
+}
+
+# --- kubetail_platform_supported ---
+
+@test "kubetail_platform_supported accepts linux_amd64" {
+  kubetail_platform_supported linux amd64
+}
+
+@test "kubetail_platform_supported accepts linux_arm64" {
+  kubetail_platform_supported linux arm64
+}
+
+@test "kubetail_platform_supported accepts darwin_amd64" {
+  kubetail_platform_supported darwin amd64
+}
+
+@test "kubetail_platform_supported accepts darwin_arm64" {
+  kubetail_platform_supported darwin arm64
+}
+
+@test "kubetail_platform_supported accepts windows_amd64" {
+  kubetail_platform_supported windows amd64
+}
+
+@test "kubetail_platform_supported accepts windows_arm64" {
+  kubetail_platform_supported windows arm64
+}
+
+@test "kubetail_platform_supported rejects unknown pair" {
+  run kubetail_platform_supported linux ppc64le
+  [ "$status" -eq 1 ]
+}
+
+@test "kubetail_platform_supported rejects freebsd_amd64" {
+  run kubetail_platform_supported freebsd amd64
+  [ "$status" -eq 1 ]
+}
+
+# --- kubetail_normalize_os / kubetail_normalize_arch ---
+
+@test "kubetail_normalize_os maps Linux" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  export UNAME_S="Linux" UNAME_M="x86_64"
+  run env UNAME_S="$UNAME_S" UNAME_M="$UNAME_M" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_os' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "linux" ]
+}
+
+@test "kubetail_normalize_os maps Darwin" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="Darwin" UNAME_M="arm64" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_os' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "darwin" ]
+}
+
+@test "kubetail_normalize_os maps mingw to windows" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="MINGW64_NT-10.0" UNAME_M="x86_64" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_os' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "windows" ]
+}
+
+@test "kubetail_normalize_os maps cygwin to windows" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="CYGWIN_NT-10.0" UNAME_M="x86_64" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_os' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "windows" ]
+}
+
+@test "kubetail_normalize_arch maps x86_64 to amd64" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="Linux" UNAME_M="x86_64" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_arch' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "amd64" ]
+}
+
+@test "kubetail_normalize_arch maps aarch64 to arm64" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="Linux" UNAME_M="aarch64" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_arch' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "arm64" ]
+}
+
+@test "kubetail_normalize_arch passes through unknown machine" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockbin"
+  run env UNAME_S="Linux" UNAME_M="ppc64le" PATH="$BATS_TEST_TMPDIR/mockbin:$PATH" bash -c 'source "$1"; kubetail_normalize_arch' _ "$KB_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ppc64le" ]
+}
+
+# --- kubetail_expected_checksum ---
+
+@test "kubetail_expected_checksum picks matching line" {
+  local sums="$BATS_TEST_TMPDIR/sums"
+  printf '%s\n' \
+    'aaa1111111111111111111111111111111111111111111111111111111111111  other-bin' \
+    'bbb2222222222222222222222222222222222222222222222222222222222222  kubetail-linux-amd64' \
+    'ccc3333333333333333333333333333333333333333333333333333333333333  kubetail-linux-arm64' >"$sums"
+  run kubetail_expected_checksum "$sums" "kubetail-linux-amd64"
+  [ "$status" -eq 0 ]
+  [ "$output" = "bbb2222222222222222222222222222222222222222222222222222222222222" ]
+}
+
+# --- kubetail_sha256_of_file ---
+
+@test "kubetail_sha256_of_file returns hex digest" {
+  if ! sha256_tool_available; then
+    skip "sha256sum and shasum unavailable"
+  fi
+  local f="$BATS_TEST_TMPDIR/payload"
+  printf 'x' >"$f"
+  run kubetail_sha256_of_file "$f"
+  [ "$status" -eq 0 ]
+  [ "${#output}" -eq 64 ]
+}
+
+# --- kubetail_verify_checksum ---
+
+@test "kubetail_verify_checksum succeeds for matching file" {
+  if ! sha256_tool_available; then
+    skip "sha256sum and shasum unavailable"
+  fi
+  local binf="$BATS_TEST_TMPDIR/binfile"
+  local sums="$BATS_TEST_TMPDIR/sums"
+  printf 'payload-bytes' >"$binf"
+  local h
+  h=$(kubetail_sha256_of_file "$binf")
+  printf '%s  %s\n' "$h" "kubetail-linux-amd64" >"$sums"
+  kubetail_verify_checksum "$binf" "$sums" "kubetail-linux-amd64"
+}
+
+@test "kubetail_verify_checksum fails when sums missing entry" {
+  if ! sha256_tool_available; then
+    skip "sha256sum and shasum unavailable"
+  fi
+  local binf="$BATS_TEST_TMPDIR/binfile"
+  local sums="$BATS_TEST_TMPDIR/sums"
+  printf 'payload-bytes' >"$binf"
+  printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "other-name" >"$sums"
+  run kubetail_verify_checksum "$binf" "$sums" "kubetail-linux-amd64"
+  [ "$status" -eq 1 ]
+}
+
+@test "kubetail_verify_checksum fails on hash mismatch" {
+  if ! sha256_tool_available; then
+    skip "sha256sum and shasum unavailable"
+  fi
+  local binf="$BATS_TEST_TMPDIR/binfile"
+  local sums="$BATS_TEST_TMPDIR/sums"
+  printf 'payload-bytes' >"$binf"
+  printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "kubetail-linux-amd64" >"$sums"
+  run kubetail_verify_checksum "$binf" "$sums" "kubetail-linux-amd64"
+  [ "$status" -eq 1 ]
+}
+
+# --- kubetail_download ---
+
+@test "kubetail_download writes curl -o destination" {
+  mock_curl_bin "$BATS_TEST_TMPDIR/mockbin"
+  export PATH="$BATS_TEST_TMPDIR/mockbin:$PATH"
+  export KUBETAIL_TEST_PAYLOAD='abc' KUBETAIL_TEST_BINARY_NAME='ignored'
+  local out="$BATS_TEST_TMPDIR/out"
+  kubetail_download "https://example.invalid/releases/latest/download/kubetail-linux-amd64" "$out"
+  [ "$(cat "$out")" = 'abc' ]
+}
+
+# --- kubetail_install_binary ---
+
+@test "kubetail_install_binary windows installs to HOME/bin" {
+  export HOME="$BATS_TEST_TMPDIR/home"
+  local src="$BATS_TEST_TMPDIR/kubetail.bin"
+  printf 'e' >"$src"
+  kubetail_install_binary windows "$src"
+  [ -x "$HOME/bin/kubetail.exe" ]
+  [ "$(cat "$HOME/bin/kubetail.exe")" = 'e' ]
+}
+
+@test "kubetail_install_binary unix uses KUBETAIL_INSTALL_DIR" {
+  if is_windows; then
+    skip "unix install path not applicable on Windows"
+  fi
+  local inst="$BATS_TEST_TMPDIR/instdir"
+  export KUBETAIL_INSTALL_DIR="$inst"
+  local src="$BATS_TEST_TMPDIR/kubetail.bin"
+  printf 'z' >"$src"
+  kubetail_install_binary linux "$src"
+  [ -x "$inst/kubetail" ]
+  [ "$(cat "$inst/kubetail")" = 'z' ]
+}
+
+# --- kubetail_main ---
+
+@test "kubetail_main installs with mocked curl" {
+  if ! sha256_tool_available; then
+    skip "sha256sum and shasum unavailable"
+  fi
+  local on_windows=false
+  is_windows && on_windows=true
+  mock_curl_bin "$BATS_TEST_TMPDIR/mockbin"
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockuname"
+  export PATH="$BATS_TEST_TMPDIR/mockbin:$BATS_TEST_TMPDIR/mockuname:$PATH"
+  export KUBETAIL_REPO_URL="https://example.invalid"
+  export KUBETAIL_TEST_PAYLOAD='fake-release-payload'
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  if $on_windows; then
+    export UNAME_S="MINGW64_NT-10.0" UNAME_M="x86_64"
+    export KUBETAIL_TEST_BINARY_NAME="kubetail-windows-amd64"
+    export HOME="$BATS_TEST_TMPDIR/home"
+    run kubetail_main
+    [ "$status" -eq 0 ]
+    [ -x "$HOME/bin/kubetail.exe" ]
+    [ "$(cat "$HOME/bin/kubetail.exe")" = 'fake-release-payload' ]
+  else
+    export UNAME_S="Linux" UNAME_M="x86_64"
+    export KUBETAIL_TEST_BINARY_NAME="kubetail-linux-amd64"
+    export KUBETAIL_INSTALL_DIR="$BATS_TEST_TMPDIR/instdir"
+    run kubetail_main
+    [ "$status" -eq 0 ]
+    [ -x "$KUBETAIL_INSTALL_DIR/kubetail" ]
+    [ "$(cat "$KUBETAIL_INSTALL_DIR/kubetail")" = 'fake-release-payload' ]
+  fi
+}
+
+@test "kubetail_main fails on unsupported platform" {
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockuname"
+  export PATH="$BATS_TEST_TMPDIR/mockuname:$PATH"
+  export UNAME_S="FreeBSD" UNAME_M="amd64"
+  run kubetail_main
+  [ "$status" -eq 1 ]
+  [[ "$output" == *Unsupported* ]]
+}
+
+@test "kubetail_main removes artifacts on checksum failure" {
+  mock_curl_bad_checksum_bin "$BATS_TEST_TMPDIR/mockbin"
+  mock_uname_bin "$BATS_TEST_TMPDIR/mockuname"
+  export PATH="$BATS_TEST_TMPDIR/mockbin:$BATS_TEST_TMPDIR/mockuname:$PATH"
+  export UNAME_S="Linux" UNAME_M="x86_64"
+  export KUBETAIL_REPO_URL="https://example.invalid"
+  export KUBETAIL_TEST_PAYLOAD='payload'
+  export KUBETAIL_TEST_BINARY_NAME="kubetail-linux-amd64"
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  run kubetail_main
+  [ "$status" -eq 1 ]
+  shopt -s nullglob
+  leftovers=("$TMPDIR"/kubetail-linux-amd64-*)
+  [ ${#leftovers[@]} -eq 0 ]
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Overridable for tests.
+: "${KUBETAIL_REPO_URL:=https://github.com/kubetail-org/kubetail}"
+# When set, non-Windows installs use this directory instead of /usr/local/bin.
+: "${KUBETAIL_INSTALL_DIR:=}"
+EXECUTABLE_NAME="kubetail"
+
+# --- platform ---
+
+kubetail_normalize_os() {
+  local raw
+  raw=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$raw" in
+    mingw* | cygwin*) echo "windows" ;;
+    linux) echo "linux" ;;
+    darwin) echo "darwin" ;;
+    *) echo "$raw" ;;
+  esac
+}
+
+kubetail_normalize_arch() {
+  case "$(uname -m)" in
+    x86_64) echo "amd64" ;;
+    arm64 | aarch64) echo "arm64" ;;
+    *) uname -m ;;
+  esac
+}
+
+kubetail_platform_supported() {
+  local os="$1" arch="$2" pair="${1}_${2}"
+  case "$pair" in
+    linux_amd64 | linux_arm64 | darwin_amd64 | darwin_arm64 | windows_amd64 | windows_arm64) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- download / checksum ---
+
+kubetail_download() {
+  local url="$1" dest="$2"
+  curl --silent --show-error --fail --location --output "$dest" "$url"
+}
+
+kubetail_sha256_of_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    echo "Neither sha256sum nor shasum is available." >&2
+    return 1
+  fi
+}
+
+kubetail_expected_checksum() {
+  local sums_file="$1" binary_name="$2"
+  awk -v name="$binary_name" '$2 == name {print $1; exit}' "$sums_file"
+}
+
+kubetail_verify_checksum() {
+  local binary_path="$1" sums_path="$2" binary_basename="$3"
+  local expected actual
+  expected=$(kubetail_expected_checksum "$sums_path" "$binary_basename")
+  if [ -z "$expected" ]; then
+    echo "Could not find checksum for $binary_basename in SHA256SUMS." >&2
+    return 1
+  fi
+  actual=$(kubetail_sha256_of_file "$binary_path")
+  if [ "$expected" != "$actual" ]; then
+    echo "Checksum mismatch for $binary_basename." >&2
+    return 1
+  fi
+}
+
+# --- install ---
+
+kubetail_install_binary() {
+  local os="$1" binary_path="$2"
+
+  chmod +x "$binary_path"
+
+  if [ "$os" = "windows" ]; then
+    local install_dir="$HOME/bin"
+    local dest="$install_dir/${EXECUTABLE_NAME}.exe"
+    mkdir -p "$install_dir"
+    mv "$binary_path" "$dest"
+  else
+    if [ -n "${KUBETAIL_INSTALL_DIR:-}" ]; then
+      mkdir -p "$KUBETAIL_INSTALL_DIR"
+      mv "$binary_path" "${KUBETAIL_INSTALL_DIR}/${EXECUTABLE_NAME}"
+    else
+      local dest="/usr/local/bin/${EXECUTABLE_NAME}"
+      if [ "$(id -u)" -ne 0 ]; then
+        sudo mv "$binary_path" "$dest"
+      else
+        mv "$binary_path" "$dest"
+      fi
+    fi
+  fi
+}
+
+kubetail_main() {
+  local os arch binary_name binary_url sums_url sums_file binary_path
+  # Not local: the EXIT trap references tmp after the function returns.
+  tmp=""
+  trap 'rm -rf "$tmp"' EXIT
+
+  os=$(kubetail_normalize_os)
+  arch=$(kubetail_normalize_arch)
+
+  if ! kubetail_platform_supported "$os" "$arch"; then
+    echo "Unsupported OS (\"$os\") or architecture (\"$arch\")." >&2
+    echo "Please report to ${KUBETAIL_REPO_URL}/issues" >&2
+    return 1
+  fi
+
+  binary_name="${EXECUTABLE_NAME}-${os}-${arch}"
+  binary_url="${KUBETAIL_REPO_URL}/releases/latest/download/${binary_name}"
+  sums_url="${KUBETAIL_REPO_URL}/releases/latest/download/SHA256SUMS"
+  tmp=$(mktemp -d)
+  sums_file="${tmp}/SHA256SUMS"
+  binary_path="${tmp}/${binary_name}"
+
+  printf "⬇️  Downloading kubetail for %s/%s... " "$os" "$arch"
+  kubetail_download "$binary_url" "$binary_path"
+  echo "✅ success"
+
+  printf "🔍 Verifying checksum... "
+  kubetail_download "$sums_url" "$sums_file"
+  if ! kubetail_verify_checksum "$binary_path" "$sums_file" "$binary_name"; then
+    return 1
+  fi
+  echo "✅ success"
+
+  if [ "$os" = "windows" ]; then
+    printf "➡️  Moving to %s/bin/%s.exe... " "$HOME" "$EXECUTABLE_NAME"
+  else
+    if [ -n "${KUBETAIL_INSTALL_DIR:-}" ]; then
+      printf "➡️  Moving to %s/%s... " "$KUBETAIL_INSTALL_DIR" "$EXECUTABLE_NAME"
+    else
+      printf "➡️  Moving to /usr/local/bin/%s... " "$EXECUTABLE_NAME"
+    fi
+  fi
+  kubetail_install_binary "$os" "$binary_path"
+  echo "✅ success"
+
+  if [ "$os" = "windows" ]; then
+    echo "🎉 Installation complete. Please add $HOME/bin to your PATH if necessary."
+  else
+    echo "🎉 Installation complete"
+  fi
+
+  echo "🚀 Have fun tailing your Kubernetes logs!"
+}
+
+if [[ "${BASH_SOURCE:-$0}" == "${0}" ]]; then
+  kubetail_main "$@"
+fi


### PR DESCRIPTION
Related issues:
Closes #1084

## Summary

The install script is refactored into small, testable functions, covered by bats tests that run in CI. The entry guard is fixed so curl … | bash works with set -u (no unsafe BASH_SOURCE[0] access). Optional KUBETAIL_REPO_URL and KUBETAIL_INSTALL_DIR support mirrors and non-root test installs. CI runs shellcheck on install.sh before bats. This addresses safer distribution and regression coverage for the documented one-liner install flow.

## Key Changes

* Add install.sh at the repo root: kubetail_* helpers (platform detection, download, checksum, install), kubetail_main, EXIT trap to clean temp artifacts on failure, stricter set -euo pipefail, curl with long flags, mkdir -p for Windows install dir, TMPDIR-aware temp paths.
* Main only runs when the file is executed, not when sourced: if [[ "${BASH_SOURCE:-$0}" == "${0}" ]]; then kubetail_main "$@".
* Add test/install/install.bats and test/install/test_helper.bash with mocked uname/curl to exercise all helpers and an end-to-end kubetail_main path without hitting the network.
* Add install-script-bats GitHub Actions job: shellcheck install.sh, install bats via apt, run bats test/install.

## Checks
I have tested on macOS, Windows, and Linux, and was able to successfully install Kubetail using this script on all three platforms:
curl -sS https://raw.githubusercontent.com/KaanSimsek/kubetail/chore/install-sh-bats-ci/install.sh | bash

## Checklist

- [ x ] Add the correct emoji to the PR title
- [ x ] Related issue linked above, if any
- [ x ] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [ x ] Changes are minimal and focused
