### PR TITLE
✨ Pin pnpm via packageManager field and use frozen lockfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+**/node_modules
 .git
 /modules/dashboard/website
 /dashboard-ui/.env*.local

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: 'Node.js version to install'
     required: false
     default: '22'
-  pnpm-version:
-    description: 'PNPM version to install'
-    required: false
-    default: '10'
   setup-rust:
     description: 'Whether to set up Rust'
     required: false
@@ -63,8 +59,6 @@ runs:
     - name: Set up PNPM
       if: inputs.setup-node == 'true'
       uses: pnpm/action-setup@v4
-      with:
-        version: ${{ inputs.pnpm-version }}
 
     - name: Set up Node.js
       if: inputs.setup-node == 'true'

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -59,6 +59,8 @@ runs:
     - name: Set up PNPM
       if: inputs.setup-node == 'true'
       uses: pnpm/action-setup@v4
+      with:
+        package_json_file: dashboard-ui/package.json
 
     - name: Set up Node.js
       if: inputs.setup-node == 'true'

--- a/build/package/Dockerfile.cli
+++ b/build/package/Dockerfile.cli
@@ -17,14 +17,14 @@
 FROM node:22.16.0-alpine3.21 AS frontend-builder
 WORKDIR /dashboard-ui
 
-# enable pnpm
+# enable pnpm (version is pinned via the "packageManager" field in package.json)
 RUN corepack enable
-RUN corepack prepare pnpm@10.11.0 --activate
 
 # fetch dependencies
 COPY dashboard-ui/package.json ./
 COPY dashboard-ui/pnpm-lock.yaml ./
-RUN pnpm install
+COPY dashboard-ui/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 
 # copy code
 COPY dashboard-ui/ .

--- a/build/package/Dockerfile.dashboard
+++ b/build/package/Dockerfile.dashboard
@@ -17,14 +17,14 @@
 FROM node:22.16.0-alpine3.21 AS frontend-builder
 WORKDIR /dashboard-ui
 
-# enable pnpm
+# enable pnpm (version is pinned via the "packageManager" field in package.json)
 RUN corepack enable
-RUN corepack prepare pnpm@10.11.0 --activate
 
 # fetch dependencies
 COPY dashboard-ui/package.json ./
 COPY dashboard-ui/pnpm-lock.yaml ./
-RUN pnpm install
+COPY dashboard-ui/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 
 # copy code
 COPY dashboard-ui/ .

--- a/dashboard-ui/pnpm-workspace.yaml
+++ b/dashboard-ui/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ allowBuilds:
   unrs-resolver: true
 minimumReleaseAge: 14400
 minimumReleaseAgeExclude:
-  - '@kubetail/ui@3.0.0'
+  - "@kubetail/ui"
 overrides:
   "@eslint/plugin-kit": "^0.3.5"
   "@isaacs/brace-expansion": "^5.0.1"


### PR DESCRIPTION
## Summary

The pnpm version was hardcoded in multiple places (`pnpm@10.11.0` in the
Docker images, a `pnpm-version` input in the setup-environment action),
which meant bumping pnpm required touching several files and risked drift.
This PR centralizes the pnpm version on the `packageManager` field in
`package.json` and makes the Docker installs deterministic.

## Key Changes

- Drop the hardcoded `pnpm@10.11.0` `corepack prepare` step from
  `Dockerfile.cli` and `Dockerfile.dashboard`; rely on the
  `packageManager` field instead.
- Remove the `pnpm-version` input from the `setup-environment` action so
  `pnpm/action-setup` reads the version from `packageManager`.
- Switch the Docker installs to `pnpm install --frozen-lockfile` and copy
  `pnpm-workspace.yaml` into the build context so workspace overrides apply.
- Broaden `.dockerignore` to ignore nested `node_modules` (`**/node_modules`).
- Loosen the `@kubetail/ui` release-age exclude to match any version.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused