### PR TITLE
🎣 Tighten Sec-Fetch-Site CSRF check to reject same-site

### DIFF
--- a/e2e/test_csrf.py
+++ b/e2e/test_csrf.py
@@ -138,22 +138,23 @@ async def _ws_send_init(
         return None
 
 
-# Explicitly cross-origin values that the CSRF gate must reject outright,
-# regardless of any accompanying token.
+# Cross-origin Sec-Fetch-Site values that the CSRF gate must reject outright,
+# regardless of any accompanying token. "same-site" covers sibling subdomains
+# on the same eTLD+1, which are still cross-origin in CSRF terms.
 _SEC_FETCH_SITE_REJECTED_CASES = pytest.mark.parametrize(
     "sec_fetch_site",
-    ["cross-site", "cross-origin"],
-    ids=["cross-site", "cross-origin"],
+    ["cross-site", "same-site"],
+    ids=["cross-site", "same-site"],
 )
 
 # Values that must be allowed through to the token check. "missing" covers
 # browsers that omit Sec-Fetch-* on non-secure, non-localhost origins (e.g.
 # plain-HTTP internal ingresses); "none" is sent on user-initiated top-level
-# navigations; "same-site" covers sibling subdomains on the same eTLD+1.
+# navigations.
 _SEC_FETCH_SITE_ALLOWED_CASES = pytest.mark.parametrize(
     "sec_fetch_site",
-    [None, "none", "same-site", "same-origin"],
-    ids=["missing", "none", "same-site", "same-origin"],
+    [None, "none", "same-origin"],
+    ids=["missing", "none", "same-origin"],
 )
 
 _TOKEN_CASES = pytest.mark.parametrize(

--- a/modules/dashboard/pkg/app/middleware.go
+++ b/modules/dashboard/pkg/app/middleware.go
@@ -36,12 +36,13 @@ import (
 	"github.com/kubetail-org/kubetail/modules/shared/k8shelpers"
 )
 
-// rejectedSecFetchSite lists Sec-Fetch-Site values that are unambiguously a
-// cross-origin request and so must be rejected outright. An absent header is
-// not rejected here: browsers omit Sec-Fetch-* on non-secure, non-localhost
+// rejectedSecFetchSite lists Sec-Fetch-Site values that are cross-origin and
+// so must be rejected outright. "same-site" covers sibling subdomains on the
+// same eTLD+1, which are still cross-origin in CSRF terms. An absent header
+// is not rejected here: browsers omit Sec-Fetch-* on non-secure, non-localhost
 // contexts (e.g. plain-HTTP internal ingresses), and the CSRF token check
 // below is the primary defense.
-var rejectedSecFetchSite = []string{"cross-site", "cross-origin"}
+var rejectedSecFetchSite = []string{"cross-site", "same-site"}
 
 // safeMethods are HTTP methods that don't change state, so they don't need
 // CSRF protection. Cross-origin reads are blocked by the Same-Origin Policy,

--- a/modules/dashboard/pkg/app/middleware_test.go
+++ b/modules/dashboard/pkg/app/middleware_test.go
@@ -219,9 +219,9 @@ func TestCSRFProtectionMiddlewareAllows(t *testing.T) {
 			seedToken: true,
 		},
 		{
-			name:      "POST same-site with valid X-CSRF-Token",
+			name:      "POST none with valid X-CSRF-Token",
 			method:    "POST",
-			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-site"}, "X-Csrf-Token": []string{csrfPreseededToken}},
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"none"}, "X-Csrf-Token": []string{csrfPreseededToken}},
 			seedToken: true,
 		},
 	}
@@ -340,8 +340,9 @@ func TestCSRFProtectionMiddlewareForbids(t *testing.T) {
 		setHeader http.Header
 		seedToken bool
 	}{
-		// Unsafe methods with an explicitly cross-origin Sec-Fetch-Site are
-		// rejected outright, even if a valid token were also present.
+		// Unsafe methods with a cross-origin Sec-Fetch-Site are rejected
+		// outright, even if a valid token were also present. "same-site"
+		// counts as cross-origin (sibling subdomains on the same eTLD+1).
 		{
 			name:      "POST cross-site",
 			method:    "POST",
@@ -349,9 +350,9 @@ func TestCSRFProtectionMiddlewareForbids(t *testing.T) {
 			seedToken: true,
 		},
 		{
-			name:      "POST cross-origin",
+			name:      "POST same-site",
 			method:    "POST",
-			setHeader: http.Header{"Sec-Fetch-Site": []string{"cross-origin"}, "X-Csrf-Token": []string{csrfPreseededToken}},
+			setHeader: http.Header{"Sec-Fetch-Site": []string{"same-site"}, "X-Csrf-Token": []string{csrfPreseededToken}},
 			seedToken: true,
 		},
 		{


### PR DESCRIPTION
## Summary

Follow-up to #1155. The denylist installed in that PR was `["cross-site", "cross-origin"]`, but `cross-origin` isn't a valid `Sec-Fetch-Site` value per the Fetch Metadata spec — the real cross-origin values are `cross-site` and `same-site`. A `same-site` request originates from a sibling subdomain on the same eTLD+1 (e.g. `evil.example.com` → `dashboard.example.com`), which is still cross-origin in CSRF terms. The CSRF token remains the primary defense, but Layer 1 should actually catch this case instead of matching a value browsers never send.

## Key Changes

- Replace the dead `cross-origin` entry in `rejectedSecFetchSite` with `same-site` so sibling-subdomain requests are rejected outright.
- Update the dashboard middleware unit tests: move the `same-site` case from the Allows table to the Forbids table, drop the bogus `cross-origin` Forbids case, and add a `none` Allows case to keep coverage of the pass-through set.
- Update the e2e CSRF tests so `same-site` is in the rejected parametrization and the allowed set is `[missing, none, same-origin]`.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused