### PR TITLE
✨ Make PR checks diff-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,57 @@ on:
 
 jobs:
   ##############################
+  # Changes detection
+  ##############################
+
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-24.04
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      rust: ${{ steps.filter.outputs.rust }}
+      typescript: ${{ steps.filter.outputs.typescript }}
+      shell: ${{ steps.filter.outputs.shell }}
+      python: ${{ steps.filter.outputs.python }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'modules/**'
+              - 'go.work'
+              - 'go.work.sum'
+              - 'Makefile'
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+            typescript:
+              - 'dashboard-ui/**'
+              - 'Makefile'
+            shell:
+              - 'scripts/**'
+            python:
+              - 'e2e/**'
+            docker:
+              - 'build/package/**'
+            workflow:
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+
+  ##############################
   # Pre-flight jobs
   ##############################
 
   go-lint:
     name: Go · Lint
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -36,6 +82,8 @@ jobs:
 
   go-vet:
     name: Go · Vet
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -56,6 +104,8 @@ jobs:
 
   go-vendor:
     name: Go · Vendor
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -74,6 +124,8 @@ jobs:
 
   rust-lint:
     name: Rust · Lint
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -87,6 +139,8 @@ jobs:
 
   rust-vet:
     name: Rust · Vet
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -100,6 +154,8 @@ jobs:
 
   typescript-lint:
     name: TypeScript · Lint
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -115,6 +171,8 @@ jobs:
 
   shell-lint:
     name: Shell · Lint
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -127,6 +185,8 @@ jobs:
 
   python-lint:
     name: Python · Lint
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -145,9 +205,11 @@ jobs:
   go-test:
     name: Go · Test
     needs:
+      - changes
       - go-lint
       - go-vet
       - go-vendor
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true')
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -212,8 +274,10 @@ jobs:
   rust-test:
     name: Rust · Test
     needs:
+      - changes
       - rust-lint
       - rust-vet
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -244,7 +308,9 @@ jobs:
   typescript-test:
     name: TypeScript · Test
     needs:
+      - changes
       - typescript-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -261,7 +327,9 @@ jobs:
   shell-test:
     name: Shell · Test
     needs:
+      - changes
       - shell-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.workflow == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -324,8 +392,10 @@ jobs:
   rust-build:
     name: Rust · Build
     needs:
+      - changes
       - rust-lint
       - rust-vet
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -356,7 +426,9 @@ jobs:
   typescript-build:
     name: TypeScript · Build
     needs:
+      - changes
       - typescript-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -377,11 +449,13 @@ jobs:
   docker-builds:
     name: Docker · Build
     needs:
+      - changes
       - rust-lint
       - rust-vet
       - go-lint
       - go-vet
       - typescript-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.workflow == 'true')
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -433,11 +507,13 @@ jobs:
   cli-builds:
     name: CLI · Build
     needs:
+      - changes
       - rust-lint
       - rust-vet
       - go-lint
       - go-vet
       - typescript-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -496,12 +572,14 @@ jobs:
   alpine-builds:
     name: Alpine · Build
     needs:
+      - changes
       - rust-lint
       - rust-vet
       - go-lint
       - go-vet
       - go-vendor
       - typescript-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -562,8 +640,10 @@ jobs:
   e2e:
     name: E2E (k8s ${{ matrix.k8s-version }})
     needs:
+      - changes
       - docker-builds
       - python-lint
+    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - "**"
   workflow_dispatch:
+    inputs:
+      run_all:
+        description: "Run full suite"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   ##############################
@@ -18,13 +24,10 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-24.04
     outputs:
-      go: ${{ steps.filter.outputs.go }}
-      rust: ${{ steps.filter.outputs.rust }}
-      typescript: ${{ steps.filter.outputs.typescript }}
-      shell: ${{ steps.filter.outputs.shell }}
-      python: ${{ steps.filter.outputs.python }}
-      docker: ${{ steps.filter.outputs.docker }}
-      workflow: ${{ steps.filter.outputs.workflow }}
+      go: ${{ steps.override.outputs.go }}
+      rust: ${{ steps.override.outputs.rust }}
+      typescript: ${{ steps.override.outputs.typescript }}
+      any: ${{ steps.override.outputs.any }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -33,26 +36,27 @@ jobs:
           filters: |
             go:
               - 'modules/**'
-              - 'go.work'
-              - 'go.work.sum'
-              - 'Makefile'
             rust:
               - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'Makefile'
             typescript:
               - 'dashboard-ui/**'
-              - 'Makefile'
-            shell:
-              - 'scripts/**'
-            python:
-              - 'e2e/**'
-            docker:
-              - 'build/package/**'
-            workflow:
-              - '.github/workflows/ci.yml'
-              - '.github/actions/**'
+      - id: override
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.run_all }}" == "true" ]; then
+            echo "go=true" >> $GITHUB_OUTPUT
+            echo "rust=true" >> $GITHUB_OUTPUT
+            echo "typescript=true" >> $GITHUB_OUTPUT
+            echo "any=true" >> $GITHUB_OUTPUT
+          else
+            echo "go=${{ steps.filter.outputs.go }}" >> $GITHUB_OUTPUT
+            echo "rust=${{ steps.filter.outputs.rust }}" >> $GITHUB_OUTPUT
+            echo "typescript=${{ steps.filter.outputs.typescript }}" >> $GITHUB_OUTPUT
+            if [ "${{ steps.filter.outputs.go }}" == "true" ] || [ "${{ steps.filter.outputs.rust }}" == "true" ] || [ "${{ steps.filter.outputs.typescript }}" == "true" ]; then
+              echo "any=true" >> $GITHUB_OUTPUT
+            else
+              echo "any=false" >> $GITHUB_OUTPUT
+            fi
+          fi
 
   ##############################
   # Pre-flight jobs
@@ -61,7 +65,7 @@ jobs:
   go-lint:
     name: Go · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -83,7 +87,7 @@ jobs:
   go-vet:
     name: Go · Vet
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -105,7 +109,7 @@ jobs:
   go-vendor:
     name: Go · Vendor
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -125,7 +129,7 @@ jobs:
   rust-lint:
     name: Rust · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -140,7 +144,7 @@ jobs:
   rust-vet:
     name: Rust · Vet
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -155,7 +159,7 @@ jobs:
   typescript-lint:
     name: TypeScript · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true'
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -172,7 +176,7 @@ jobs:
   shell-lint:
     name: Shell · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.workflow == 'true'
+    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -186,7 +190,7 @@ jobs:
   python-lint:
     name: Python · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflow == 'true'
+    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -209,7 +213,7 @@ jobs:
       - go-lint
       - go-vet
       - go-vendor
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.go == 'true'
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -277,7 +281,7 @@ jobs:
       - changes
       - rust-lint
       - rust-vet
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.rust == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -310,7 +314,7 @@ jobs:
     needs:
       - changes
       - typescript-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -329,7 +333,7 @@ jobs:
     needs:
       - changes
       - shell-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.shell == 'true' || needs.changes.outputs.workflow == 'true')
+    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     strategy:
       fail-fast: false
       matrix:
@@ -395,7 +399,7 @@ jobs:
       - changes
       - rust-lint
       - rust-vet
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.rust == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -428,7 +432,7 @@ jobs:
     needs:
       - changes
       - typescript-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -455,7 +459,7 @@ jobs:
       - go-lint
       - go-vet
       - typescript-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.any == 'true'
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -513,7 +517,7 @@ jobs:
       - go-lint
       - go-vet
       - typescript-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.any == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -579,7 +583,7 @@ jobs:
       - go-vet
       - go-vendor
       - typescript-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.go == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -643,7 +647,7 @@ jobs:
       - changes
       - docker-builds
       - python-lint
-    if: always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.typescript == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflow == 'true')
+    if: needs.changes.outputs.any == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,6 @@ jobs:
   shell-lint:
     name: Shell · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -190,7 +189,6 @@ jobs:
   python-lint:
     name: Python · Lint
     needs: changes
-    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -333,7 +331,6 @@ jobs:
     needs:
       - changes
       - shell-lint
-    if: github.event_name == 'workflow_dispatch' && inputs.run_all == true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes #1154 

## Summary

This PR optimizes our GitHub Actions CI pipeline by making it diff-aware. Currently, every PR commit triggers all CI jobs across all languages and components, which is time-consuming. By introducing `dorny/paths-filter`, we can detect which files changed and conditionally skip jobs for untouched components (e.g., skipping Rust tests if only Go files were modified). This will provide faster feedback loops for contributors and save CI runner minutes.

## Key Changes

- Added a new `changes` job at the start of the workflow using `dorny/paths-filter` to detect file changes across `go`, `rust`, `typescript`, `shell`, `python`, `docker`, and `workflow` paths.
- Updated pre-flight jobs (lint, vet, vendor) with `needs: changes` and `if` conditions to run only when relevant files are modified.
- Updated test, build, and downstream jobs with `needs: changes` and conditional `if: always() && !failure() && !cancelled() && (...)` logic so they safely bypass intentionally skipped upstream dependencies.
- Added fallbacks to ensure all jobs still run unconditionally if the workflow is triggered manually (`workflow_dispatch`) or if the CI workflow files themselves are modified.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused
