### PR TITLE
✨ Simplify console sidebar UI and bump @kubetail/ui

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -16,7 +16,7 @@
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/roboto-flex": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
-    "@kubetail/ui": "3.0.0-rc8-mm",
+    "@kubetail/ui": "3.0.0-rc12-mm",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.23",
     "clsx": "^2.1.1",

--- a/dashboard-ui/pnpm-lock.yaml
+++ b/dashboard-ui/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
       '@kubetail/ui':
-        specifier: 3.0.0-rc8-mm
-        version: 3.0.0-rc8-mm(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.8.0(react@19.2.5))(react-day-picker@9.14.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)
+        specifier: 3.0.0-rc12-mm
+        version: 3.0.0-rc12-mm(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.8.0(react@19.2.5))(react-day-picker@9.14.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1113,8 +1113,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubetail/ui@3.0.0-rc8-mm':
-    resolution: {integrity: sha512-mOV3U/A8+9G1//JQLLONltJb82oTh1voPrhO4rDLuB28nZUT5QJAy1KCWweUvzyIomTSyq0j852lcvUtTFwy/Q==}
+  '@kubetail/ui@3.0.0-rc12-mm':
+    resolution: {integrity: sha512-Pwl1Cn0DPvFiszJU+St6zWJRN06qI/QBFf2HiVI1dMl7w3Nhxx1Pp72mU1ycUCJJwbTx10VgBLVFmCfRNSeY7g==}
     peerDependencies:
       '@base-ui/react': ^1
       lucide-react: '*'
@@ -5111,7 +5111,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubetail/ui@3.0.0-rc8-mm(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.8.0(react@19.2.5))(react-day-picker@9.14.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)':
+  '@kubetail/ui@3.0.0-rc12-mm(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.8.0(react@19.2.5))(react-day-picker@9.14.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.2)':
     dependencies:
       '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority: 0.7.1

--- a/dashboard-ui/src/index.css
+++ b/dashboard-ui/src/index.css
@@ -9,37 +9,27 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+
 /**
  * Custom theme
  */
 
 :root, .light {
-  --accent: var(--color-blue-200);
-  --elevated: var(--color-zinc-100);   /* color-bg-elevated */
-  --strong: var(--color-zinc-200);     /* color-bg-strong */
-  --success: #047857;  
-
-  --sidebar: #F9FAFB;
+  --elevated: var(--color-zinc-100);
+  --success: #047857;
   --chart-4: #8FC6FF;
   --selection-band: color-mix(in srgb, var(--chart-4) 30%, transparent);
 }
 
 .dark {
-  --accent: var(--color-blue-800);
-  --elevated: var(--color-zinc-800);   /* color-bg-elevated */
-  --strong: var(--color-zinc-950);     /* color-bg-strong */
+  --elevated: var(--color-zinc-800);
   --success: #6EE7B7;
-
-  --sidebar: #171717;
   --chart-4: #1447E6;
   --selection-band: color-mix(in srgb, var(--chart-4) 50%, transparent);
 }
 
 @theme inline {
   --color-elevated: var(--elevated);
-  --color-strong: var(--strong);
-  --color-focus: var(--focus);
-
   --color-success: var(--success);
 }
 

--- a/dashboard-ui/src/pages/console/index.tsx
+++ b/dashboard-ui/src/pages/console/index.tsx
@@ -85,8 +85,8 @@ type InnerLayoutProps = {
 // Starting width auto-fits the sidebar content (longest source/container name)
 // between a floor that keeps the "Pods/Containers" header from overflowing and
 // a ceiling that keeps it from getting too wide.
-const SIDEBAR_MIN_WIDTH = 220;
-const SIDEBAR_MAX_WIDTH = 300;
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 320;
 
 const InnerLayout = ({ sidebar, header, main }: InnerLayoutProps) => {
   const { isSidebarOpen, setIsSidebarOpen } = useContext(PageContext);

--- a/dashboard-ui/src/pages/console/sidebar.tsx
+++ b/dashboard-ui/src/pages/console/sidebar.tsx
@@ -13,25 +13,13 @@
 // limitations under the License.
 
 import { useAtomValue } from 'jotai';
-import {
-  ChevronDown as ChevronDownIcon,
-  CirclePlus as CirclePlusIcon,
-  Cpu as CpuIcon,
-  Globe as GlobeIcon,
-  LandPlot as LandPlotIcon,
-  type LucideIcon,
-  MonitorCog as MonitorCogIcon,
-  Plug as PlugIcon,
-  Server as ServerIcon,
-  Trash2 as TrashIcon,
-} from 'lucide-react';
+import { ChevronDown as ChevronDownIcon, CirclePlus as CirclePlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { type ComponentType, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Checkbox } from '@kubetail/ui/elements/checkbox';
 import { Label } from '@kubetail/ui/elements/label';
 
-import PodGlyphIcon from '@/assets/k8s-icons/glyph/pod.svg?react';
 import KubetailLogo from '@/assets/logo.svg?react';
 import SourcePickerModal from '@/components/widgets/SourcePickerModal';
 import type { LogSourceFragmentFragment } from '@/lib/graphql/dashboard/__generated__/graphql';
@@ -47,14 +35,6 @@ import { cssID } from './util';
  */
 
 export const generateMapKey = (namespace: string, podName: string) => `${namespace}/${podName}`;
-
-const FACET_ICON_MAP: Record<string, LucideIcon> = {
-  Region: GlobeIcon,
-  Zone: LandPlotIcon,
-  OS: MonitorCogIcon,
-  Arch: CpuIcon,
-  Node: ServerIcon,
-};
 
 /**
  * CollapsibleSection component
@@ -79,6 +59,9 @@ const CollapsibleSection = ({ icon: Icon, label, count, children }: CollapsibleS
         className="w-full border-t border-divider mt-2.5 py-2.5 font-bold flex items-center justify-between cursor-pointer"
       >
         <div className="flex items-center space-x-1 min-w-0">
+          <ChevronDownIcon
+            className={cn('size-4 shrink-0 transition-transform text-muted-foreground', isCollapsed && '-rotate-90')}
+          />
           {Icon && <Icon className="size-4 shrink-0" />}
           <span className="whitespace-nowrap overflow-hidden text-ellipsis">{label}</span>
         </div>
@@ -86,7 +69,6 @@ const CollapsibleSection = ({ icon: Icon, label, count, children }: CollapsibleS
           <span className="text-xs font-medium border border-sidebar-border min-w-6 h-6 px-1 rounded-sm flex items-center justify-center">
             {count}
           </span>
-          <ChevronDownIcon className={cn('size-4 shrink-0 transition-transform', isCollapsed && '-rotate-90')} />
         </div>
       </button>
       {!isCollapsed && children}
@@ -170,10 +152,7 @@ const SidebarWorkloads = () => {
         </div>
       )}
       <div className="flex items-center justify-between mb-1">
-        <div className="flex items-center space-x-1">
-          <PlugIcon className="size-4 shrink-0" />
-          <span className="font-bold">Sources</span>
-        </div>
+        <span className="font-bold">Sources</span>
         <button
           type="button"
           onClick={() => setIsPickerOpen(true)}
@@ -343,7 +322,7 @@ const SidebarPodsAndContainers = () => {
   const containerCount = containerGroups.reduce((sum, group) => sum + group.containers.length, 0);
 
   return (
-    <CollapsibleSection icon={PodGlyphIcon} label="Pods/Containers" count={containerCount}>
+    <CollapsibleSection label="Pods/Containers" count={containerCount}>
       <div className="space-y-3">
         {containerGroups.map((group) => (
           <div key={`${group.namespace}/${group.podName}`}>
@@ -365,7 +344,6 @@ const SidebarPodsAndContainers = () => {
 const Facets = ({ label, counter }: { label: string; counter: Counter }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const urlKey = label.toLocaleLowerCase();
-  const FacetIcon = FACET_ICON_MAP[label];
 
   const entries = counter.orderedEntries();
 
@@ -384,7 +362,7 @@ const Facets = ({ label, counter }: { label: string; counter: Counter }) => {
   }
 
   return (
-    <CollapsibleSection icon={FacetIcon} label={label} count={entries.length}>
+    <CollapsibleSection label={label} count={entries.length}>
       <div className="space-y-1.5">
         {entries.map(([facet, count]) => (
           <div key={facet}>


### PR DESCRIPTION
## Summary

Cleans up the logging console sidebar by removing decorative icons from
section headers and reorganizing the collapse control for a cleaner look.
Also widens the default sidebar range and bumps the @kubetail/ui dependency.

## Key Changes

- Remove icons from Sources, Pods/Containers, and all facet section headers
- Move the collapse chevron to the left of each section label
- Apply muted color to the collapse chevron
- Widen sidebar default width range (min 220→240, max 300→320)
- Bump @kubetail/ui from rc8 to rc12
- Remove unused CSS variables (--accent, --strong, --sidebar, etc.)

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused