### PR TITLE
✨ Use fresh single-entry changelog with -sa per series for Launchpad

### DIFF
--- a/.github/workflows/publish-launchpad.yml
+++ b/.github/workflows/publish-launchpad.yml
@@ -120,7 +120,6 @@ jobs:
           DEBFULLNAME: ${{ vars.KUBETAIL_BOT_NAME}}
           DEBEMAIL: ${{ vars.KUBETAIL_BOT_EMAIL }}
         run: |
-          FIRST_SERIES=true
           for SERIES in ${{ steps.config.outputs.series }}; do
             export PKG_VERSION="${VERSION}-${{ steps.config.outputs.debian_revision }}~${SERIES}1"
 
@@ -134,17 +133,14 @@ jobs:
               < "${SRC_DIR}/control.tmpl" \
               > debian/control
 
-            if [ "${FIRST_SERIES}" = "true" ]; then
-              DCH_FLAGS="--create --package kubetail-cli"
-              DEBUILD_FLAGS="-sa"
-              FIRST_SERIES=false
-            else
-              DCH_FLAGS=""
-              DEBUILD_FLAGS="-sd"
-            fi
+            # Fresh single-entry changelog per series (each is an independent
+            # -sa upload). rm makes --create idempotent across iterations.
+            rm -f debian/changelog
 
-            dch ${DCH_FLAGS} -D "${SERIES}" -v "${PKG_VERSION}" "Initial release for ${SERIES}."
-            debuild ${DEBUILD_FLAGS} -S -d -k"${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}"
+            # -sa for every series: each series is a self-contained source
+            # upload sharing one orig tarball; re-sends are de-duplicated.
+            dch --create --package kubetail-cli -D "${SERIES}" -v "${PKG_VERSION}" "Initial release for ${SERIES}."
+            debuild -sa -S -d -k"${{ vars.KUBETAIL_BOT_GPG_SIGNING_KEY_FINGERPRINT }}"
 
             if [ "${{ steps.config.outputs.dry_run }}" = "false" ]; then
               dput ppa:kubetail/kubetail "../kubetail-cli_${PKG_VERSION}_source.changes"


### PR DESCRIPTION
## Summary

The Launchpad publish workflow built the first Ubuntu series with `-sa`
(include the orig tarball) and a freshly created changelog, then built
every subsequent series with `-sd` against an accumulating changelog.
Since each series is an independent source upload that shares the same
orig tarball, this special-casing was unnecessary and made the loop
harder to follow.

## Key Changes

- Build every series with `-sa` instead of tracking a `FIRST_SERIES`
  flag to switch between `-sa`/`-sd` and `--create`/empty `dch` flags.
- Remove `debian/changelog` before each `dch --create` so the create is
  idempotent across loop iterations, yielding a fresh single-entry
  changelog per series.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused