### PR TITLE
✨ Add fail-fast: false to matrix jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     name: Go · Lint
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         module:
           - cli
@@ -37,6 +38,7 @@ jobs:
     name: Go · Vet
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         module:
           - cli
@@ -148,6 +150,7 @@ jobs:
       - go-vendor
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         module:
           - cli
@@ -212,6 +215,7 @@ jobs:
       - rust-lint
       - rust-vet
     strategy:
+      fail-fast: false
       matrix:
         os:
           - linux
@@ -323,6 +327,7 @@ jobs:
       - rust-lint
       - rust-vet
     strategy:
+      fail-fast: false
       matrix:
         os:
           - linux
@@ -379,6 +384,7 @@ jobs:
       - typescript-lint
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         component:
           - cli
@@ -433,6 +439,7 @@ jobs:
       - go-vet
       - typescript-lint
     strategy:
+      fail-fast: false
       matrix:
         os:
           - linux


### PR DESCRIPTION
Closes #1152

## Summary

GitHub's recent platform availability issues have been causing flaky runner
failures to abort entire matrix jobs early, which means jobs that would have
succeeded get cancelled too. Setting `fail-fast: false` on all matrix jobs
means a single runner failure no longer takes down the whole run, and failed
jobs can be re-run individually.

## Key Changes

- Add `fail-fast: false` to all matrix jobs in [.github/workflows/ci.yml](https://github.com/kubetail-org/kubetail/blob/main/.github/workflows/ci.yml?rgh-link-date=2026-05-23T18%3A55%3A36.000Z) that were missing it:
  `go-lint`, `go-vet`, `go-test`, `rust-test`, `rust-build`, `docker-builds`,
  and `cli-builds`
- Jobs that already had `fail-fast: false` (`shell-test`, `alpine-builds`,
  `e2e`) and non-matrix jobs are untouched

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused