### PR TITLE
✨ Add Python lint job to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,19 @@ jobs:
       - name: Run shellcheck
         run: shellcheck scripts/install.sh
 
+  python-lint:
+    name: Python · Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Lint
+        working-directory: ./e2e
+        run: |
+          uv sync --group dev
+          uv run ruff check .
+          uv run ruff format --check .
+
   ###########################
   # Test jobs
   ###########################
@@ -543,6 +556,7 @@ jobs:
     name: E2E (k8s ${{ matrix.k8s-version }})
     needs:
       - docker-builds
+      - python-lint
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,19 @@ cargo test
 cargo build --release
 ```
 
+### Python (E2E Tests)
+
+```bash
+cd e2e
+
+# Install dependencies (including dev tools)
+uv sync --group dev
+
+# Lint
+uv run ruff check .
+uv run ruff format --check .
+```
+
 ## Commit Guidelines
 
 Keep commits minimal and focused. Multiple commits in a PR are fine if they represent logical, well-separated steps that make the change easier to review.

--- a/e2e/_kubeconfig.py
+++ b/e2e/_kubeconfig.py
@@ -22,6 +22,7 @@ class ApiserverAccess:
     `cert_path` / `key_path` are paths to PEM files written to a private
     temp dir; callers can pass them to `ssl.SSLContext.load_cert_chain`.
     """
+
     server: str
     ca_path: str
     cert_path: str

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -51,8 +51,7 @@ def _cluster_ready(request):
         resp.raise_for_status()
     except Exception as e:
         pytest.fail(
-            f"e2e dashboard not reachable at {url} — run e2e/scripts/up.sh "
-            f"first ({e})"
+            f"e2e dashboard not reachable at {url} — run e2e/scripts/up.sh first ({e})"
         )
 
 
@@ -104,9 +103,7 @@ def serve_url(cli):
     if Path(_E2E_KUBECONFIG).exists():
         env["KUBECONFIG"] = _E2E_KUBECONFIG
     elif not Path(env.get("KUBECONFIG", Path.home() / ".kube" / "config")).exists():
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".kubeconfig", delete=False
-        )
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".kubeconfig", delete=False)
         tmp.write(_DUMMY_KUBECONFIG)
         tmp.flush()
         env["KUBECONFIG"] = tmp.name
@@ -154,9 +151,12 @@ def log_producer(_cluster_ready):
     kubectl("apply", "-f", "-", input=rendered_manifest())
     try:
         kubectl(
-            "rollout", "status",
-            "deployment", LP_NAME,
-            "-n", LP_NS,
+            "rollout",
+            "status",
+            "deployment",
+            LP_NAME,
+            "-n",
+            LP_NS,
             "--timeout=60s",
         )
         yield LogProducer(namespace=LP_NS, name=LP_NAME, line_prefix=LP_LINE_PREFIX)
@@ -204,10 +204,16 @@ def restricted_sa_tokens(_cluster_ready):
         for ns in (SA1_NS, SA2_NS, GROUP_NS):
             kubectl("delete", "namespace", ns, "--wait=false", check=False)
         kubectl(
-            "delete", "clusterrolebinding", BASELINE_CLUSTER_ROLE,
-            "--ignore-not-found", check=False,
+            "delete",
+            "clusterrolebinding",
+            BASELINE_CLUSTER_ROLE,
+            "--ignore-not-found",
+            check=False,
         )
         kubectl(
-            "delete", "clusterrole", BASELINE_CLUSTER_ROLE,
-            "--ignore-not-found", check=False,
+            "delete",
+            "clusterrole",
+            BASELINE_CLUSTER_ROLE,
+            "--ignore-not-found",
+            check=False,
         )

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -10,6 +10,14 @@ dependencies = [
     "websockets>=13.0",
 ]
 
+[dependency-groups]
+dev = [
+    "ruff>=0.9",
+]
+
+[tool.ruff]
+target-version = "py311"
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore::urllib3.exceptions.InsecureRequestWarning",

--- a/e2e/test_allowed_namespaces.py
+++ b/e2e/test_allowed_namespaces.py
@@ -49,9 +49,7 @@ _PODS_LIST_QUERY = (
     "coreV1PodsList(namespace:$namespace){items{metadata{name namespace}}}}"
 )
 
-_NAMESPACES_LIST_QUERY = (
-    "query Q{coreV1NamespacesList{items{metadata{name}}}}"
-)
+_NAMESPACES_LIST_QUERY = "query Q{coreV1NamespacesList{items{metadata{name}}}}"
 
 _LOG_METADATA_QUERY = (
     "query Q($namespace:String){"
@@ -89,9 +87,7 @@ def _patch_allowed_namespaces(configmap, allowed):
         count=1,
         flags=re.MULTILINE,
     )
-    assert count == 1, (
-        f"allowed-namespaces line not found in ConfigMap {configmap}"
-    )
+    assert count == 1, f"allowed-namespaces line not found in ConfigMap {configmap}"
     cm["data"]["config.yaml"] = new_blob
     kubectl("apply", "-f", "-", input=json.dumps(cm))
 
@@ -102,8 +98,12 @@ def _rollout_restart(deployment):
 
 def _rollout_wait(deployment):
     kubectl(
-        "rollout", "status", f"deployment/{deployment}",
-        "-n", _KUBE_NS, "--timeout=120s",
+        "rollout",
+        "status",
+        f"deployment/{deployment}",
+        "-n",
+        _KUBE_NS,
+        "--timeout=120s",
     )
 
 
@@ -134,9 +134,13 @@ def _kill_existing_port_forwards():
 def _start_port_forward(service, local_port, remote_port):
     return subprocess.Popen(
         [
-            "kubectl", f"--kubeconfig={KUBECONFIG}",
-            "port-forward", "-n", _KUBE_NS,
-            f"service/{service}", f"{local_port}:{remote_port}",
+            "kubectl",
+            f"--kubeconfig={KUBECONFIG}",
+            "port-forward",
+            "-n",
+            _KUBE_NS,
+            f"service/{service}",
+            f"{local_port}:{remote_port}",
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -169,8 +173,11 @@ def _wait_for_apiservice_available(name="v1.api.kubetail.com", timeout=60):
     last_status = None
     while time.monotonic() < deadline:
         out = kubectl(
-            "get", "apiservice", name,
-            "-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+            "get",
+            "apiservice",
+            name,
+            "-o",
+            "jsonpath={.status.conditions[?(@.type=='Available')].status}",
         ).stdout.strip()
         last_status = out
         if out == "True":
@@ -228,10 +235,14 @@ def _reconfigure(allowed, *, dashboard_url, cluster_api_url):
 
     procs = [
         _start_port_forward(
-            "kubetail-dashboard", _port_from_url(dashboard_url), 8080,
+            "kubetail-dashboard",
+            _port_from_url(dashboard_url),
+            8080,
         ),
         _start_port_forward(
-            "kubetail-cluster-api", _port_from_url(cluster_api_url), 443,
+            "kubetail-cluster-api",
+            _port_from_url(cluster_api_url),
+            443,
         ),
     ]
     Path(_PF_PID_FILE).write_text("\n".join(str(p.pid) for p in procs) + "\n")
@@ -334,7 +345,9 @@ class TestDashboardAllowedNamespaces:
         assert names == [_ALLOWED_NS], body
 
     def test_user_without_rbac_denied_for_logs_in_allowed(
-        self, restricted_deployments, restricted_sa_tokens,
+        self,
+        restricted_deployments,
+        restricted_sa_tokens,
     ):
         """The user-RBAC enforcement that allowed-namespaces must not
         override is exercised by log streaming: the bearer token rides
@@ -390,7 +403,9 @@ class TestClusterAPIAllowedNamespaces:
         assert graphql_field(body, "logMetadataList") is not None, body
 
     def test_user_without_rbac_denied_in_allowed(
-        self, restricted_deployments, restricted_sa_tokens,
+        self,
+        restricted_deployments,
+        restricted_sa_tokens,
     ):
         """Mirror of the dashboard test, but exercising the cluster-agent's
         identity-keyed SAR. SA2's token rides the aggregation chain to the

--- a/e2e/test_auth_mode_token.py
+++ b/e2e/test_auth_mode_token.py
@@ -37,13 +37,12 @@ _DASHBOARD_LOG_FETCH = (
     "{records{message}}}"
 )
 _CLUSTER_API_LOG_METADATA = (
-    "query Q($namespace:String){"
-    "logMetadataList(namespace:$namespace)"
-    "{items{id}}}"
+    "query Q($namespace:String){logMetadataList(namespace:$namespace){items{id}}}"
 )
 
 _PROTECTED_PATHS = pytest.mark.parametrize(
-    "path", ["/graphql", "/cluster-api-proxy/graphql"],
+    "path",
+    ["/graphql", "/cluster-api-proxy/graphql"],
 )
 
 _FORWARDING_CASES = pytest.mark.parametrize(
@@ -135,9 +134,13 @@ spec:
 
 def _dashboard_image() -> str:
     out = kubectl(
-        "-n", _NS,
-        "get", "deployment", "kubetail-dashboard",
-        "-o", "jsonpath={.spec.template.spec.containers[0].image}",
+        "-n",
+        _NS,
+        "get",
+        "deployment",
+        "kubetail-dashboard",
+        "-o",
+        "jsonpath={.spec.template.spec.containers[0].image}",
     ).stdout.strip()
     assert out, "could not resolve dashboard image"
     return out
@@ -151,18 +154,27 @@ def token_dashboard_url(cluster_api_url):
     kubectl("apply", "-f", "-", input=_manifest(_dashboard_image()))
     try:
         kubectl(
-            "-n", _NS, "rollout", "status", f"deployment/{_NAME}",
+            "-n",
+            _NS,
+            "rollout",
+            "status",
+            f"deployment/{_NAME}",
             "--timeout=120s",
         )
 
         local_port = free_port()
         pf = subprocess.Popen(
             [
-                "kubectl", f"--kubeconfig={KUBECONFIG}",
-                "-n", _NS, "port-forward",
-                f"service/{_NAME}", f"{local_port}:8080",
+                "kubectl",
+                f"--kubeconfig={KUBECONFIG}",
+                "-n",
+                _NS,
+                "port-forward",
+                f"service/{_NAME}",
+                f"{local_port}:8080",
             ],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         try:
             base = f"http://localhost:{local_port}"
@@ -189,8 +201,14 @@ def token_dashboard_url(cluster_api_url):
     finally:
         for kind in ("service", "deployment", "configmap"):
             kubectl(
-                "-n", _NS, "delete", kind, _NAME,
-                "--ignore-not-found", "--wait=false", check=False,
+                "-n",
+                _NS,
+                "delete",
+                kind,
+                _NAME,
+                "--ignore-not-found",
+                "--wait=false",
+                check=False,
             )
 
 
@@ -200,8 +218,13 @@ def dashboard_sa_token():
     everything the dashboard itself can do, so happy-path requests through
     token mode succeed end-to-end."""
     out = kubectl(
-        "create", "token", "kubetail-dashboard",
-        "-n", _NS, "--duration", "1h",
+        "create",
+        "token",
+        "kubetail-dashboard",
+        "-n",
+        _NS,
+        "--duration",
+        "1h",
     ).stdout.strip()
     assert out, "empty SA token"
     return out
@@ -271,7 +294,9 @@ class TestHTTPRequiresBearer:
     @_PROTECTED_PATHS
     def test_bearer_passes(self, token_dashboard_url, dashboard_sa_token, path):
         r = _post_graphql(
-            token_dashboard_url, path, "{__typename}",
+            token_dashboard_url,
+            path,
+            "{__typename}",
             bearer=dashboard_sa_token,
         )
         assert r.status_code == 200, r.text
@@ -282,25 +307,35 @@ class TestWebSocketRequiresBearer:
     @_PROTECTED_PATHS
     def test_no_bearer_rejected(self, token_dashboard_url, path):
         s, _ = session(token_dashboard_url)
-        status = asyncio.run(_ws_upgrade(
-            _ws_url(token_dashboard_url, path),
-            origin=token_dashboard_url, cookies=s.cookies, bearer=None,
-        ))
+        status = asyncio.run(
+            _ws_upgrade(
+                _ws_url(token_dashboard_url, path),
+                origin=token_dashboard_url,
+                cookies=s.cookies,
+                bearer=None,
+            )
+        )
         assert status == 401, f"expected 401 on upgrade, got {status}"
 
     @_PROTECTED_PATHS
     def test_bearer_passes_upgrade(
-        self, token_dashboard_url, dashboard_sa_token, path,
+        self,
+        token_dashboard_url,
+        dashboard_sa_token,
+        path,
     ):
         # Pins only that the auth gate lets the upgrade through. We don't
         # complete the GraphQL handshake — InitFunc still requires the
         # session's CSRF token, and that gate is covered by test_csrf.py.
         s, _ = session(token_dashboard_url)
-        status = asyncio.run(_ws_upgrade(
-            _ws_url(token_dashboard_url, path),
-            origin=token_dashboard_url, cookies=s.cookies,
-            bearer=dashboard_sa_token,
-        ))
+        status = asyncio.run(
+            _ws_upgrade(
+                _ws_url(token_dashboard_url, path),
+                origin=token_dashboard_url,
+                cookies=s.cookies,
+                bearer=dashboard_sa_token,
+            )
+        )
         assert status is None, f"expected upgrade to succeed, got status {status}"
 
 
@@ -328,11 +363,20 @@ class TestBearerForwarded:
     )
     @_FORWARDING_CASES
     def test_identity_threading(
-        self, token_dashboard_url, restricted_sa_tokens,
-        path, query, variables_for, namespace, expect_denial,
+        self,
+        token_dashboard_url,
+        restricted_sa_tokens,
+        path,
+        query,
+        variables_for,
+        namespace,
+        expect_denial,
     ):
         r = _post_graphql(
-            token_dashboard_url, path, query, variables_for(namespace),
+            token_dashboard_url,
+            path,
+            query,
+            variables_for(namespace),
             bearer=restricted_sa_tokens[SA1_NS],
         )
         assert r.status_code == 200, r.text

--- a/e2e/test_cli.py
+++ b/e2e/test_cli.py
@@ -58,9 +58,13 @@ def backend(request):
 def test_logs_tail(cli, log_producer, backend):
     result = subprocess.run(
         [
-            cli, "logs", log_producer.source,
-            "--backend", backend,
-            "--tail", "5",
+            cli,
+            "logs",
+            log_producer.source,
+            "--backend",
+            backend,
+            "--tail",
+            "5",
             "--raw",
         ],
         capture_output=True,
@@ -82,8 +86,11 @@ def test_logs_tail(cli, log_producer, backend):
 def test_logs_follow(cli, log_producer, backend):
     proc = subprocess.Popen(
         [
-            cli, "logs", log_producer.source,
-            "--backend", backend,
+            cli,
+            "logs",
+            log_producer.source,
+            "--backend",
+            backend,
             "--follow",
             "--raw",
         ],

--- a/e2e/test_cluster_api_websocket_auth.py
+++ b/e2e/test_cluster_api_websocket_auth.py
@@ -125,6 +125,7 @@ def test_cluster_api_rejects_direct_ws_upgrade_without_front_proxy_cert(
     # production is the apiserver layer above; this layer's job is the
     # 401 once a TLS handshake completes.)
     import ssl as _ssl
+
     ctx = _ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = _ssl.CERT_NONE

--- a/e2e/test_csrf.py
+++ b/e2e/test_csrf.py
@@ -39,9 +39,7 @@ def env(request):
 
 @pytest.fixture
 def target_url(env, request):
-    return request.getfixturevalue(
-        "dashboard_url" if env == "cluster" else "serve_url"
-    )
+    return request.getfixturevalue("dashboard_url" if env == "cluster" else "serve_url")
 
 
 @pytest.fixture
@@ -106,7 +104,8 @@ async def _ws_upgrade(ws_url, *, origin=None, cookies=None, extra_headers=None):
             ws_url,
             subprotocols=[_WS_SUBPROTOCOL],
             additional_headers=_ws_headers(
-                origin=origin, cookies=cookies, extra=extra_headers),
+                origin=origin, cookies=cookies, extra=extra_headers
+            ),
             open_timeout=5,
         ):
             return True
@@ -114,7 +113,9 @@ async def _ws_upgrade(ws_url, *, origin=None, cookies=None, extra_headers=None):
         return False
 
 
-async def _ws_send_init(ws_url, *, origin, cookies=None, csrf_token=None, url_suffix=""):
+async def _ws_send_init(
+    ws_url, *, origin, cookies=None, csrf_token=None, url_suffix=""
+):
     """Complete the upgrade, send connection_init, return the first message.
 
     Returns {"type": "connection_error"} if the server closes cleanly on
@@ -174,92 +175,138 @@ _WS_ORIGIN_CASES = pytest.mark.parametrize(
 
 
 class TestDashboardHTTPCSRF:
-
     @_SEC_FETCH_SITE_REJECTED_CASES
     def test_sec_fetch_site_rejected(self, target_url, sec_fetch_site):
         s, tok = _session(target_url)
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site=sec_fetch_site,
-                  csrf_token=tok, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site=sec_fetch_site,
+            csrf_token=tok,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     @_SEC_FETCH_SITE_ALLOWED_CASES
     def test_sec_fetch_site_allowed_with_valid_token(self, target_url, sec_fetch_site):
         s, tok = _session(target_url)
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site=sec_fetch_site,
-                  csrf_token=tok, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site=sec_fetch_site,
+            csrf_token=tok,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 200
 
     @_TOKEN_CASES
     def test_csrf_token_rejected(self, target_url, bad_token):
         s, _ = _session(target_url)
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site="same-origin",
-                  csrf_token=bad_token, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site="same-origin",
+            csrf_token=bad_token,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     def test_cross_session_token_rejected(self, target_url):
         _, tok_other = _session(target_url)
         s, _ = _session(target_url)
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site="same-origin",
-                  csrf_token=tok_other, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site="same-origin",
+            csrf_token=tok_other,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     def test_form_without_csrf_field_rejected(self, target_url):
         s, _ = _session(target_url)
-        r = _post(s, f"{target_url}/graphql",
-                  sec_fetch_site="same-origin", data={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site="same-origin",
+            data={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     def test_forwarded_csrf_token_smuggling_rejected(self, target_url):
         s, _ = _session(target_url)
-        headers = {"Sec-Fetch-Site": "same-origin",
-                   "X-Forwarded-CSRF-Token": "attacker-token"}
-        r = s.post(f"{target_url}/graphql", headers=headers,
-                   json={"query": "{__typename}"})
+        headers = {
+            "Sec-Fetch-Site": "same-origin",
+            "X-Forwarded-CSRF-Token": "attacker-token",
+        }
+        r = s.post(
+            f"{target_url}/graphql", headers=headers, json={"query": "{__typename}"}
+        )
         assert r.status_code == 403
 
     def test_valid_csrf_passes(self, target_url):
         s, tok = _session(target_url)
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site="same-origin",
-                  csrf_token=tok, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site="same-origin",
+            csrf_token=tok,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code != 403
 
     def test_text_plain_content_type_rejected(self, target_url):
         """text/plain with a JSON body is a CORS-simple request — must still be CSRF-rejected."""
         s, _ = _session(target_url)
-        headers = {"Sec-Fetch-Site": "same-origin",
-                   "Content-Type": "text/plain"}
-        r = s.post(f"{target_url}/graphql", headers=headers,
-                   data=json.dumps({"query": "{__typename}"}))
+        headers = {"Sec-Fetch-Site": "same-origin", "Content-Type": "text/plain"}
+        r = s.post(
+            f"{target_url}/graphql",
+            headers=headers,
+            data=json.dumps({"query": "{__typename}"}),
+        )
         assert r.status_code == 403
 
     def test_get_mutation_rejected(self, target_url):
         """Mutations via GET (CORS-simple, browser-fireable cross-origin) must not succeed."""
         s, tok = _session(target_url)
         headers = {"Sec-Fetch-Site": "same-origin", "X-CSRF-Token": tok}
-        r = s.get(f"{target_url}/graphql",
-                  params={"query": "mutation { __typename }"}, headers=headers)
+        r = s.get(
+            f"{target_url}/graphql",
+            params={"query": "mutation { __typename }"},
+            headers=headers,
+        )
         assert r.status_code >= 400 or "errors" in r.json()
 
     def test_token_without_session_rejected(self, target_url):
         """A fabricated token with no session cookie must not pass."""
         s = requests.Session()
-        r = _post(s, f"{target_url}/graphql", sec_fetch_site="same-origin",
-                  csrf_token="deadbeef", json={"query": "{__typename}"})
+        r = _post(
+            s,
+            f"{target_url}/graphql",
+            sec_fetch_site="same-origin",
+            csrf_token="deadbeef",
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     def test_query_string_token_rejected(self, target_url):
         """Token must come from header or form body, not URL query (avoids leak via Referer/logs)."""
         s, tok = _session(target_url)
         headers = {"Sec-Fetch-Site": "same-origin"}
-        r = s.post(f"{target_url}/graphql", params={"csrfToken": tok},
-                   headers=headers, json={"query": "{__typename}"})
+        r = s.post(
+            f"{target_url}/graphql",
+            params={"csrfToken": tok},
+            headers=headers,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code == 403
 
     def test_logout_endpoint_csrf_rejected(self, target_url):
         """Other mutation endpoints (e.g. /api/auth/logout) must enforce CSRF too."""
         s, _ = _session(target_url)
-        r = s.post(f"{target_url}/api/auth/logout",
-                   headers={"Sec-Fetch-Site": "same-origin"})
+        r = s.post(
+            f"{target_url}/api/auth/logout", headers={"Sec-Fetch-Site": "same-origin"}
+        )
         assert r.status_code == 403
 
 
@@ -269,7 +316,6 @@ class TestDashboardHTTPCSRF:
 
 
 class TestDashboardWSCSWSH:
-
     @_WS_ORIGIN_CASES
     def test_ws_cross_origin_upgrade_rejected(self, dashboard_ws_url, origin):
         assert not asyncio.run(_ws_upgrade(dashboard_ws_url, origin=origin)), (
@@ -283,39 +329,57 @@ class TestDashboardWSCSWSH:
 
     def test_ws_missing_csrf_token_rejected(self, target_url, dashboard_ws_url):
         s, _ = _session(target_url)
-        msg = asyncio.run(_ws_send_init(dashboard_ws_url,
-                          origin=target_url, cookies=s.cookies))
+        msg = asyncio.run(
+            _ws_send_init(dashboard_ws_url, origin=target_url, cookies=s.cookies)
+        )
         _assert_ws_rejected(msg, "missing csrfToken")
 
     def test_ws_wrong_csrf_token_rejected(self, target_url, dashboard_ws_url):
         s, _ = _session(target_url)
-        msg = asyncio.run(_ws_send_init(
-            dashboard_ws_url, origin=target_url, cookies=s.cookies, csrf_token="deadbeef"))
+        msg = asyncio.run(
+            _ws_send_init(
+                dashboard_ws_url,
+                origin=target_url,
+                cookies=s.cookies,
+                csrf_token="deadbeef",
+            )
+        )
         _assert_ws_rejected(msg, "wrong csrfToken")
 
     def test_ws_cross_session_csrf_token_rejected(self, target_url, dashboard_ws_url):
         _, tok_other = _session(target_url)
         s, _ = _session(target_url)
-        msg = asyncio.run(_ws_send_init(
-            dashboard_ws_url, origin=target_url, cookies=s.cookies, csrf_token=tok_other))
+        msg = asyncio.run(
+            _ws_send_init(
+                dashboard_ws_url,
+                origin=target_url,
+                cookies=s.cookies,
+                csrf_token=tok_other,
+            )
+        )
         _assert_ws_rejected(msg, "cross-session csrfToken")
 
     def test_ws_no_cookie_rejected(self, target_url, dashboard_ws_url):
         """WS connect with valid Origin and a fabricated token but no session cookie must fail."""
-        msg = asyncio.run(_ws_send_init(
-            dashboard_ws_url, origin=target_url, cookies=None, csrf_token="deadbeef"))
+        msg = asyncio.run(
+            _ws_send_init(
+                dashboard_ws_url, origin=target_url, cookies=None, csrf_token="deadbeef"
+            )
+        )
         _assert_ws_rejected(msg, "no-cookie WS connect")
 
     def test_ws_query_string_token_rejected(self, target_url, dashboard_ws_url):
         """CSRF token must come from connection_init payload, not URL query."""
         s, tok = _session(target_url)
-        msg = asyncio.run(_ws_send_init(
-            dashboard_ws_url,
-            origin=target_url,
-            cookies=s.cookies,
-            csrf_token=None,
-            url_suffix=f"?csrfToken={tok}",
-        ))
+        msg = asyncio.run(
+            _ws_send_init(
+                dashboard_ws_url,
+                origin=target_url,
+                cookies=s.cookies,
+                csrf_token=None,
+                url_suffix=f"?csrfToken={tok}",
+            )
+        )
         _assert_ws_rejected(msg, "query-string WS token")
 
 
@@ -328,8 +392,11 @@ class TestDashboardWSCSWSH:
 class TestDashboardWSAccepted:
     def test_valid_connection_accepted(self, target_url, dashboard_ws_url):
         s, tok = _session(target_url)
-        msg = asyncio.run(_ws_send_init(
-            dashboard_ws_url, origin=target_url, cookies=s.cookies, csrf_token=tok))
+        msg = asyncio.run(
+            _ws_send_init(
+                dashboard_ws_url, origin=target_url, cookies=s.cookies, csrf_token=tok
+            )
+        )
         assert msg is not None and msg.get("type") == "connection_ack", (
             f"expected connection_ack from dashboard /graphql, got {msg}"
         )
@@ -348,8 +415,7 @@ class TestProxyHTTPCSRF:
 
     def test_post_wrong_csrf_rejected(self, target_url, proxy_url):
         s, _ = _session(target_url)
-        r = _post(s, proxy_url, sec_fetch_site="same-origin",
-                  csrf_token="deadbeef")
+        r = _post(s, proxy_url, sec_fetch_site="same-origin", csrf_token="deadbeef")
         assert r.status_code == 403
 
     @_SEC_FETCH_SITE_REJECTED_CASES
@@ -359,23 +425,28 @@ class TestProxyHTTPCSRF:
         assert r.status_code == 403
 
     @_SEC_FETCH_SITE_ALLOWED_CASES
-    def test_post_sec_fetch_site_allowed_with_valid_token(self, target_url, proxy_url, sec_fetch_site):
+    def test_post_sec_fetch_site_allowed_with_valid_token(
+        self, target_url, proxy_url, sec_fetch_site
+    ):
         s, tok = _session(target_url)
-        r = _post(s, proxy_url, sec_fetch_site=sec_fetch_site,
-                  csrf_token=tok, json={"query": "{__typename}"})
+        r = _post(
+            s,
+            proxy_url,
+            sec_fetch_site=sec_fetch_site,
+            csrf_token=tok,
+            json={"query": "{__typename}"},
+        )
         assert r.status_code < 400
 
     def test_post_cross_session_token_rejected(self, target_url, proxy_url):
         _, tok_other = _session(target_url)
         s, _ = _session(target_url)
-        r = _post(s, proxy_url, sec_fetch_site="same-origin",
-                  csrf_token=tok_other)
+        r = _post(s, proxy_url, sec_fetch_site="same-origin", csrf_token=tok_other)
         assert r.status_code == 403
 
     def test_post_token_without_session_rejected(self, proxy_url):
         s = requests.Session()
-        r = _post(s, proxy_url, sec_fetch_site="same-origin",
-                  csrf_token="deadbeef")
+        r = _post(s, proxy_url, sec_fetch_site="same-origin", csrf_token="deadbeef")
         assert r.status_code == 403
 
 
@@ -390,9 +461,9 @@ class TestProxyWSCSWSH:
     @_WS_ORIGIN_CASES
     def test_cross_origin_upgrade_rejected(self, target_url, proxy_ws_url, origin):
         s, _ = _session(target_url)
-        assert not asyncio.run(_ws_upgrade(proxy_ws_url, origin=origin, cookies=s.cookies)), (
-            f"expected upgrade rejection for Origin: {origin}"
-        )
+        assert not asyncio.run(
+            _ws_upgrade(proxy_ws_url, origin=origin, cookies=s.cookies)
+        ), f"expected upgrade rejection for Origin: {origin}"
 
     def test_no_origin_upgrade_rejected(self, target_url, proxy_ws_url):
         s, _ = _session(target_url)
@@ -402,18 +473,20 @@ class TestProxyWSCSWSH:
 
     def test_no_session_upgrade_rejected(self, target_url, proxy_ws_url):
         """Same-origin upgrade with no session cookie has no X-Forwarded-CSRF-Token stamped — must be rejected."""
-        assert not asyncio.run(_ws_upgrade(proxy_ws_url, origin=target_url, cookies=None)), (
-            "expected upgrade rejection without a CSRF-bearing session"
-        )
+        assert not asyncio.run(
+            _ws_upgrade(proxy_ws_url, origin=target_url, cookies=None)
+        ), "expected upgrade rejection without a CSRF-bearing session"
 
     def test_forwarded_csrf_smuggling_rejected(self, target_url, proxy_ws_url):
         """A client-supplied X-Forwarded-CSRF-Token without a session must be stripped and the upgrade rejected."""
-        assert not asyncio.run(_ws_upgrade(
-            proxy_ws_url,
-            origin=target_url,
-            cookies=None,
-            extra_headers={"X-Forwarded-CSRF-Token": "attacker-token"},
-        )), "client-supplied X-Forwarded-CSRF-Token must not bypass CSWSH gate"
+        assert not asyncio.run(
+            _ws_upgrade(
+                proxy_ws_url,
+                origin=target_url,
+                cookies=None,
+                extra_headers={"X-Forwarded-CSRF-Token": "attacker-token"},
+            )
+        ), "client-supplied X-Forwarded-CSRF-Token must not bypass CSWSH gate"
 
 
 # ---------------------------------------------------------------------------
@@ -428,8 +501,11 @@ class TestProxyWSAccepted:
 
     def test_valid_connection_accepted(self, target_url, proxy_ws_url):
         s, tok = _session(target_url)
-        msg = asyncio.run(_ws_send_init(
-            proxy_ws_url, origin=target_url, cookies=s.cookies, csrf_token=tok))
+        msg = asyncio.run(
+            _ws_send_init(
+                proxy_ws_url, origin=target_url, cookies=s.cookies, csrf_token=tok
+            )
+        )
         assert msg is not None and msg.get("type") == "connection_ack", (
             f"expected connection_ack from cluster-api-proxy graphql, got {msg}"
         )

--- a/e2e/test_namespace_rbac.py
+++ b/e2e/test_namespace_rbac.py
@@ -49,9 +49,7 @@ _DASHBOARD_LOG_FETCH = (
 )
 
 _CLUSTER_API_LOG_METADATA = (
-    "query Q($namespace:String){"
-    "logMetadataList(namespace:$namespace)"
-    "{items{id}}}"
+    "query Q($namespace:String){logMetadataList(namespace:$namespace){items{id}}}"
 )
 
 # kind names the kubeconfig context "kind-<cluster>". The CLI's DesktopProxy
@@ -79,9 +77,7 @@ def _build_restricted_kubeconfig(token):
     cluster entry (with embedded CA data) without adding a YAML dependency.
     """
     cfg = json.loads(
-        kubectl(
-            "config", "view", "--raw", "--minify", "--flatten", "-o", "json"
-        ).stdout
+        kubectl("config", "view", "--raw", "--minify", "--flatten", "-o", "json").stdout
     )
     cluster_entry = cfg["clusters"][0]
     context_name = cfg["contexts"][0]["name"]
@@ -103,9 +99,7 @@ def _build_restricted_kubeconfig(token):
 @pytest.fixture(scope="module")
 def restricted_serve_url(restricted_sa_tokens, cli):
     kubeconfig = _build_restricted_kubeconfig(restricted_sa_tokens[SA1_NS])
-    fh = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".kubeconfig", delete=False
-    )
+    fh = tempfile.NamedTemporaryFile(mode="w", suffix=".kubeconfig", delete=False)
     json.dump(kubeconfig, fh)
     fh.close()
 
@@ -148,8 +142,10 @@ class TestCliDashboard:
     @_NAMESPACE_CASES
     def test_log_records_fetch(self, restricted_serve_url, namespace, expect_denial):
         body = post_graphql(
-            restricted_serve_url, "/graphql",
-            _DASHBOARD_LOG_FETCH, {"sources": [f"{namespace}:pods/chatter"]},
+            restricted_serve_url,
+            "/graphql",
+            _DASHBOARD_LOG_FETCH,
+            {"sources": [f"{namespace}:pods/chatter"]},
         )
         assert has_authz_denial(body) == expect_denial, body
         if expect_denial:
@@ -162,7 +158,8 @@ class TestCliApiProxy:
         body = post_graphql(
             restricted_serve_url,
             f"/cluster-api-proxy/{_E2E_KUBE_CONTEXT}/graphql",
-            _CLUSTER_API_LOG_METADATA, {"namespace": namespace},
+            _CLUSTER_API_LOG_METADATA,
+            {"namespace": namespace},
         )
         assert has_authz_denial(body) == expect_denial, body
 
@@ -178,8 +175,10 @@ class TestClusterDashboard:
         self, dashboard_url, restricted_sa_tokens, namespace, expect_denial
     ):
         body = post_graphql(
-            dashboard_url, "/graphql",
-            _DASHBOARD_LOG_FETCH, {"sources": [f"{namespace}:pods/chatter"]},
+            dashboard_url,
+            "/graphql",
+            _DASHBOARD_LOG_FETCH,
+            {"sources": [f"{namespace}:pods/chatter"]},
             bearer=restricted_sa_tokens[SA1_NS],
         )
         assert has_authz_denial(body) == expect_denial, body
@@ -193,8 +192,10 @@ class TestClusterApiProxy:
         self, dashboard_url, restricted_sa_tokens, namespace, expect_denial
     ):
         body = post_graphql(
-            dashboard_url, "/cluster-api-proxy/graphql",
-            _CLUSTER_API_LOG_METADATA, {"namespace": namespace},
+            dashboard_url,
+            "/cluster-api-proxy/graphql",
+            _CLUSTER_API_LOG_METADATA,
+            {"namespace": namespace},
             bearer=restricted_sa_tokens[SA1_NS],
         )
         assert has_authz_denial(body) == expect_denial, body
@@ -204,8 +205,10 @@ class TestClusterApiProxy:
         self, dashboard_url, restricted_sa_tokens, namespace, expect_denial
     ):
         body = post_graphql(
-            dashboard_url, "/cluster-api-proxy/graphql",
-            _DASHBOARD_LOG_FETCH, {"sources": [f"{namespace}:pods/chatter"]},
+            dashboard_url,
+            "/cluster-api-proxy/graphql",
+            _DASHBOARD_LOG_FETCH,
+            {"sources": [f"{namespace}:pods/chatter"]},
             bearer=restricted_sa_tokens[SA1_NS],
         )
         assert has_authz_denial(body) == expect_denial, body
@@ -223,8 +226,12 @@ class TestClusterApiProxy:
         ids=["sa1-on-own", "sa1-on-other", "sa2-on-own", "sa2-on-other"],
     )
     def test_identity_keyed_authorization(
-        self, dashboard_url, restricted_sa_tokens,
-        token_ns, query_ns, expect_denial,
+        self,
+        dashboard_url,
+        restricted_sa_tokens,
+        token_ns,
+        query_ns,
+        expect_denial,
     ):
         """Two SAs scoped to different namespaces (sa1 -> SA1_NS,
         sa2 -> SA2_NS) must not bleed into each other. Same query,
@@ -232,14 +239,18 @@ class TestClusterApiProxy:
         aggregation -> cluster-api -> cluster-agent and the cluster-agent's
         identity-keyed SAR cache."""
         body = post_graphql(
-            dashboard_url, "/cluster-api-proxy/graphql",
-            _CLUSTER_API_LOG_METADATA, {"namespace": query_ns},
+            dashboard_url,
+            "/cluster-api-proxy/graphql",
+            _CLUSTER_API_LOG_METADATA,
+            {"namespace": query_ns},
             bearer=restricted_sa_tokens[token_ns],
         )
         assert has_authz_denial(body) == expect_denial, body
 
     def test_agent_permission_denied_yields_no_data(
-        self, dashboard_url, restricted_sa_tokens,
+        self,
+        dashboard_url,
+        restricted_sa_tokens,
     ):
         """When the cluster-agent answers PermissionDenied for a fan-out
         shard, cluster-api must surface that as a GraphQL error and leave
@@ -247,8 +258,10 @@ class TestClusterApiProxy:
         alongside the error would slip past `has_authz_denial` alone — this
         test pins the no-leak side of the contract explicitly."""
         body = post_graphql(
-            dashboard_url, "/cluster-api-proxy/graphql",
-            _CLUSTER_API_LOG_METADATA, {"namespace": SA2_NS},
+            dashboard_url,
+            "/cluster-api-proxy/graphql",
+            _CLUSTER_API_LOG_METADATA,
+            {"namespace": SA2_NS},
             bearer=restricted_sa_tokens[SA1_NS],
         )
         assert has_authz_denial(body), body
@@ -260,7 +273,11 @@ class TestClusterApiProxy:
         ids=["group-sa-allowed", "non-member-sa-denied"],
     )
     def test_group_bound_access(
-        self, dashboard_url, restricted_sa_tokens, token_ns, expect_denial,
+        self,
+        dashboard_url,
+        restricted_sa_tokens,
+        token_ns,
+        expect_denial,
     ):
         """pods/log in GROUP_NS is bound to Group `system:serviceaccounts:
         GROUP_NS`. The group-bound SA (lives in GROUP_NS, no other RBAC) is a
@@ -269,8 +286,10 @@ class TestClusterApiProxy:
         front-proxy headers -> cluster-agent SAR and is honored, not silently
         dropped."""
         body = post_graphql(
-            dashboard_url, "/cluster-api-proxy/graphql",
-            _CLUSTER_API_LOG_METADATA, {"namespace": GROUP_NS},
+            dashboard_url,
+            "/cluster-api-proxy/graphql",
+            _CLUSTER_API_LOG_METADATA,
+            {"namespace": GROUP_NS},
             bearer=restricted_sa_tokens[token_ns],
         )
         assert has_authz_denial(body) == expect_denial, body

--- a/e2e/test_zero_trust.py
+++ b/e2e/test_zero_trust.py
@@ -70,10 +70,12 @@ def front_proxy_client_cert(tmp_path_factory):
     by it (and matching the requestheader-allowed-names CN) is trusted by
     aggregationAuthMiddleware to *carry* an identity in headers, but the
     headers themselves still have to be present."""
+
     def _docker_cat(path):
         return subprocess.run(
             ["docker", "exec", _KIND_SERVER, "cat", path],
-            check=True, capture_output=True,
+            check=True,
+            capture_output=True,
         ).stdout
 
     try:
@@ -98,11 +100,24 @@ def admin_client_cert(tmp_path_factory):
     into its ClientCAs pool (extension-apiserver-authentication's
     client-ca-file), so a request bearing it takes the middleware's
     direct-cert path."""
-    cfg = json.loads(subprocess.run(
-        ["kubectl", f"--kubeconfig={_KUBECONFIG}", "config", "view",
-         "--raw", "--minify", "--flatten", "-o", "json"],
-        check=True, capture_output=True, text=True,
-    ).stdout)
+    cfg = json.loads(
+        subprocess.run(
+            [
+                "kubectl",
+                f"--kubeconfig={_KUBECONFIG}",
+                "config",
+                "view",
+                "--raw",
+                "--minify",
+                "--flatten",
+                "-o",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
     user = cfg["users"][0]["user"]
     d = tmp_path_factory.mktemp("admin-cert")
     crt = d / "client.crt"
@@ -168,7 +183,9 @@ class TestClusterAPIAggregationGate:
         assert r.status_code == 401
 
     def test_legitimate_cluster_cert_not_front_proxy_rejected(
-        self, cluster_api_url, admin_client_cert,
+        self,
+        cluster_api_url,
+        admin_client_cert,
     ):
         """A holder of a legitimate cluster cert (kubectl admin, controller,
         system:node, etc.) is NOT kube-apiserver — they must be rejected at
@@ -178,7 +195,9 @@ class TestClusterAPIAggregationGate:
         pool (the only trust anchor we honor)."""
         r = requests.post(
             f"{cluster_api_url}{_AGGREGATED_BASE}/graphql",
-            json={"query": '{ logMetadataList(namespace: "kubetail-e2e") { items { id } } }'},
+            json={
+                "query": '{ logMetadataList(namespace: "kubetail-e2e") { items { id } } }'
+            },
             headers={
                 "X-Remote-User": "spoofed-attacker",
                 "X-Remote-Group": "system:masters",
@@ -190,7 +209,9 @@ class TestClusterAPIAggregationGate:
         assert r.status_code == 401, r.text
 
     def test_front_proxy_cert_without_user_header_rejected(
-        self, cluster_api_url, front_proxy_client_cert,
+        self,
+        cluster_api_url,
+        front_proxy_client_cert,
     ):
         """Holding a valid front-proxy cert authorizes you to *forward* an
         identity — it doesn't make you one. Without an X-Remote-User header
@@ -204,7 +225,9 @@ class TestClusterAPIAggregationGate:
         assert r.status_code == 401, r.text
 
     def test_front_proxy_cert_with_user_header_authorized(
-        self, cluster_api_url, front_proxy_client_cert,
+        self,
+        cluster_api_url,
+        front_proxy_client_cert,
     ):
         """Sanity check that the 401 above isn't cert-rejection in disguise:
         the same cert with X-Remote-User present passes the gate."""
@@ -226,7 +249,9 @@ class TestClusterAPIAggregationGate:
             + f"{_AGGREGATED_BASE}/graphql"
         )
         ctx = ssl.create_default_context()
-        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # silence CodeQL; we're testing mTLS gate, not TLS version
+        ctx.minimum_version = (
+            ssl.TLSVersion.TLSv1_2
+        )  # silence CodeQL; we're testing mTLS gate, not TLS version
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
 
@@ -246,7 +271,13 @@ class TestClusterAPIAggregationGate:
     @pytest.mark.usefixtures("cluster_api_url")
     def test_through_kube_apiserver_authorized(self):
         out = subprocess.run(
-            ["kubectl", f"--kubeconfig={_KUBECONFIG}", "get", "--raw", f"{_AGGREGATED_BASE}/healthz"],
+            [
+                "kubectl",
+                f"--kubeconfig={_KUBECONFIG}",
+                "get",
+                "--raw",
+                f"{_AGGREGATED_BASE}/healthz",
+            ],
             check=True,
             capture_output=True,
             text=True,
@@ -257,10 +288,16 @@ class TestClusterAPIAggregationGate:
 def _cluster_agent_pod():
     out = subprocess.run(
         [
-            "kubectl", f"--kubeconfig={_KUBECONFIG}", "-n", _NS,
-            "get", "pods",
-            "-l", "app.kubernetes.io/component=cluster-agent",
-            "-o", "jsonpath={.items[0].metadata.name}",
+            "kubectl",
+            f"--kubeconfig={_KUBECONFIG}",
+            "-n",
+            _NS,
+            "get",
+            "pods",
+            "-l",
+            "app.kubernetes.io/component=cluster-agent",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
         ],
         check=True,
         capture_output=True,
@@ -280,8 +317,13 @@ def _port_forward(pod, remote_port):
         local_port = s.getsockname()[1]
     proc = subprocess.Popen(
         [
-            "kubectl", f"--kubeconfig={_KUBECONFIG}", "-n", _NS,
-            "port-forward", f"pod/{pod}", f"{local_port}:{remote_port}",
+            "kubectl",
+            f"--kubeconfig={_KUBECONFIG}",
+            "-n",
+            _NS,
+            "port-forward",
+            f"pod/{pod}",
+            f"{local_port}:{remote_port}",
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -315,12 +357,18 @@ def cluster_agent_local_port(cluster_api_url):
 class TestClusterAgentMTLSGate:
     def test_tls_without_client_cert_rejected(self, cluster_agent_local_port):
         ctx = ssl.create_default_context()
-        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # silence CodeQL; we're testing mTLS gate, not TLS version
+        ctx.minimum_version = (
+            ssl.TLSVersion.TLSv1_2
+        )  # silence CodeQL; we're testing mTLS gate, not TLS version
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        with socket.create_connection(("127.0.0.1", cluster_agent_local_port), timeout=5) as raw:
+        with socket.create_connection(
+            ("127.0.0.1", cluster_agent_local_port), timeout=5
+        ) as raw:
             with pytest.raises(OSError):
-                with ctx.wrap_socket(raw, server_hostname="kubetail-cluster-agent.kubetail-e2e.svc") as tls:
+                with ctx.wrap_socket(
+                    raw, server_hostname="kubetail-cluster-agent.kubetail-e2e.svc"
+                ) as tls:
                     # Some servers defer the cert demand to the first record.
                     tls.send(b"\x00")
                     tls.recv(1)
@@ -366,14 +414,16 @@ class TestClusterAgentAuthGate:
             # under the cluster-api SA's privileges.
             (
                 "missing_user_metadata",
-                _CLUSTER_API_CLIENT_CERT, _CLUSTER_API_CLIENT_KEY,
+                _CLUSTER_API_CLIENT_CERT,
+                _CLUSTER_API_CLIENT_KEY,
                 (),
                 grpc.StatusCode.UNAUTHENTICATED,
             ),
             # Empty value must not be treated as anonymous-but-trusted.
             (
                 "empty_user_metadata",
-                _CLUSTER_API_CLIENT_CERT, _CLUSTER_API_CLIENT_KEY,
+                _CLUSTER_API_CLIENT_CERT,
+                _CLUSTER_API_CLIENT_KEY,
                 (("x-remote-user", ""),),
                 grpc.StatusCode.UNAUTHENTICATED,
             ),
@@ -382,14 +432,20 @@ class TestClusterAgentAuthGate:
             # the allowlist.
             (
                 "valid_ca_but_disallowed_cn",
-                _CLUSTER_AGENT_CERT, _CLUSTER_AGENT_KEY,
-                (("x-remote-user", "spoofed-attacker"), ("x-remote-group", "system:masters")),
+                _CLUSTER_AGENT_CERT,
+                _CLUSTER_AGENT_KEY,
+                (
+                    ("x-remote-user", "spoofed-attacker"),
+                    ("x-remote-group", "system:masters"),
+                ),
                 grpc.StatusCode.PERMISSION_DENIED,
             ),
         ],
         ids=lambda v: v if isinstance(v, str) else None,
     )
-    def test_rejected(self, cluster_agent_local_port, case, cert, key, metadata, expected):
+    def test_rejected(
+        self, cluster_agent_local_port, case, cert, key, metadata, expected
+    ):
         del case  # used as the parametrize id
         with _grpc_channel(cert, key, cluster_agent_local_port) as channel:
             err = _call_list(channel, metadata=metadata)

--- a/e2e/uv.lock
+++ b/e2e/uv.lock
@@ -190,6 +190,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.60" },
@@ -198,6 +203,9 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "websockets", specifier = ">=13.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.9" }]
 
 [[package]]
 name = "packaging"
@@ -264,6 +272,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1156

## Summary

E2E tests are written in Python, but PR checks did not lint that code. This PR adds a `python-lint` job that runs Ruff (`check` and `format --check`) on `e2e/`, gates the E2E workflow on it, and formats existing test files so CI passes from day one. Contributors can run the same checks locally via `CONTRIBUTING.md`.

## Key Changes

- Add `python-lint` job to `.github/workflows/ci.yml` using `uv` and Ruff
- Add Ruff as an `e2e` dev dependency and update `uv.lock`
- Format E2E Python tests with Ruff (no logic changes)
- Document Python lint commands in `CONTRIBUTING.md`
- Require `python-lint` to pass before E2E runs

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused