### PR TITLE
✨ Add install.sh health checks to package-healthcheck cronjob

### DIFF
--- a/.github/workflows/package-healthcheck.yml
+++ b/.github/workflows/package-healthcheck.yml
@@ -802,6 +802,112 @@ jobs:
           path: ${{ runner.temp }}/results/*.txt
           retention-days: 1
 
+  install-sh:
+    if: github.repository == 'kubetail-org/kubetail'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - linux
+          - macos
+          - windows
+        arch:
+          - amd64
+          - arm64
+        include:
+          - os: linux
+            arch: amd64
+            runner: ubuntu-24.04
+          - os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - os: macos
+            arch: amd64
+            runner: macos-26-intel
+          - os: macos
+            arch: arm64
+            runner: macos-26
+          - os: windows
+            arch: amd64
+            runner: windows-2025-vs2026
+          - os: windows
+            arch: arm64
+            runner: windows-11-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      TRIPLET: install-sh_${{ matrix.os }}_${{ matrix.arch }}
+    steps:
+      - name: Install
+        if: matrix.os != 'windows'
+        shell: bash
+        env:
+          KUBETAIL_INSTALL_DIR: /tmp/kubetail-bin
+        run: |
+          set -euxo pipefail
+          curl -sS https://www.kubetail.com/install.sh | bash
+
+      - name: Install
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+          & curl.exe -sS https://www.kubetail.com/install.sh | & "C:\Program Files\Git\bin\bash.exe"
+
+      - name: Add HOME/bin to PATH
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+          $homeBin = Join-Path $env:USERPROFILE "bin"
+          $homeBin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      - name: Check version
+        if: matrix.os != 'windows'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cli_ver="$(/tmp/kubetail-bin/kubetail --version)"
+
+          # Save result for summary table
+          mkdir -p /tmp/results
+          echo "${cli_ver}" > "/tmp/results/${{ env.TRIPLET }}.txt"
+
+      - name: Check version
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+          $out = & kubetail.exe --version 2>&1
+          $ver = ($out | Select-String -Pattern '\d+\.\d+\.\d+' -AllMatches).Matches.Value | Select-Object -First 1
+          if (-not $ver) {
+            Write-Warning "Could not parse version from output: $out"
+            $ver = "unknown"
+          }
+
+          # Save result for summary table
+          $resultsDir = Join-Path $env:RUNNER_TEMP "results"
+          New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+          Set-Content -Path "$resultsDir\${{ env.TRIPLET }}.txt" -Value $ver
+
+      - name: Upload result
+        if: matrix.os != 'windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: version-${{ env.TRIPLET }}
+          path: /tmp/results/*.txt
+          retention-days: 1
+
+      - name: Upload result
+        if: matrix.os == 'windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: version-${{ env.TRIPLET }}
+          path: ${{ runner.temp }}/results/*.txt
+          retention-days: 1
+
   summary:
     needs:
       - linux
@@ -814,6 +920,7 @@ jobs:
       - linux-zypper
       - macos
       - windows
+      - install-sh
     runs-on: ubuntu-24.04
     if: always() && github.repository == 'kubetail-org/kubetail'
     steps:


### PR DESCRIPTION
Closes #1083
Ref #1082

## Summary

The curl-pipe installer (`install.sh`) had no automated test coverage, which
is how #1082 went undetected until users started hitting it. This PR adds a
new `install-sh` job to the daily `package-healthcheck.yml` cronjob that runs
the real user-facing install command across all six supported OS/arch combos
and surfaces the installed version in the existing summary table.

## Key Changes

- New `install-sh` job in `package-healthcheck.yml` covering all six supported
  platform combos: Linux and macOS on native arm64/amd64 runners, Windows on
  `windows-2025` and `windows-11-arm`
- Unix steps set `KUBETAIL_INSTALL_DIR=/tmp/kubetail-bin` so the install does
  not depend on passwordless sudo
- Windows steps invoke the script under Git Bash, append `$env:USERPROFILE\bin`
  to `$GITHUB_PATH` before the version check, and follow the same
  `$ErrorActionPreference`/`$ProgressPreference` preamble used in the existing
  `windows` job
- `install-sh` added to `summary.needs` so results show up in the daily table

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused