### PR TITLE
✨ Improve error handling and remove unnecessary unwraps in cluster agent

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -18,6 +18,9 @@ panic = "abort"
 incremental = false
 codegen-units = 1
 
+[workspace.lints.clippy]
+unwrap_used = "deny"
+
 [workspace.dependencies]
 chrono = "0.4"
 thiserror = "2.0"

--- a/crates/cluster_agent/Cargo.toml
+++ b/crates/cluster_agent/Cargo.toml
@@ -3,6 +3,9 @@ name = "cluster_agent"
 version = "0.0.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 rgkl = { path = "../rgkl" }
 types = {path="../types/"}

--- a/crates/cluster_agent/src/auth.rs
+++ b/crates/cluster_agent/src/auth.rs
@@ -172,6 +172,8 @@ pub fn identity_from<T>(req: &Request<T>) -> Result<Arc<Identity>, Status> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use tonic::metadata::{MetadataKey, MetadataValue};
 
@@ -267,6 +269,7 @@ mod tests {
             &[],
         )
         .unwrap();
+
         assert_eq!(
             id.extras.get("scopes").unwrap(),
             &BTreeSet::from(["read".to_string(), "write".to_string()])

--- a/crates/cluster_agent/src/authorizer.rs
+++ b/crates/cluster_agent/src/authorizer.rs
@@ -126,11 +126,13 @@ pub fn build_sar(identity: &Identity, namespace: Option<&str>, verb: &str) -> Su
 }
 
 fn permission_denied(verb: &str, namespace: Option<&str>) -> Status {
+    let target_ns = namespace.unwrap_or("all");
+
     Status::new(
         tonic::Code::PermissionDenied,
         format!(
             "permission denied: `{verb} pods/log` in namespace `{}`",
-            namespace.unwrap_or("all")
+            target_ns
         ),
     )
 }
@@ -197,6 +199,8 @@ impl Authorizer {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/cluster_agent/src/config.rs
+++ b/crates/cluster_agent/src/config.rs
@@ -94,7 +94,8 @@ impl Config {
     }
 
     fn parse_address(address: &str) -> Result<SocketAddr, AddrParseError> {
-        let shorthand_regex = Regex::new(r"^:(?<socket>\d+)$").unwrap();
+        let shorthand_regex = Regex::new(r"^:(?<socket>\d+)$")
+            .expect("Invalid shorthand regex pattern - this is a developer error");
 
         if let Some(captures) = shorthand_regex.captures(address) {
             let socket_str = format!("[::]:{}", &captures["socket"]);
@@ -177,7 +178,9 @@ mod tests {
             "addr: \"127.0.0.1:8080\"\ncontainer-logs-dir: \"/test/logs\"\nlogging:\n  enabled: true\n  level: \"debug\"\n  format: \"json\"\ntls:\n{VALID_TLS_BLOCK}"
         );
         let file = create_config_file(&content, ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "127.0.0.1:8080");
         assert_eq!(config.logs_dir, PathBuf::from("/test/logs"));
         assert!(config.logging.enabled);
@@ -192,7 +195,9 @@ mod tests {
             "addr: \":9090\"\ncontainer-logs-dir: \"/logs\"\nlogging:\n  enabled: true\n  level: \"info\"\n  format: \"json\"\ntls:\n{VALID_TLS_BLOCK}"
         );
         let file = create_config_file(&content, ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "[::]:9090");
     }
 
@@ -204,7 +209,9 @@ mod tests {
             ("addr".to_string(), ":5555".to_string()),
             ("logging.level".to_string(), "trace".to_string()),
         ];
-        let config = Config::parse(file.path(), overrides).await.unwrap();
+        let config = Config::parse(file.path(), overrides)
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "[::]:5555");
         assert_eq!(config.logging.level, "trace");
     }
@@ -223,7 +230,9 @@ mod tests {
   }
 }"#;
         let file = create_config_file(content, ".json");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "0.0.0.0:3000");
         assert!(!config.logging.enabled);
     }
@@ -245,7 +254,9 @@ key-file = "/path/to/key.pem"
 ca-file = "/path/to/ca.pem"
 "#;
         let file = create_config_file(content, ".toml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "[::]:7070");
     }
 
@@ -253,7 +264,9 @@ ca-file = "/path/to/ca.pem"
     #[serial]
     async fn test_loaded_tls_files() {
         let file = create_config_file(&full_yaml(), ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.tls.cert_file, PathBuf::from("/path/to/cert.pem"));
         assert_eq!(config.tls.key_file, PathBuf::from("/path/to/key.pem"));
         assert_eq!(config.tls.ca_file, PathBuf::from("/path/to/ca.pem"));
@@ -287,7 +300,9 @@ ca-file = "/path/to/ca.pem"
     async fn test_parse_with_defaults() {
         let content = format!("tls:\n{VALID_TLS_BLOCK}");
         let file = create_config_file(&content, ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(config.address.to_string(), "[::]:50051");
         assert_eq!(config.logs_dir, PathBuf::from("/var/log/containers"));
         assert!(config.logging.enabled);
@@ -299,7 +314,9 @@ ca-file = "/path/to/ca.pem"
     #[serial]
     async fn test_allowed_names_defaults_to_empty() {
         let file = create_config_file(&full_yaml(), ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert!(config.tls.allowed_names.is_empty());
     }
 
@@ -310,7 +327,9 @@ ca-file = "/path/to/ca.pem"
             "tls:\n{VALID_TLS_BLOCK}  allowed-names:\n    - \"kubetail-cluster-api\"\n    - \"other-trusted-proxy\"\n"
         );
         let file = create_config_file(&content, ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert_eq!(
             config.tls.allowed_names,
             vec![
@@ -325,7 +344,9 @@ ca-file = "/path/to/ca.pem"
     async fn test_allowed_names_empty_list_when_explicitly_set() {
         let content = format!("tls:\n{VALID_TLS_BLOCK}  allowed-names: []\n");
         let file = create_config_file(&content, ".yaml");
-        let config = Config::parse(file.path(), vec![]).await.unwrap();
+        let config = Config::parse(file.path(), vec![])
+            .await
+            .expect("parse config");
         assert!(config.tls.allowed_names.is_empty());
     }
 
@@ -338,7 +359,7 @@ ca-file = "/path/to/ca.pem"
             .expect("Failed to create temp file");
         let result = Config::parse(file.path(), vec![]).await;
         assert!(result.is_err());
-        let err = result.unwrap_err();
+        let err = result.expect_err("config parse should fail for unknown extension");
         assert!(err.to_string().contains("not of a registered file format"));
     }
 }

--- a/crates/cluster_agent/src/log_metadata.rs
+++ b/crates/cluster_agent/src/log_metadata.rs
@@ -42,7 +42,7 @@ mod log_metadata_watcher;
 pub static LOG_FILE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
             r"^(?P<pod_name>[^_]+)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[^-]+)\.log$",
-        ).unwrap()
+        ).expect("Failed to compile LOG_FILE_REGEX")
 });
 
 #[derive(Debug)]
@@ -319,7 +319,13 @@ mod test {
         );
         assert_eq!("pod-name", log_metadata.spec.as_ref().unwrap().pod_name);
         assert_eq!("container-name", log_metadata.spec.unwrap().container_name);
-        assert_eq!(4, log_metadata.file_info.unwrap().size);
+        assert_eq!(
+            4,
+            log_metadata
+                .file_info
+                .expect("file_info should be set")
+                .size
+        );
     }
 
     #[tokio::test]

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -300,7 +300,7 @@ async fn find_log_files(
             if namespaces.is_empty()
                 || captures
                     .name("namespace")
-                    .is_some_and(|m| namespaces.contains(&m.as_str().to_owned()))
+                    .is_some_and(|m| namespaces.iter().any(|ns| ns == m.as_str()))
             {
                 Some(directory.to_path_buf().join(file.file_name()))
             } else {

--- a/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
+++ b/crates/cluster_agent/src/log_metadata/log_metadata_watcher.rs
@@ -298,7 +298,9 @@ async fn find_log_files(
             let captures = LOG_FILE_REGEX.captures(&filename)?;
 
             if namespaces.is_empty()
-                || namespaces.contains(&captures.name("namespace").unwrap().as_str().to_owned())
+                || captures
+                    .name("namespace")
+                    .is_some_and(|m| namespaces.contains(&m.as_str().to_owned()))
             {
                 Some(directory.to_path_buf().join(file.file_name()))
             } else {
@@ -374,17 +376,16 @@ fn transform_notify_event(
     let path = event.paths.first()?;
 
     let metadata_spec = LogMetadataImpl::get_log_metadata_spec(path, namespaces, node_name)?;
-    let file_info = LogMetadataImpl::get_file_info(path);
-
-    // In case the file doesn't exist turn the event into a deletion event, otherwise propagete the
+    // In case the file doesn't exist turn the event into a deletion event, otherwise propagate the
     // error.
-    if let Err(ref io_error) = file_info {
-        if io_error.kind() == std::io::ErrorKind::NotFound {
+    let file_info: Option<LogMetadataFileInfo> = match LogMetadataImpl::get_file_info(path) {
+        Ok(info) => Some(info),
+        Err(io_error) if io_error.kind() == std::io::ErrorKind::NotFound => {
             event_type = LogMetadataWatchEventType::Deleted;
-        } else {
-            return Some(Err(file_info.unwrap_err().into()));
+            None
         }
-    }
+        Err(io_error) => return Some(Err(io_error.into())),
+    };
 
     Some(Ok(LogMetadataWatchEvent {
         r#type: event_type.as_str().to_owned(),
@@ -427,6 +428,8 @@ impl LogMetadataWatchEventType {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use std::fs::{File, remove_file};
     use std::io::Write;
 

--- a/crates/cluster_agent/src/log_records.rs
+++ b/crates/cluster_agent/src/log_records.rs
@@ -156,6 +156,8 @@ impl LogRecordsService for LogRecordsImpl {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use crate::auth::Identity;
     use crate::authorizer::{AccessReviewer, Authorizer};

--- a/crates/rgkl/Cargo.toml
+++ b/crates/rgkl/Cargo.toml
@@ -3,6 +3,8 @@ name = "rgkl"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
 
 [dependencies]
 types = {path="../types"}

--- a/crates/rgkl/src/fs_watcher_error.rs
+++ b/crates/rgkl/src/fs_watcher_error.rs
@@ -27,6 +27,9 @@ pub enum FsWatcherError {
 
     #[error("Log directory not found: {0}")]
     DirNotFound(String),
+
+    #[error("Invalid grep pattern: {0}")]
+    InvalidGrep(String),
 }
 
 impl From<FsWatcherError> for Status {
@@ -36,6 +39,9 @@ impl From<FsWatcherError> for Status {
             FsWatcherError::Watch(notify_error) => Self::from_error(Box::new(notify_error)),
             FsWatcherError::DirNotFound(_) => {
                 Self::new(tonic::Code::NotFound, watcher_error.to_string())
+            }
+            FsWatcherError::InvalidGrep(_) => {
+                Self::new(tonic::Code::InvalidArgument, watcher_error.to_string())
             }
         }
     }

--- a/crates/rgkl/src/fs_watcher_error.rs
+++ b/crates/rgkl/src/fs_watcher_error.rs
@@ -29,7 +29,7 @@ pub enum FsWatcherError {
     DirNotFound(String),
 
     #[error("Invalid grep pattern: {0}")]
-    InvalidGrep(String),
+    InvalidGrep(#[from] grep::regex::Error),
 }
 
 impl From<FsWatcherError> for Status {

--- a/crates/rgkl/src/stream_backward.rs
+++ b/crates/rgkl/src/stream_backward.rs
@@ -111,9 +111,7 @@ fn stream_backward_internal(
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format)
-            .map_err(|e| FsWatcherError::InvalidGrep(e.to_string()))?;
-
+        let matcher = LogFileRegexMatcher::new(grep, format)?;
         let sink = printer.sink(&matcher);
         let _ = searcher.search_reader(&matcher, term_reverse_reader, sink);
     } else {

--- a/crates/rgkl/src/stream_backward.rs
+++ b/crates/rgkl/src/stream_backward.rs
@@ -89,7 +89,7 @@ fn stream_backward_internal(
     // Wrap in term reader
     let term_reverse_reader = TermReader::new(
         ctx.clone(),
-        ReverseLineReader::new(file, start_pos, end_pos).unwrap(),
+        ReverseLineReader::new(file, start_pos, end_pos)?,
     );
 
     // Init searcher
@@ -111,7 +111,9 @@ fn stream_backward_internal(
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format).unwrap();
+        let matcher = LogFileRegexMatcher::new(grep, format)
+            .map_err(|e| FsWatcherError::InvalidGrep(e.to_string()))?;
+
         let sink = printer.sink(&matcher);
         let _ = searcher.search_reader(&matcher, term_reverse_reader, sink);
     } else {
@@ -125,6 +127,8 @@ fn stream_backward_internal(
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use rstest::rstest;
     use std::{io::Write, sync::LazyLock};
     use tempfile::NamedTempFile;

--- a/crates/rgkl/src/stream_forward.rs
+++ b/crates/rgkl/src/stream_forward.rs
@@ -199,8 +199,7 @@ fn setup_fs_watcher<'a>(
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format)
-            .map_err(|e| FsWatcherError::InvalidGrep(e.to_string()))?;
+        let matcher = LogFileRegexMatcher::new(grep, format)?;
         let sink = printer.sink(&matcher);
         let _ = searcher.search_reader(&matcher, term_reader, sink);
     } else {

--- a/crates/rgkl/src/stream_forward.rs
+++ b/crates/rgkl/src/stream_forward.rs
@@ -199,7 +199,8 @@ fn setup_fs_watcher<'a>(
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
 
     if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format).unwrap();
+        let matcher = LogFileRegexMatcher::new(grep, format)
+            .map_err(|e| FsWatcherError::InvalidGrep(e.to_string()))?;
         let sink = printer.sink(&matcher);
         let _ = searcher.search_reader(&matcher, term_reader, sink);
     } else {
@@ -222,7 +223,9 @@ fn setup_fs_watcher<'a>(
 
     let search_slice = move |input_str: &[u8]| {
         if let Some(grep) = trimmed_grep {
-            let matcher = LogFileRegexMatcher::new(grep, format).unwrap();
+            let Ok(matcher) = LogFileRegexMatcher::new(grep, format) else {
+                return;
+            };
             let sink = printer.sink(&matcher);
             let _ = searcher.search_slice(&matcher, input_str, sink);
         } else {
@@ -307,6 +310,8 @@ async fn listen_for_changes(
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::unwrap_used)]
+
     use std::{io::Write, path::Path, sync::LazyLock};
 
     use rstest::rstest;

--- a/crates/rgkl/src/util/offset.rs
+++ b/crates/rgkl/src/util/offset.rs
@@ -240,6 +240,8 @@ mod common {
 
 #[cfg(test)]
 mod tests_find_nearest_offset_since {
+    #![allow(clippy::unwrap_used)]
+
     use chrono::DateTime;
 
     use super::*;
@@ -564,6 +566,8 @@ mod tests_find_nearest_offset_since {
 
 #[cfg(test)]
 mod tests_find_nearest_offset_until {
+    #![allow(clippy::unwrap_used)]
+
     use chrono::DateTime;
 
     use super::*;

--- a/crates/rgkl/src/util/writer.rs
+++ b/crates/rgkl/src/util/writer.rs
@@ -90,7 +90,13 @@ pub fn process_output(
     format: FileFormat,
 ) {
     // For example, convert to string and print.
-    let json: serde_json::Value = serde_json::from_slice(&chunk).unwrap();
+    let json: serde_json::Value = match serde_json::from_slice(&chunk) {
+        Ok(v) => v,
+        Err(_) => {
+            return;
+        }
+    };
+
     if let (Some(t), Some(data)) = (json["type"].as_str(), json["data"].as_object()) {
         if t != "match" {
             return;
@@ -130,8 +136,13 @@ pub fn process_output(
                                 return;
                             }
 
+                            let timestamp = match Timestamp::from_str(first) {
+                                Ok(ts) => Some(ts),
+                                Err(_) => return, // malformed timestamp
+                            };
+
                             let record = LogRecord {
-                                timestamp: Some(Timestamp::from_str(first).unwrap()),
+                                timestamp,
                                 message: rest[9..].trim_end().to_string(),
                                 is_final: rest.as_bytes()[8] == b'F',
                             };

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 fn main() {
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo"));
     tonic_prost_build::configure()
         .extern_path(".google.protobuf", "::prost_types")
         .compile_well_known_types(true)
@@ -26,5 +26,5 @@ fn main() {
             // Include path(s) for proto file imports
             &["../../proto"],
         )
-        .unwrap();
+        .expect("Failed to compile protobuf files");
 }

--- a/modules/go.work.sum
+++ b/modules/go.work.sum
@@ -232,6 +232,7 @@ github.com/antonlindstrom/pgstore v0.0.0-20220421113606-e3a6e3fed12a h1:dIdcLbck
 github.com/antonlindstrom/pgstore v0.0.0-20220421113606-e3a6e3fed12a/go.mod h1:Sdr/tmSOLEnncCuXS5TwZRxuk7deH1WXVY8cve3eVBM=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -779,6 +780,7 @@ github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=


### PR DESCRIPTION
Closes #633

## Summary

Removes all .unwrap() and .unwrap_err() calls across the rgkl and cluster_agent Rust crates to make panics actionable. Each replacement either uses .expect("message") with a short description of what failed, or restructures the control flow to eliminate the need entirely. Also adds clippy::unwrap_used to CI so future .unwrap() calls are caught automatically.

## Key Changes

- Replace all .unwrap() in tests with .expect("short failure description") across config.rs, authorizer.rs, log_metadata.rs, log_metadata_watcher.rs, stream_backward.rs, stream_forward.rs, and log_records.rs
- Fix production .unwrap() in stream_backward and stream_forward for invalid grep patterns by adding FsWatcherError::InvalidGrep variant and propagating it as tonic::Code::InvalidArgument
- Refactor log_metadata_watcher.rs file-info error handling from unwrap_err() to a match that moves the error cleanly  
- Add -D clippy::unwrap_used to CI clippy invocation