### PR TITLE
🐋 Add utilities for configurable timestamp formatting and timezone support

### DIFF
--- a/dashboard-ui/src/lib/timestamp-format.test.tsx
+++ b/dashboard-ui/src/lib/timestamp-format.test.tsx
@@ -32,6 +32,7 @@ describe('TimestampFormat', () => {
     expect(TimestampFormat.RFC_1123).toBe('rfc1123');
     expect(TimestampFormat.UNIX).toBe('unix');
     expect(TimestampFormat.UNIX_MS).toBe('unix_ms');
+    expect(TimestampFormat.LOCALE).toBe('locale');
   });
 });
 
@@ -43,13 +44,14 @@ describe('TIMESTAMP_FORMAT_OPTIONS', () => {
     });
   });
 
-  it('contains exactly the five supported formats in order', () => {
+  it('contains exactly the six supported formats in order', () => {
     expect(TIMESTAMP_FORMAT_OPTIONS.map((o: { value: string }) => o.value)).toEqual([
       'iso8601',
       'rfc3339',
       'rfc1123',
       'unix',
       'unix_ms',
+      'locale',
     ]);
   });
 });
@@ -75,6 +77,10 @@ describe('formatTimestamp', () => {
     expect(formatTimestamp(FIXED_DATE, 'UTC', TimestampFormat.UNIX_MS)).toBe(String(FIXED_EPOCH_MS));
   });
 
+  it('formats Locale using Intl.DateTimeFormat', () => {
+    expect(formatTimestamp(FIXED_DATE, 'UTC', TimestampFormat.LOCALE).length).toBeGreaterThan(0);
+  });
+
   it('honours timezone for ISO 8601 (non-UTC offset)', () => {
     const formatted = formatTimestamp(FIXED_DATE, 'America/New_York', TimestampFormat.ISO_8601);
     expect(formatted).toMatch(/^2026-04-23T\d{2}:35:22\.123-04:00$/);
@@ -83,6 +89,12 @@ describe('formatTimestamp', () => {
   it('honours timezone for RFC 1123 (non-UTC offset)', () => {
     const formatted = formatTimestamp(FIXED_DATE, 'America/New_York', TimestampFormat.RFC_1123);
     expect(formatted).toMatch(/^Thu, 23 Apr 2026 \d{2}:35:22 -0400$/);
+  });
+
+  it('honours timezone for LOCALE (non-UTC offset)', () => {
+    const formattedUTC = formatTimestamp(FIXED_DATE, 'UTC', TimestampFormat.LOCALE);
+    const formattedNY = formatTimestamp(FIXED_DATE, 'America/New_York', TimestampFormat.LOCALE);
+    expect(formattedUTC).not.toBe(formattedNY);
   });
 
   it('accepts an ISO date string', () => {

--- a/dashboard-ui/src/lib/timestamp-format.ts
+++ b/dashboard-ui/src/lib/timestamp-format.ts
@@ -23,6 +23,7 @@ export const TimestampFormat = {
   RFC_1123: 'rfc1123',
   UNIX: 'unix',
   UNIX_MS: 'unix_ms',
+  LOCALE: 'locale',
 } as const;
 
 export type TimestampFormatValue = (typeof TimestampFormat)[keyof typeof TimestampFormat];
@@ -33,6 +34,19 @@ export const TIMESTAMP_FORMAT_OPTIONS: { value: TimestampFormatValue; label: str
   { value: TimestampFormat.RFC_1123, label: 'RFC 1123', hint: 'Mon, 02 Jan 2006 15:04:05 +0000' },
   { value: TimestampFormat.UNIX, label: 'Unix seconds', hint: '1136214245' },
   { value: TimestampFormat.UNIX_MS, label: 'Unix milliseconds', hint: '1136214245000' },
+  {
+    value: TimestampFormat.LOCALE,
+    label: 'Browser locale',
+    hint: new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      fractionalSecondDigits: 3,
+    }).format(new Date('2006-01-02T15:04:05.000Z')),
+  },
 ];
 
 const PATTERNS: Record<TimestampFormatValue, string> = {
@@ -41,6 +55,7 @@ const PATTERNS: Record<TimestampFormatValue, string> = {
   [TimestampFormat.RFC_1123]: 'EEE, dd MMM yyyy HH:mm:ss xx',
   [TimestampFormat.UNIX]: '',
   [TimestampFormat.UNIX_MS]: '',
+  [TimestampFormat.LOCALE]: '',
 };
 
 function coerceDate(date: Date | string): Date {
@@ -55,6 +70,18 @@ export function formatTimestamp(date: Date | string, timezone: string, format: s
   }
   if (format === TimestampFormat.UNIX_MS) {
     return String(d.getTime());
+  }
+  if (format === TimestampFormat.LOCALE) {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      fractionalSecondDigits: 3,
+      timeZone: timezone,
+    }).format(d);
   }
 
   const pattern = PATTERNS[format as TimestampFormatValue] ?? PATTERNS[TimestampFormat.ISO_8601];


### PR DESCRIPTION
<!-- PR title emoji:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

<!-- Related issues:
Closes #
Ref #
-->
Closes #1102 

## Summary
This PR adds a new timestamp formatting option that automatically adopts the user's browser region/locale settings. This allows users to see log timestamps in their local format (e.g. `27.04.2026, 06:25:29` for German locale) without needing to configure specific regional formats manually.

## Key Changes
- Added a new `LOCALE` timestamp format using the browser's native `Intl.DateTimeFormat` API (zero new dependencies).
- Added "Browser locale" to the timestamp settings dropdown, including a dynamically generated hint that previews what the local format will look like.
- Updated `formatTimestamp` to handle the new format alongside existing options like ISO 8601 and RFC 3339.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
