### PR TITLE
🎣 Handle unsupported grep regex errors

### DIFF
--- a/crates/rgkl/src/stream_backward.rs
+++ b/crates/rgkl/src/stream_backward.rs
@@ -109,11 +109,13 @@ fn stream_backward_internal(
 
     // Remove leading and trailing whitespace
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
+    let matcher = trimmed_grep
+        .map(|grep| LogFileRegexMatcher::new(grep, format))
+        .transpose()?;
 
-    if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format)?;
-        let sink = printer.sink(&matcher);
-        let _ = searcher.search_reader(&matcher, term_reverse_reader, sink);
+    if let Some(matcher) = matcher.as_ref() {
+        let sink = printer.sink(matcher);
+        let _ = searcher.search_reader(matcher, term_reverse_reader, sink);
     } else {
         let matcher = PassThroughMatcher::new();
         let sink = printer.sink(&matcher);
@@ -250,6 +252,26 @@ mod test {
 
         // Compare output with expected lines
         compare_lines(output, expected_lines);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_grep_returns_invalid_argument() {
+        let test_file = TEST_FILE.path().to_path_buf();
+        let (tx, mut rx) = mpsc::channel(1);
+
+        stream_backward(
+            CancellationToken::new(),
+            &test_file,
+            None,
+            None,
+            Some("(?=.*settings)"),
+            tx,
+        )
+        .await;
+
+        let status = rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Invalid grep pattern"));
     }
 
     // Test `start_time` and `stop_time` args together

--- a/crates/rgkl/src/stream_forward.rs
+++ b/crates/rgkl/src/stream_forward.rs
@@ -197,11 +197,13 @@ fn setup_fs_watcher<'a>(
 
     // Remove leading and trailing whitespace
     let trimmed_grep = grep.map(str::trim).filter(|grep| !grep.is_empty());
+    let matcher = trimmed_grep
+        .map(|grep| LogFileRegexMatcher::new(grep, format))
+        .transpose()?;
 
-    if let Some(grep) = trimmed_grep {
-        let matcher = LogFileRegexMatcher::new(grep, format)?;
-        let sink = printer.sink(&matcher);
-        let _ = searcher.search_reader(&matcher, term_reader, sink);
+    if let Some(matcher) = matcher.as_ref() {
+        let sink = printer.sink(matcher);
+        let _ = searcher.search_reader(matcher, term_reader, sink);
     } else {
         let matcher = PassThroughMatcher::new();
         let sink = printer.sink(&matcher);
@@ -221,12 +223,9 @@ fn setup_fs_watcher<'a>(
     }
 
     let search_slice = move |input_str: &[u8]| {
-        if let Some(grep) = trimmed_grep {
-            let Ok(matcher) = LogFileRegexMatcher::new(grep, format) else {
-                return;
-            };
-            let sink = printer.sink(&matcher);
-            let _ = searcher.search_slice(&matcher, input_str, sink);
+        if let Some(matcher) = matcher.as_ref() {
+            let sink = printer.sink(matcher);
+            let _ = searcher.search_slice(matcher, input_str, sink);
         } else {
             let matcher = PassThroughMatcher::new();
             let sink = printer.sink(&matcher);
@@ -698,5 +697,28 @@ mod test {
 
         // Channel should close after sending the shutdown error
         assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_grep_returns_invalid_argument() {
+        let test_file = create_test_file();
+        let path = test_file.path().to_path_buf();
+        let ctx = CancellationToken::new();
+        let (tx, mut rx) = mpsc::channel(1);
+
+        stream_forward(
+            ctx,
+            &path,
+            None,
+            None,
+            Some("(?=.*settings)"),
+            FollowFrom::Noop,
+            tx,
+        )
+        .await;
+
+        let status = rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("Invalid grep pattern"));
     }
 }

--- a/modules/shared/logs/options_test.go
+++ b/modules/shared/logs/options_test.go
@@ -117,4 +117,15 @@ func TestWithGrep(t *testing.T) {
 			t.Errorf("Expected 'foobar' not to match 'foo.bar', but it did")
 		}
 	})
+
+	t.Run("UnsupportedLookahead", func(t *testing.T) {
+		stream := &stream{}
+		err := WithGrep("(?=.*(?:settings|about))(?!.*v1)")(stream)
+		if err == nil {
+			t.Fatal("WithGrep returned nil error for unsupported regex")
+		}
+		if stream.grepRegex != nil {
+			t.Fatal("grepRegex was set for unsupported regex")
+		}
+	})
 }


### PR DESCRIPTION
Closes #679 

## Summary

Handles unsupported grep regex syntax, such as lookahead assertions, as clean validation errors instead of allowing Rust log streaming paths to fail poorly.

## Key Changes

- Add Go regression coverage for unsupported grep lookahead patterns.
- Add Rust regression coverage for invalid grep errors in forward and backward streaming.
- Compile the optional Rust grep matcher once during stream setup.
- Propagate invalid regex errors instead of silently returning or recompiling during follow updates.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused